### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-03-15
+
+### Changed
+
+- **History entries insert full command on accept** — selecting a history entry from the popup now replaces the entire command buffer with the full historical command (e.g., `tmux source ~/.config/tmux/tmux.conf`), not just the first word (`tmux`).
+- **Buffer-wide history matching** — history entries are fuzzy-matched against the full typed buffer at any word position, not just at command position. Typing `git push` surfaces `git push origin main` from history.
+- **History suppressed in compound commands** — history entries no longer appear after pipe (`|`), chain (`&&`, `||`), or semicolon (`;`) operators. Full commands don't make sense as pipe/chain segments.
+- **History result cap** — history results are capped to remaining `max_results` slots after main suggestions, preventing unbounded combined result sets.
+
+### Added
+
+- **`is_first_segment` field on `CommandContext`** — tracks whether the cursor is in the first command segment (before any `|`, `&&`, `||`, `;`). Used to gate history suggestions.
+
 ## [0.2.0] - 2026-03-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.2.0 to 0.2.1
- Add CHANGELOG entry for v0.2.1

## What's in v0.2.1

- **History entries insert full command on accept** — selecting a history entry replaces the entire buffer with the full command, not just the first word
- **Buffer-wide history matching** — history matches against the full typed buffer at any word position
- **History suppressed in compound commands** — no history after `|`, `&&`, `||`, `;`
- **History result cap** — capped to remaining `max_results` slots

## Test plan

- [x] 383 tests passing
- [x] Clippy clean
- [x] Version updated in workspace Cargo.toml
- [x] CHANGELOG updated