### PR TITLE
feat: support tmux-in-Ghostty activation

### DIFF
--- a/crates/gc-overlay/src/ansi.rs
+++ b/crates/gc-overlay/src/ansi.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-/// Begin synchronized output (Ghostty DECSET 2026).
+/// Begin synchronized output (DECSET 2026).
 /// Terminal buffers all output until end_sync, then draws atomically.
 pub fn begin_sync(buf: &mut Vec<u8>) {
     let _ = buf.write_all(b"\x1b[?2026h");

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -40,6 +40,15 @@ impl Drop for RawModeGuard {
 ///
 /// Returns the shell's exit code.
 pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Result<i32> {
+    // Log tmux detection for debugging
+    if std::env::var("TMUX").is_ok() {
+        tracing::info!("tmux session detected — running inside tmux pane");
+        if let Ok(output) = std::process::Command::new("tmux").arg("-V").output() {
+            let version = String::from_utf8_lossy(&output.stdout);
+            tracing::info!("tmux version: {}", version.trim());
+        }
+    }
+
     let SpawnedShell { master, mut child } = spawn_shell(shell, args)?;
 
     let mut reader = master

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -94,6 +94,9 @@ fn init_block() -> String {
          if [[ \"$TERM_PROGRAM\" == \"ghostty\" && -z \"$GHOST_COMPLETE_ACTIVE\" ]]; then\n  \
            export GHOST_COMPLETE_ACTIVE=1\n  \
            exec ghost-complete\n\
+         elif [[ -n \"$TMUX\" && -n \"$GHOSTTY_RESOURCES_DIR\" && \\\n    \
+           \"$(ps -o comm= -p $PPID 2>/dev/null)\" != \"ghost-complete\" ]]; then\n  \
+           exec ghost-complete\n\
          fi\n\
          {INIT_END}"
     )
@@ -327,8 +330,15 @@ mod tests {
         assert!(block.contains(INIT_BEGIN));
         assert!(block.contains(INIT_END));
         assert!(block.contains(MANAGED_WARNING));
-        assert!(block.contains("GHOST_COMPLETE_ACTIVE"));
         assert!(block.contains("exec ghost-complete"));
+        // Pure Ghostty: TERM_PROGRAM + GHOST_COMPLETE_ACTIVE guard
+        assert!(block.contains("$TERM_PROGRAM"));
+        assert!(block.contains("GHOST_COMPLETE_ACTIVE"));
+        // tmux-in-Ghostty: TMUX + GHOSTTY_RESOURCES_DIR + PPID guard
+        assert!(block.contains("$TMUX"));
+        assert!(block.contains("$GHOSTTY_RESOURCES_DIR"));
+        assert!(block.contains("$PPID"));
+        assert!(block.contains("ghost-complete\""));
     }
 
     #[test]


### PR DESCRIPTION
Add a second init block branch that detects tmux sessions launched from Ghostty (via $GHOSTTY_RESOURCES_DIR) and uses a PPID-based guard instead of $GHOST_COMPLETE_ACTIVE to avoid env var inheritance through tmux.

Also adds tmux version logging at proxy startup for diagnostics.

## What

<!-- Brief description of the change -->

## Why

<!-- Motivation / context for the change -->

## Testing

- [ ] `cargo test` passes
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] Manually tested in Ghostty with zsh
