### PR TITLE
fix: inherit parent cwd when spawning shell via PTY

### DIFF
--- a/crates/gc-pty/src/spawn.rs
+++ b/crates/gc-pty/src/spawn.rs
@@ -18,6 +18,7 @@ pub fn spawn_shell(shell: &str, args: &[String]) -> Result<SpawnedShell> {
 
     let mut cmd = CommandBuilder::new(shell);
     cmd.args(args);
+    cmd.cwd(std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/")));
 
     // Inherit the current environment
     for (key, value) in std::env::vars() {


### PR DESCRIPTION
## Summary

- Spawned shell now inherits the parent process's working directory instead of defaulting to `$HOME`

## Problem

When ghost-complete is launched via `exec ghost-complete` in `.zshrc`, the ghost-complete process correctly inherits the shell's working directory. However, when it spawns the child shell via `portable_pty::CommandBuilder`, no `cwd` is set — so the child shell starts in `$HOME`.

This breaks terminal multiplexers like [cmux](https://cmux.dev) that save and restore the working directory per pane. On session restore:

1. cmux launches a new shell, which sources `.zshrc`
2. `.zshrc` restores the saved cwd (e.g. `cd ~/Work/myproject`)
3. The ghost-complete init block runs `exec ghost-complete`
4. ghost-complete spawns a new shell via PTY — but without inheriting cwd, the shell starts in `$HOME`
5. The user's working directory is lost

## Fix

One-line change in `crates/gc-pty/src/spawn.rs`: pass `std::env::current_dir()` to `CommandBuilder::cwd()` so the child shell starts in the same directory as the ghost-complete process.

## Note for cmux users

This PR fixes the initial cwd, but cmux's shell integration (precmd hooks, `report_pwd`, etc.) is injected via `ZDOTDIR`, which is consumed before `exec ghost-complete` runs. The inner shell spawned by ghost-complete does not go through cmux's ZDOTDIR chain, so it never gets the cmux shell integration hooks.

To restore full per-pane cwd tracking in cmux, add this to your shell config (e.g. `~/.zshrc.d/cmux-shell-integration.zsh` or after the ghost-complete init block in `~/.zshrc`):

```zsh
# Re-source cmux shell integration for ghost-complete's inner shell.
# ghost-complete's `exec` breaks cmux's ZDOTDIR injection chain,
# so the inner shell never gets the cmux precmd/preexec hooks.
if [[ "${CMUX_SHELL_INTEGRATION:-0}" == "1" && -n "${CMUX_SHELL_INTEGRATION_DIR:-}" && -z "${_CMUX_PWD_LAST_PWD+x}" ]]; then
  source "$CMUX_SHELL_INTEGRATION_DIR/cmux-zsh-integration.zsh"
fi
```