### PR TITLE
feat: track CWD via OSC 7 for accurate filesystem completions

### DIFF
--- a/shell/ghost-complete.bash
+++ b/shell/ghost-complete.bash
@@ -5,6 +5,8 @@ _gc_prompt_command() {
     printf '\e]133;A\a'
     # Check GHOSTTY_RESOURCES_DIR too — TERM_PROGRAM is overwritten inside tmux
     [[ "$TERM_PROGRAM" != "ghostty" && -z "$GHOSTTY_RESOURCES_DIR" ]] && printf '\e]7771;A\a'
+    # Report current working directory via OSC 7 for filesystem completions
+    printf '\e]7;file://%s%s\a' "$HOSTNAME" "$PWD"
 }
 PROMPT_COMMAND="_gc_prompt_command${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 

--- a/shell/ghost-complete.fish
+++ b/shell/ghost-complete.fish
@@ -8,6 +8,8 @@ function _gc_prompt --on-event fish_prompt
     if test "$TERM_PROGRAM" != ghostty -a -z "$GHOSTTY_RESOURCES_DIR"
         printf '\e]7771;A\a'
     end
+    # Report current working directory via OSC 7 for filesystem completions
+    printf '\e]7;file://%s%s\a' "$hostname" "$PWD"
 end
 
 function _gc_preexec --on-event fish_preexec

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -5,6 +5,7 @@
 # boundaries and track the current command buffer.
 # OSC 133: native semantic prompts (Ghostty, iTerm2 partial)
 # OSC 7771: terminal-agnostic prompt boundary for Ghost Complete
+# OSC 7: current working directory reporting
 
 _gc_precmd() {
     # Mark: prompt is about to be displayed
@@ -22,6 +23,22 @@ _gc_preexec() {
 
 precmd_functions+=(_gc_precmd)
 preexec_functions+=(_gc_preexec)
+
+# Report current working directory via OSC 7 on directory change.
+# This enables the proxy to track CWD and provide correct filesystem completions.
+_gc_chpwd() {
+    printf '\e]7;file://%s%s\a' "$HOST" "$PWD"
+}
+
+chpwd_functions+=(_gc_chpwd)
+# Also emit on first prompt in case the shell started in a non-default directory
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _gc_osc7_precmd
+_gc_osc7_precmd() {
+    printf '\e]7;file://%s%s\a' "$HOST" "$PWD"
+    # Remove self after first run — chpwd hook handles subsequent changes
+    precmd_functions=(${precmd_functions:#_gc_osc7_precmd})
+}
 
 # Report current command buffer to the proxy via custom OSC 7770.
 # Fires after every buffer modification (typing, deletion, cursor movement, paste).


### PR DESCRIPTION
## Summary
- Add OSC 7 emission to shell integration scripts (zsh, bash, fish) on directory changes
- The PTY proxy already parses OSC 7 and auto-triggers completions on CWD changes — the shell just wasn't sending it
- Fixes completions continuing to use the old directory after running `cd`

## Changes
- `shell/ghost-complete.zsh` — Add `_gc_chpwd` hook via `chpwd_functions` + one-shot precmd for initial CWD
- `shell/ghost-complete.bash` — Add OSC 7 emission to `_gc_prompt_command` (runs on every prompt)
- `shell/ghost-complete.fish` — Add OSC 7 emission to `_gc_prompt` (runs on every `fish_prompt`)