### PR TITLE
fix: scope init block to Ghostty terminal only

### DIFF
--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -75,7 +75,7 @@ fn init_block() -> String {
     format!(
         "{INIT_BEGIN}\n\
          {MANAGED_WARNING}\n\
-         if [[ -z \"$GHOST_COMPLETE_ACTIVE\" ]]; then\n  \
+         if [[ \"$TERM_PROGRAM\" == \"ghostty\" && -z \"$GHOST_COMPLETE_ACTIVE\" ]]; then\n  \
            export GHOST_COMPLETE_ACTIVE=1\n  \
            exec ghost-complete\n\
          fi\n\


### PR DESCRIPTION
## Problem

The init block written to `.zshrc` by `ghost-complete install` would unconditionally `exec ghost-complete` in **any** terminal that sources the file. The only guard was the `GHOST_COMPLETE_ACTIVE` env var, which stops re-entrancy but does nothing to prevent the exec from firing in unrelated terminal emulators (VS Code integrated terminal, iTerm2, Terminal.app, Kitty, etc.).

This caused ghost-complete to intercept sessions in terminals that have no awareness of its PTY/multiplexing protocol, leading to broken shell sessions outside of Ghostty.

## Fix

Added a `TERM_PROGRAM == "ghostty"` outer check to the condition:

```zsh
# Before
if [[ -z "$GHOST_COMPLETE_ACTIVE" ]]; then
  export GHOST_COMPLETE_ACTIVE=1
  exec ghost-complete
fi

# After
if [[ "$TERM_PROGRAM" == "ghostty" && -z "$GHOST_COMPLETE_ACTIVE" ]]; then
  export GHOST_COMPLETE_ACTIVE=1
  exec ghost-complete
fi
```

`TERM_PROGRAM` is a widely-supported convention set by terminal emulators to identify themselves:

| Terminal      | `TERM_PROGRAM` value |
|---------------|----------------------|
| Ghostty       | `ghostty`            |
| VS Code       | `vscode`             |
| iTerm2        | `iTerm.app`          |
| Terminal.app  | `Apple_Terminal`     |
| Others        | unset / varies       |

With this guard in place, the `exec` is a no-op in every terminal except Ghostty, so users who source `.zshrc` from VS Code, iTerm2, or any other emulator are completely unaffected.

## Testing

All existing unit tests continue to pass. The `test_init_block_content` test already asserts the presence of `GHOST_COMPLETE_ACTIVE` and `exec ghost-complete`; adding an assertion for `"ghostty"` would further lock in this behaviour.

## Impact

- **No behaviour change** for Ghostty users
- **Fixes broken shell sessions** for users running other terminal emulators alongside Ghostty