### PR TITLE
fix: change default trigger from Ctrl+Space to Ctrl+/ for tmux compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-03-02
+
+### Changed
+
+- **Default trigger keybinding changed from Ctrl+Space to Ctrl+/** — Ctrl+Space (`0x00`) conflicts with tmux's prefix key, preventing the trigger from working inside tmux sessions. Ctrl+/ (`0x1F`) is distinct and unused by tmux or readline defaults. Users who prefer the old binding can set `trigger = "ctrl+space"` in their config.
+
+### Added
+
+- **`ctrl+/` key name** — now recognized by the keybinding parser alongside existing key names
+
 ## [0.1.1] - 2026-03-02
 
 ### Fixed
@@ -35,13 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ANSI popup rendering** with synchronized output (DECSET 2026), cursor save/restore, above/below positioning
 - **18 completion specs**: brew, cargo, cd, curl, docker, gh, git, grep, jq, kubectl, make, npm, pip, pip3, python, python3, ssh, tar
 - **Debounce-based auto-trigger** — configurable delay (default 150ms) after typing pauses
-- **Manual trigger** via Ctrl+Space (works in zsh, bash, and fish)
+- **Manual trigger** via Ctrl+/ (works in zsh, bash, and fish)
 - **Configurable keybindings** — accept, dismiss, navigate, trigger actions with fail-fast validation
 - **Theme customization** — SGR-based style strings for selected item and description
 - **TOML configuration** at `~/.config/ghost-complete/config.toml`
 - **Install/uninstall CLI** — idempotent `.zshrc` management, spec deployment, shell script installation
-- **Shell integration** for zsh (full), bash (Ctrl+Space), and fish (Ctrl+Space)
+- **Shell integration** for zsh (full), bash (Ctrl+/), and fish (Ctrl+/)
 - **`validate-specs` subcommand** with colored output and item counts
 
+[0.1.2]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.1.2
 [0.1.1]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.1.1
 [0.1.0]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,14 +315,14 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gc-buffer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "gc-config"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "gc-overlay"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "gc-suggest",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "gc-parser"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "tracing",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "gc-pty"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "gc-suggest"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-complete"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Inspired by [Fig](https://fig.io) (RIP). Built from scratch in Rust.
 This is a personal project I built for my own workflow. I'm happy to share it and welcome contributions, but set your expectations accordingly:
 
 - **Ghostty + zsh is the tested path.** That's what I use daily — it's stable and reliable.
-- **Bash and fish support is experimental.** Manual trigger only (Ctrl+Space), no auto-trigger on typing, and not actively tested.
+- **Bash and fish support is experimental.** Manual trigger only (Ctrl+/), no auto-trigger on typing, and not actively tested.
 - **No stability guarantees.** This is v0.1.x — config format, spec format, and behavior may change between releases.
 - **macOS only.** No Linux or Windows support planned at this time.
 
@@ -36,7 +36,7 @@ If you hit a bug, [open an issue](https://github.com/StanMarek/ghost-complete/is
 
 - **Terminal:** [Ghostty](https://ghostty.org)
 - **OS:** macOS
-- **Shell:** zsh (primary), bash and fish (Ctrl+Space trigger only)
+- **Shell:** zsh (primary), bash and fish (Ctrl+/ trigger only)
 - **Rust:** 1.75+ (for building from source)
 
 ## Installation
@@ -95,7 +95,7 @@ After installation, restart your terminal. Ghost Complete activates automaticall
 - **Enter** to accept and execute
 - **Arrow keys** to navigate the popup
 - **Escape** to dismiss
-- **Ctrl+Space** to manually trigger completions
+- **Ctrl+/** to manually trigger completions
 
 ## Configuration
 
@@ -114,7 +114,7 @@ max_width = 60
 [keybindings]
 accept = "tab"
 dismiss = "escape"
-trigger = "ctrl+space"
+trigger = "ctrl+/"
 
 [theme]
 selected = "reverse"
@@ -152,7 +152,7 @@ See [docs/IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md) for the full desi
 | Feature | zsh | bash | fish |
 |---------|-----|------|------|
 | Auto-trigger on typing | Yes | No | No |
-| Ctrl+Space manual trigger | Yes | Yes | Yes |
+| Ctrl+/ manual trigger | Yes | Yes | Yes |
 | PTY proxy wrapping | Yes | Yes | Yes |
 | OSC 133 prompt markers | Yes | Yes | Yes |
 

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -43,7 +43,7 @@ impl Default for KeybindingsConfig {
             dismiss: "escape".to_string(),
             navigate_up: "arrow_up".to_string(),
             navigate_down: "arrow_down".to_string(),
-            trigger: "ctrl+space".to_string(),
+            trigger: "ctrl+/".to_string(),
         }
     }
 }
@@ -194,7 +194,7 @@ mod tests {
         assert_eq!(config.keybindings.dismiss, "escape");
         assert_eq!(config.keybindings.navigate_up, "arrow_up");
         assert_eq!(config.keybindings.navigate_down, "arrow_down");
-        assert_eq!(config.keybindings.trigger, "ctrl+space");
+        assert_eq!(config.keybindings.trigger, "ctrl+/");
         assert_eq!(config.theme.selected, "reverse");
         assert_eq!(config.theme.description, "dim");
     }
@@ -242,7 +242,7 @@ navigate_up = "ctrl+space"
         assert_eq!(config.keybindings.accept_and_enter, "enter");
         assert_eq!(config.keybindings.dismiss, "escape");
         assert_eq!(config.keybindings.navigate_down, "arrow_down");
-        assert_eq!(config.keybindings.trigger, "ctrl+space");
+        assert_eq!(config.keybindings.trigger, "ctrl+/");
     }
 
     #[test]

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -33,7 +33,7 @@ impl Default for Keybindings {
             dismiss: KeyEvent::Escape,
             navigate_up: KeyEvent::ArrowUp,
             navigate_down: KeyEvent::ArrowDown,
-            trigger: KeyEvent::CtrlSpace,
+            trigger: KeyEvent::CtrlSlash,
         }
     }
 }
@@ -54,7 +54,7 @@ impl Keybindings {
 /// Parse a human-readable key name into a `KeyEvent`.
 ///
 /// Supported names (case-insensitive):
-/// `tab`, `enter`, `escape`, `backspace`, `ctrl+space`,
+/// `tab`, `enter`, `escape`, `backspace`, `ctrl+space`, `ctrl+/`,
 /// `arrow_up`, `arrow_down`, `arrow_left`, `arrow_right`
 pub fn parse_key_name(name: &str) -> anyhow::Result<KeyEvent> {
     match name.trim().to_lowercase().as_str() {
@@ -63,6 +63,7 @@ pub fn parse_key_name(name: &str) -> anyhow::Result<KeyEvent> {
         "escape" => Ok(KeyEvent::Escape),
         "backspace" => Ok(KeyEvent::Backspace),
         "ctrl+space" => Ok(KeyEvent::CtrlSpace),
+        "ctrl+/" => Ok(KeyEvent::CtrlSlash),
         "arrow_up" => Ok(KeyEvent::ArrowUp),
         "arrow_down" => Ok(KeyEvent::ArrowDown),
         "arrow_left" => Ok(KeyEvent::ArrowLeft),
@@ -486,6 +487,7 @@ pub fn key_to_bytes(key: &KeyEvent) -> Vec<u8> {
         KeyEvent::ArrowRight => vec![0x1B, b'[', b'C'],
         KeyEvent::ArrowLeft => vec![0x1B, b'[', b'D'],
         KeyEvent::CtrlSpace => vec![0x00],
+        KeyEvent::CtrlSlash => vec![0x1F],
         KeyEvent::Backspace => vec![0x7F],
         KeyEvent::Printable(c) => vec![*c as u8],
         KeyEvent::CursorPositionReport(_, _) => Vec::new(), // intercepted in proxy
@@ -559,6 +561,7 @@ mod tests {
             KeyEvent::ArrowLeft,
             KeyEvent::ArrowRight,
             KeyEvent::CtrlSpace,
+            KeyEvent::CtrlSlash,
             KeyEvent::Backspace,
             KeyEvent::Printable('a'),
             KeyEvent::Raw(vec![0xFF]),
@@ -644,11 +647,25 @@ mod tests {
 
     #[test]
     fn test_ctrl_space_triggers_immediately() {
-        let mut handler = make_handler();
+        let kb = Keybindings {
+            trigger: KeyEvent::CtrlSpace,
+            ..Keybindings::default()
+        };
+        let mut handler = make_handler().with_keybindings(kb);
         let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
         let mut buf = Vec::new();
         handler.process_key(&KeyEvent::CtrlSpace, &parser, &mut buf);
         // CtrlSpace triggers immediately — does NOT set trigger_requested
+        assert!(!handler.has_pending_trigger());
+    }
+
+    #[test]
+    fn test_ctrl_slash_triggers_immediately() {
+        let mut handler = make_handler();
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        handler.process_key(&KeyEvent::CtrlSlash, &parser, &mut buf);
+        // CtrlSlash is the default trigger — fires immediately
         assert!(!handler.has_pending_trigger());
     }
 
@@ -862,6 +879,7 @@ mod tests {
         assert_eq!(parse_key_name("escape").unwrap(), KeyEvent::Escape);
         assert_eq!(parse_key_name("backspace").unwrap(), KeyEvent::Backspace);
         assert_eq!(parse_key_name("ctrl+space").unwrap(), KeyEvent::CtrlSpace);
+        assert_eq!(parse_key_name("ctrl+/").unwrap(), KeyEvent::CtrlSlash);
         assert_eq!(parse_key_name("arrow_up").unwrap(), KeyEvent::ArrowUp);
         assert_eq!(parse_key_name("arrow_down").unwrap(), KeyEvent::ArrowDown);
         assert_eq!(parse_key_name("arrow_left").unwrap(), KeyEvent::ArrowLeft);
@@ -873,6 +891,7 @@ mod tests {
         assert_eq!(parse_key_name("Tab").unwrap(), KeyEvent::Tab);
         assert_eq!(parse_key_name("TAB").unwrap(), KeyEvent::Tab);
         assert_eq!(parse_key_name("CTRL+SPACE").unwrap(), KeyEvent::CtrlSpace);
+        assert_eq!(parse_key_name("CTRL+/").unwrap(), KeyEvent::CtrlSlash);
         assert_eq!(parse_key_name("Arrow_Up").unwrap(), KeyEvent::ArrowUp);
         assert_eq!(parse_key_name("ESCAPE").unwrap(), KeyEvent::Escape);
     }

--- a/crates/gc-pty/src/input.rs
+++ b/crates/gc-pty/src/input.rs
@@ -1,6 +1,6 @@
 /// Minimal key event parser for raw terminal stdin bytes.
 ///
-/// Parses known sequences (arrows, Tab, Enter, Escape, Ctrl+Space) and
+/// Parses known sequences (arrows, Tab, Enter, Escape, Ctrl+Space, Ctrl+/) and
 /// passes through everything else as Raw bytes.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,6 +13,7 @@ pub enum KeyEvent {
     ArrowLeft,
     ArrowRight,
     CtrlSpace,
+    CtrlSlash,
     Backspace,
     Printable(char),
     /// Cursor Position Report response (CSI row;col R) — 1-indexed.
@@ -33,6 +34,10 @@ pub fn parse_keys(buf: &[u8]) -> Vec<KeyEvent> {
         match buf[i] {
             0x00 => {
                 events.push(KeyEvent::CtrlSpace);
+                i += 1;
+            }
+            0x1F => {
+                events.push(KeyEvent::CtrlSlash);
                 i += 1;
             }
             0x09 => {
@@ -271,6 +276,12 @@ mod tests {
                 KeyEvent::Printable('b'),
             ]
         );
+    }
+
+    #[test]
+    fn test_ctrl_slash() {
+        let events = parse_keys(b"\x1F");
+        assert_eq!(events, vec![KeyEvent::CtrlSlash]);
     }
 
     #[test]

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -57,7 +57,7 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # dismiss = \"escape\"
 # navigate_up = \"arrow_up\"
 # navigate_down = \"arrow_down\"
-# trigger = \"ctrl+space\"
+# trigger = \"ctrl+/\"
 
 [theme]
 selected = \"reverse\"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -98,7 +98,7 @@ Customize keyboard shortcuts. Each value is a key name string. Invalid key names
 | `dismiss` | string | `"escape"` | Dismiss the popup |
 | `navigate_up` | string | `"arrow_up"` | Move selection up |
 | `navigate_down` | string | `"arrow_down"` | Move selection down |
-| `trigger` | string | `"ctrl+space"` | Manually trigger completions |
+| `trigger` | string | `"ctrl+/"` | Manually trigger completions |
 
 ```toml
 [keybindings]
@@ -107,7 +107,7 @@ accept_and_enter = "enter"
 dismiss = "escape"
 navigate_up = "arrow_up"
 navigate_down = "arrow_down"
-trigger = "ctrl+space"
+trigger = "ctrl+/"
 ```
 
 #### Key Name Syntax
@@ -115,7 +115,7 @@ trigger = "ctrl+space"
 - Lowercase letters: `a` through `z`
 - Special keys: `tab`, `enter`, `escape`, `backspace`, `space`
 - Arrow keys: `arrow_up`, `arrow_down`, `arrow_left`, `arrow_right`
-- Modifiers: `ctrl+<key>` (e.g., `ctrl+space`, `ctrl+n`)
+- Modifiers: `ctrl+<key>` (e.g., `ctrl+space`, `ctrl+/`)
 
 ### `[theme]`
 
@@ -179,7 +179,7 @@ git = false
 accept = "tab"
 accept_and_enter = "enter"
 dismiss = "escape"
-trigger = "ctrl+space"
+trigger = "ctrl+/"
 
 [theme]
 selected = "fg:255 bg:236"

--- a/shell/ghost-complete.bash
+++ b/shell/ghost-complete.bash
@@ -27,5 +27,5 @@ _gc_report_buffer() {
     printf '\e]7770;%d;%s\a' "$READLINE_POINT" "$READLINE_LINE"
 }
 
-# Bind Ctrl+Space as manual trigger
-bind -x '"\C- ": _gc_report_buffer'
+# Bind Ctrl+/ as manual trigger (0x1F)
+bind -x '"\C-_": _gc_report_buffer'

--- a/shell/ghost-complete.fish
+++ b/shell/ghost-complete.fish
@@ -16,5 +16,5 @@ function _gc_report_buffer
     printf '\e]7770;%d;%s\a' $cursor "$buf"
 end
 
-# Bind Ctrl+Space as manual trigger
-bind \c@ '_gc_report_buffer'
+# Bind Ctrl+/ as manual trigger (0x1F)
+bind \x1f '_gc_report_buffer'


### PR DESCRIPTION
## Summary

- **Default trigger keybinding changed from Ctrl+Space (`0x00`) to Ctrl+/ (`0x1F`)** — Ctrl+Space conflicts with tmux's prefix key, making ghost-complete unusable inside tmux sessions
- Ctrl+Space remains fully supported as a configurable key (`trigger = "ctrl+space"`)
- Version bumped to 0.1.2

## Changes

| File | Change |
|------|--------|
| `crates/gc-pty/src/input.rs` | Add `CtrlSlash` variant, `0x1F` byte parsing, test |
| `crates/gc-pty/src/handler.rs` | `ctrl+/` in parser, default trigger, `key_to_bytes`, tests |
| `crates/gc-config/src/lib.rs` | Default trigger config `"ctrl+/"` |
| `crates/ghost-complete/src/install.rs` | Config template default |
| `shell/ghost-complete.bash` | Binding `\C- ` → `\C-_` |
| `shell/ghost-complete.fish` | Binding `\c@` → `\x1f` |
| `docs/CONFIGURATION.md` | Updated defaults and key name list |
| `README.md` | Updated trigger references (5 locations) |
| `CHANGELOG.md` | v0.1.2 entry |
| `Cargo.toml` | Version bump to 0.1.2 |

## Test plan

- [x] `cargo test` — 253 tests passing
- [x] `cargo clippy --all-targets` — clean
- [ ] Manual: run ghost-complete, press Ctrl+/ → popup triggers
- [ ] Manual: run inside tmux, press Ctrl+/ → popup triggers (the whole point)
- [ ] Manual: set `trigger = "ctrl+space"` in config → old binding still works