### PR TITLE
chore: bump version to v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-03-22
+
+### Fixed
+
+- **Popup suppressed during shell history navigation** — up/down arrow keys for history recall no longer trigger the debounce auto-suggest. A `debounce_suppressed` flag gates the debounce path, set on arrow up/down when the popup is hidden and cleared on printable input or manual trigger.
+- **Spawned shell inherits parent working directory** — `CommandBuilder` was not inheriting the parent process's CWD, causing the shell to start in `$HOME`. This broke terminal multiplexers (e.g. cmux) that rely on restoring the working directory when reopening sessions. The current directory is now explicitly passed to `CommandBuilder`.
+
 ## [0.2.3] - 2026-03-16
 
 ### Added
@@ -160,6 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Shell integration** for zsh (full), bash (Ctrl+/), and fish (Ctrl+/)
 - **`validate-specs` subcommand** with colored output and item counts
 
+[0.2.4]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.2.4
 [0.2.3]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.2.3
 [0.2.2]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.2.2
 [0.2.1]: https://github.com/StanMarek/ghost-complete/releases/tag/v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,14 +422,14 @@ dependencies = [
 
 [[package]]
 name = "gc-buffer"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "gc-config"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "gc-overlay"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "gc-suggest",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "gc-parser"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "gc-pty"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "gc-suggest"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-complete"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version `0.2.3` → `0.2.4`
- Add CHANGELOG entry for v0.2.4 with two bug fixes:
  - **Popup suppressed during shell history navigation** — up/down arrow keys no longer trigger debounce auto-suggest
  - **Spawned shell inherits parent working directory** — fixes CWD loss in terminal multiplexers (e.g. cmux)

## Test plan

- [x] 449 tests passing
- [x] clippy clean
- [x] fmt clean
- [ ] After merge, tag `v0.2.4` to trigger cargo-dist release