### PR TITLE
feat: support ctrl+a through ctrl+z keybindings

### DIFF
--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -57,7 +57,7 @@ impl Keybindings {
 ///
 /// Supported names (case-insensitive):
 /// `tab`, `enter`, `escape`, `backspace`, `ctrl+space`, `ctrl+/`,
-/// `arrow_up`, `arrow_down`, `arrow_left`, `arrow_right`
+/// `arrow_up`, `arrow_down`, `arrow_left`, `arrow_right`, `ctrl+a`-`ctrl+z`
 pub fn parse_key_name(name: &str) -> anyhow::Result<KeyEvent> {
     match name.trim().to_lowercase().as_str() {
         "tab" => Ok(KeyEvent::Tab),
@@ -70,7 +70,14 @@ pub fn parse_key_name(name: &str) -> anyhow::Result<KeyEvent> {
         "arrow_down" => Ok(KeyEvent::ArrowDown),
         "arrow_left" => Ok(KeyEvent::ArrowLeft),
         "arrow_right" => Ok(KeyEvent::ArrowRight),
-        other => anyhow::bail!("unknown key name: {:?}", other),
+        other => {
+            if let Some(c) = other.strip_prefix("ctrl+") {
+                if c.len() == 1 && c.chars().next().unwrap().is_ascii_lowercase() {
+                    return Ok(KeyEvent::Ctrl(c.chars().next().unwrap()));
+                }
+            }
+            anyhow::bail!("unknown key name: {:?}", other)
+        }
     }
 }
 
@@ -698,6 +705,7 @@ pub fn key_to_bytes(key: &KeyEvent) -> Vec<u8> {
         KeyEvent::CtrlSpace => vec![0x00],
         KeyEvent::CtrlSlash => vec![0x1F],
         KeyEvent::Backspace => vec![0x7F],
+        KeyEvent::Ctrl(c) => vec![*c as u8 - 0x60],
         KeyEvent::Printable(c) => vec![*c as u8],
         KeyEvent::CursorPositionReport(_, _) => Vec::new(), // intercepted in proxy
         KeyEvent::Raw(bytes) => bytes.clone(),
@@ -772,11 +780,21 @@ mod tests {
             KeyEvent::Backspace,
             KeyEvent::Printable('a'),
             KeyEvent::Raw(vec![0xFF]),
+            KeyEvent::Ctrl('a'),
+            KeyEvent::Ctrl('d'),
+            KeyEvent::Ctrl('z'),
         ];
         for key in keys {
             let bytes = key_to_bytes(&key);
             assert!(!bytes.is_empty(), "key_to_bytes({:?}) was empty", key);
         }
+    }
+
+    #[test]
+    fn test_key_to_bytes_ctrl() {
+        assert_eq!(key_to_bytes(&KeyEvent::Ctrl('a')), vec![0x01]);
+        assert_eq!(key_to_bytes(&KeyEvent::Ctrl('d')), vec![0x04]);
+        assert_eq!(key_to_bytes(&KeyEvent::Ctrl('z')), vec![0x1A]);
     }
 
     #[test]
@@ -1047,9 +1065,19 @@ mod tests {
     #[test]
     fn test_parse_key_name_unknown_errors() {
         assert!(parse_key_name("f1").is_err());
-        assert!(parse_key_name("ctrl+c").is_err());
         assert!(parse_key_name("").is_err());
         assert!(parse_key_name("banana").is_err());
+        assert!(parse_key_name("ctrl+1").is_err());
+        assert!(parse_key_name("ctrl+").is_err());
+    }
+
+    #[test]
+    fn test_parse_key_name_ctrl_letters() {
+        assert_eq!(parse_key_name("ctrl+a").unwrap(), KeyEvent::Ctrl('a'));
+        assert_eq!(parse_key_name("ctrl+d").unwrap(), KeyEvent::Ctrl('d'));
+        assert_eq!(parse_key_name("ctrl+z").unwrap(), KeyEvent::Ctrl('z'));
+        assert_eq!(parse_key_name("CTRL+C").unwrap(), KeyEvent::Ctrl('c'));
+        assert_eq!(parse_key_name("Ctrl+X").unwrap(), KeyEvent::Ctrl('x'));
     }
 
     // --- Keybindings tests ---

--- a/crates/gc-pty/src/input.rs
+++ b/crates/gc-pty/src/input.rs
@@ -14,6 +14,7 @@ pub enum KeyEvent {
     ArrowRight,
     CtrlSpace,
     CtrlSlash,
+    Ctrl(char),
     Backspace,
     Printable(char),
     /// Cursor Position Report response (CSI row;col R) — 1-indexed.
@@ -132,6 +133,13 @@ pub fn parse_keys(buf: &[u8]) -> Vec<KeyEvent> {
                     events.push(KeyEvent::Raw(buf[i..].to_vec()));
                     i = buf.len();
                 }
+            }
+            b if (0x01..=0x08).contains(&b)
+                || (0x0A..=0x0C).contains(&b)
+                || (0x0E..=0x1A).contains(&b) =>
+            {
+                events.push(KeyEvent::Ctrl((b + 0x60) as char));
+                i += 1;
             }
             b if (0x20..=0x7E).contains(&b) => {
                 events.push(KeyEvent::Printable(b as char));
@@ -293,5 +301,26 @@ mod tests {
             KeyEvent::Raw(bytes) => assert_eq!(bytes, b"\x1Ba"),
             other => panic!("expected Raw, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_ctrl_letters() {
+        assert_eq!(parse_keys(b"\x01"), vec![KeyEvent::Ctrl('a')]);
+        assert_eq!(parse_keys(b"\x04"), vec![KeyEvent::Ctrl('d')]);
+        assert_eq!(parse_keys(b"\x03"), vec![KeyEvent::Ctrl('c')]);
+        assert_eq!(parse_keys(b"\x1A"), vec![KeyEvent::Ctrl('z')]);
+    }
+
+    #[test]
+    fn test_ctrl_mixed_with_printable() {
+        let events = parse_keys(b"a\x04b");
+        assert_eq!(
+            events,
+            vec![
+                KeyEvent::Printable('a'),
+                KeyEvent::Ctrl('d'),
+                KeyEvent::Printable('b'),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `Ctrl(char)` variant to `KeyEvent` enum, enabling any Ctrl+letter combination
- Update `parse_keys()` to recognize Ctrl+letter control bytes (0x01–0x08, 0x0A–0x0C, 0x0E–0x1A)
- Extend `parse_key_name()` to parse `ctrl+x` patterns in config keybindings
- Users can now bind actions to any Ctrl+letter, e.g. `dismiss = "ctrl+d"`

## Changes
- `crates/gc-pty/src/input.rs` — Add `Ctrl(char)` variant, parse Ctrl bytes
- `crates/gc-pty/src/handler.rs` — Parse `ctrl+x` key names, convert back to bytes, add tests