### PR TITLE
docs: add shell installer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Inspired by [Fig](https://fig.io) (RIP). Built from scratch in Rust.
 
 ## Installation
 
+### Shell installer (recommended)
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/StanMarek/ghost-complete/releases/latest/download/ghost-complete-installer.sh | sh
+ghost-complete install
+```
+
 ### From Git
 
 ```bash


### PR DESCRIPTION
## Summary
- Add curl-based shell installer as recommended install method
- v0.1.0 release is live with cargo-dist binaries

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)