### PR TITLE
fix: dynamic script generator results render when shell is idle

### DIFF
--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -11,7 +11,7 @@ use gc_overlay::types::{
 use gc_overlay::{clear_popup, render_popup, PopupTheme};
 use gc_parser::TerminalParser;
 use gc_suggest::{Suggestion, SuggestionEngine};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
 
 use crate::input::KeyEvent;
 
@@ -87,6 +87,7 @@ pub struct InputHandler {
     keybindings: Keybindings,
     theme: PopupTheme,
     dynamic_rx: Option<mpsc::Receiver<Vec<Suggestion>>>,
+    dynamic_notify: Arc<Notify>,
     generator_timeout_ms: u64,
     /// Accumulated viewport scroll from popup rendering. Persists across
     /// dismiss/re-trigger cycles because viewport scroll is permanent.
@@ -110,9 +111,14 @@ impl InputHandler {
             keybindings: Keybindings::default(),
             theme: PopupTheme::default(),
             dynamic_rx: None,
+            dynamic_notify: Arc::new(Notify::new()),
             generator_timeout_ms: 5000,
             scroll_deficit: 0,
         })
+    }
+
+    pub fn dynamic_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.dynamic_notify)
     }
 
     pub fn with_popup_config(mut self, max_visible: usize, min_width: u16, max_width: u16) -> Self {
@@ -419,11 +425,8 @@ impl InputHandler {
 
         // Spawn async task for script-based generators only if the command
         // actually has any. Avoids wasted channel + task spawn on every trigger.
-        // NOTE: dynamic results are blocked on PTY read — try_merge_dynamic()
-        // only runs when Task B reads output. If the shell goes idle after the
-        // trigger, results won't render until the next keystroke. This is a
-        // known architectural limitation; a dedicated polling task or
-        // tokio::select! combining PTY read with the dynamic channel is needed.
+        // Task E (dynamic_merge_loop) awaits dynamic_notify and calls
+        // try_merge_dynamic() so results render even when the shell is idle.
         if self.engine.has_script_generators(&ctx) {
             let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
             self.dynamic_rx = Some(rx);
@@ -431,6 +434,7 @@ impl InputHandler {
             let ctx_clone = ctx.clone();
             let cwd_clone = cwd.clone();
             let timeout = self.generator_timeout_ms;
+            let notify = Arc::clone(&self.dynamic_notify);
             tokio::spawn(async move {
                 match engine
                     .suggest_dynamic(&ctx_clone, &cwd_clone, timeout)
@@ -438,6 +442,7 @@ impl InputHandler {
                 {
                     Ok(results) if !results.is_empty() => {
                         let _ = tx.send(results).await;
+                        notify.notify_one();
                     }
                     Ok(_) => {} // empty results, nothing to send
                     Err(e) => {
@@ -727,6 +732,7 @@ mod tests {
             keybindings: Keybindings::default(),
             theme: PopupTheme::default(),
             dynamic_rx: None,
+            dynamic_notify: Arc::new(Notify::new()),
             generator_timeout_ms: 5000,
             scroll_deficit: 0,
         };
@@ -755,6 +761,7 @@ mod tests {
             keybindings: Keybindings::default(),
             theme: PopupTheme::default(),
             dynamic_rx: None,
+            dynamic_notify: Arc::new(Notify::new()),
             generator_timeout_ms: 5000,
             scroll_deficit: 0,
         }
@@ -839,6 +846,7 @@ mod tests {
             keybindings: Keybindings::default(),
             theme: PopupTheme::default(),
             dynamic_rx: None,
+            dynamic_notify: Arc::new(Notify::new()),
             generator_timeout_ms: 5000,
             scroll_deficit: 0,
         };
@@ -896,6 +904,7 @@ mod tests {
             keybindings: Keybindings::default(),
             theme: PopupTheme::default(),
             dynamic_rx: None,
+            dynamic_notify: Arc::new(Notify::new()),
             generator_timeout_ms: 5000,
             scroll_deficit: 0,
         };
@@ -950,6 +959,7 @@ mod tests {
             keybindings: Keybindings::default(),
             theme: PopupTheme::default(),
             dynamic_rx: None,
+            dynamic_notify: Arc::new(Notify::new()),
             generator_timeout_ms: 5000,
             scroll_deficit: 0,
         };
@@ -991,6 +1001,7 @@ mod tests {
             keybindings: Keybindings::default(),
             theme: PopupTheme::default(),
             dynamic_rx: None,
+            dynamic_notify: Arc::new(Notify::new()),
             generator_timeout_ms: 5000,
             scroll_deficit: 0,
         };

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -128,6 +128,17 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
         None
     };
 
+    // Task E: dynamic merge loop — renders script generator results when shell is idle.
+    let dynamic_notify = {
+        let h = handler.lock().unwrap();
+        h.dynamic_notify()
+    };
+    let handler_for_merge = Arc::clone(&handler);
+    let parser_for_merge = Arc::clone(&parser);
+    let merge_handle = tokio::spawn(async move {
+        dynamic_merge_loop(dynamic_notify, handler_for_merge, parser_for_merge).await;
+    });
+
     // Channel to signal that one of the I/O tasks has finished
     let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
 
@@ -334,6 +345,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     // Clean up: abort I/O tasks (they'll be blocked on reads)
     stdin_handle.abort();
     stdout_handle.abort();
+    merge_handle.abort();
     if let Some(h) = debounce_handle {
         h.abort();
     }
@@ -373,6 +385,29 @@ async fn debounce_loop(
         {
             let mut h = handler.lock().unwrap();
             h.trigger(&parser, &mut render_buf);
+        }
+        if !render_buf.is_empty() {
+            let mut stdout = std::io::stdout().lock();
+            let _ = stdout.write_all(&render_buf);
+            let _ = stdout.flush();
+        }
+    }
+}
+
+/// Dynamic merge loop: awaits notification from script generator tasks and
+/// merges results into the popup. This ensures dynamic results render even
+/// when the shell is idle (no PTY output flowing through Task B).
+async fn dynamic_merge_loop(
+    notify: Arc<Notify>,
+    handler: Arc<Mutex<InputHandler>>,
+    parser: Arc<Mutex<TerminalParser>>,
+) {
+    loop {
+        notify.notified().await;
+        let mut render_buf = Vec::new();
+        {
+            let mut h = handler.lock().unwrap();
+            h.try_merge_dynamic(&parser, &mut render_buf);
         }
         if !render_buf.is_empty() {
             let mut stdout = std::io::stdout().lock();


### PR DESCRIPTION
## Summary

- Script generators (brew, docker, kubectl, npm, cargo, gh — 191 specs total) executed successfully in the background but results **never rendered** when the shell was idle, because `try_merge_dynamic()` only ran inside Task B's blocking PTY read loop
- When the user eventually typed, the new trigger **dropped** the old `dynamic_rx` channel, perpetually losing results
- Added a Notify-driven merger task (Task E) that awaits a signal from the generator spawn task after sending results — event-driven, zero polling overhead, instant rendering
- Task B's existing `try_merge_dynamic()` remains as a fast path when PTY output is actively flowing; both callers are race-safe (`try_recv` is take-once, both hold the handler mutex)

## Test plan

- [x] `cargo test -p gc-pty` — 45 tests passing
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --release` — builds
- [ ] Manual: run `ghost-complete`, type `brew install `, wait — formulae should appear without typing
- [ ] Manual: type `git checkout ` — branches still appear (native generators unaffected)
- [ ] Manual: dismiss popup, verify no ghost renders from stale Task E wakeups