### PR TITLE
chore(deps): bump vte 0.13→0.15, remove unused nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,12 +104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,7 +318,6 @@ dependencies = [
  "gc-overlay",
  "gc-parser",
  "gc-suggest",
- "nix 0.31.2",
  "portable-pty",
  "tokio",
  "tracing",
@@ -554,18 +547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,7 +642,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix 0.25.1",
+ "nix",
  "serial",
  "shared_library",
  "shell-words",
@@ -1214,23 +1195,12 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vte"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0b683b20ef64071ff03745b14391751f6beab06a54347885459b77a3f2caa5"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
+ "memchr",
 ]
 
 [[package]]

--- a/crates/gc-parser/Cargo.toml
+++ b/crates/gc-parser/Cargo.toml
@@ -8,6 +8,6 @@ authors.workspace = true
 publish = false
 
 [dependencies]
-vte = "0.13"
+vte = "0.15"
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/gc-parser/src/lib.rs
+++ b/crates/gc-parser/src/lib.rs
@@ -27,9 +27,7 @@ impl TerminalParser {
 
     /// Feed raw bytes from PTY output through the VT parser.
     pub fn process_bytes(&mut self, bytes: &[u8]) {
-        for &byte in bytes {
-            self.parser.advance(&mut self.state, byte);
-        }
+        self.parser.advance(&mut self.state, bytes);
     }
 
     pub fn state(&self) -> &TerminalState {

--- a/crates/gc-pty/Cargo.toml
+++ b/crates/gc-pty/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 portable-pty = "0.8"
 tokio = { workspace = true }
 crossterm = { workspace = true }
-nix = { version = "0.31", features = ["signal"] }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 gc-parser = { path = "../gc-parser" }


### PR DESCRIPTION
## Summary\n- **vte 0.13 → 0.15**: `Parser::advance()` now takes `&[u8]` instead of single byte — updated `process_bytes()` accordingly. This is actually a performance improvement (eliminates per-byte loop, vte batches state machine transitions internally).\n- **Remove unused `nix` crate** from gc-pty: declared with `features = [\"signal\"]` but never imported. All signal handling uses `tokio::signal`. Dead dependency = wasted compile time.\n\nSupersedes #3 (Dependabot vte bump) which would fail to compile without the `process_bytes()` fix.\n\n## Test plan\n- [x] `cargo check --all-targets` passes\n- [x] All 234 tests pass\n- [x] `cargo clippy --all-targets -- -D warnings` clean\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"