### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-03-12
+
+### Fixed
+
+- **Popup rendering artifacts from long suggestions** — suggestion text (history URLs, deep paths) was written to the render buffer without truncation, overflowing past the popup's declared width. `clear_popup` only erased `layout.width` columns, leaving ghost characters on screen until a terminal resize. Text is now truncated to fit within the popup boundary.
+- **Redundant path prefix in filesystem completions** — directory/file suggestions now display only the last path component (e.g., `2023-rust/` instead of `Desktop/coding/project/2023-rust/`), since the user already typed the prefix.
+
 ## [0.1.3] - 2026-03-10
 
 ### Added
@@ -64,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Shell integration** for zsh (full), bash (Ctrl+/), and fish (Ctrl+/)
 - **`validate-specs` subcommand** with colored output and item counts
 
+[0.1.4]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.1.4
 [0.1.3]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.1.3
 [0.1.2]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.1.2
 [0.1.1]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,14 +315,14 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gc-buffer"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "gc-config"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "gc-overlay"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "gc-suggest",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "gc-parser"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "tracing",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "gc-pty"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "gc-suggest"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-complete"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump workspace version 0.1.3 → 0.1.4
- Update CHANGELOG with v0.1.4 entries

### What's in v0.1.4

**Fixed:**
- Popup rendering artifacts from long suggestions — text now truncated to fit within popup boundary
- Redundant path prefix in filesystem completions — shows only the last path component

## Test plan
- [x] All 248 workspace tests pass
- [x] Clippy clean
- [x] `cargo fmt --check` clean
- [x] Manually verified both fixes in Ghostty

**After merge:** tag `v0.1.4` on master to trigger cargo-dist release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)