### PR TITLE
fix: harden keybindings, OSC 7 encoding, border rendering

### DIFF
--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -75,11 +75,15 @@ impl Default for TriggerConfig {
 #[serde(default)]
 pub struct PopupConfig {
     pub max_visible: usize,
+    pub borders: bool,
 }
 
 impl Default for PopupConfig {
     fn default() -> Self {
-        Self { max_visible: 10 }
+        Self {
+            max_visible: 10,
+            borders: false,
+        }
     }
 }
 

--- a/crates/gc-overlay/src/layout.rs
+++ b/crates/gc-overlay/src/layout.rs
@@ -15,8 +15,10 @@ pub fn compute_layout(
     max_visible: usize,
     min_width: u16,
     max_width: u16,
+    borders: bool,
 ) -> PopupLayout {
     let visible_count = suggestions.len().min(max_visible);
+    let border_pad: u16 = if borders { 2 } else { 0 };
 
     // Compute width from visible suggestions (content only, no border)
     let content_width = suggestions
@@ -25,12 +27,11 @@ pub fn compute_layout(
         .take(max_visible)
         .map(item_display_width)
         .max()
-        .unwrap_or((min_width - 2) as usize);
-    // Add 2 for left/right border columns
-    let width = (content_width as u16 + 2).clamp(min_width, max_width.min(screen_cols));
+        .unwrap_or(min_width.saturating_sub(border_pad) as usize);
+    let width = (content_width as u16 + border_pad).clamp(min_width, max_width.min(screen_cols));
 
-    // Height includes top + bottom border rows
-    let height = (visible_count as u16) + 2;
+    // Height includes border rows when enabled
+    let height = (visible_count as u16) + border_pad;
 
     // Always render below cursor. Caller is responsible for adjusting
     // cursor_row via scroll deficit before calling this function.
@@ -102,6 +103,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
+            true,
         );
         assert_eq!(layout.scroll_deficit, 0);
         assert_eq!(layout.start_row, 6);
@@ -121,6 +123,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
+            true,
         );
         // Layout always places below — start_row = cursor_row + 1
         assert_eq!(layout.start_row, 23);
@@ -140,6 +143,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
+            true,
         );
         assert!(layout.start_col + layout.width <= 80);
     }
@@ -157,6 +161,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
+            true,
         );
         assert_eq!(layout.start_row, 1);
         assert_eq!(layout.start_col, 0);
@@ -175,6 +180,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
+            true,
         );
         assert!(layout.width >= DEFAULT_MIN_POPUP_WIDTH);
     }
@@ -193,6 +199,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
+            true,
         );
         assert!(layout.width <= DEFAULT_MAX_POPUP_WIDTH);
     }
@@ -211,6 +218,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
+            true,
         );
         assert_eq!(layout.height, DEFAULT_MAX_VISIBLE as u16 + 2); // +2 for borders
     }
@@ -229,6 +237,7 @@ mod tests {
             5,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
+            true,
         );
         assert_eq!(layout.height, 7); // 5 content + 2 borders
     }

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -30,7 +30,7 @@ impl Default for PopupTheme {
             item_text_on: vec![],
             scrollbar_on: b"\x1b[2m".to_vec(),
             border_on: b"\x1b[2m".to_vec(),
-            borders: true,
+            borders: false,
         }
     }
 }
@@ -156,7 +156,7 @@ pub fn render_popup(
     let space_below = screen_rows.saturating_sub(adj_cursor_row + 1);
     let visible_count = suggestions.len().min(effective_max) as u16;
     let loading_extra_deficit = if loading && theme.borders {
-        2u16
+        1u16 // loading row displaces bottom border; new border drawn 1 row below layout extent
     } else if loading {
         1u16
     } else {
@@ -371,7 +371,7 @@ pub fn render_popup(
                     }
                     buf.extend_from_slice("╯".as_bytes());
                     ansi::reset(buf);
-                    2 // loading row + bottom border
+                    1 // loading row extends 1 row beyond layout.height (border is within that row)
                 } else {
                     1 // only loading row fit
                 }
@@ -580,6 +580,13 @@ mod tests {
         TerminalProfile::for_iterm2()
     }
 
+    fn bordered_theme() -> PopupTheme {
+        PopupTheme {
+            borders: true,
+            ..PopupTheme::default()
+        }
+    }
+
     fn make(text: &str, desc: Option<&str>, kind: SuggestionKind) -> Suggestion {
         Suggestion {
             text: text.to_string(),
@@ -618,7 +625,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -647,7 +654,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &iterm2_profile(),
@@ -704,7 +711,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -730,7 +737,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -760,7 +767,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -776,7 +783,7 @@ mod tests {
     fn test_format_item_shows_kind_gutter() {
         let mut buf = Vec::new();
         let s = make("checkout", None, SuggestionKind::Subcommand);
-        format_item(&mut buf, &s, 30, false, &PopupTheme::default());
+        format_item(&mut buf, &s, 30, false, &bordered_theme());
         let output = String::from_utf8_lossy(&buf);
         assert!(
             output.starts_with(" \u{F0DA} checkout"),
@@ -792,7 +799,7 @@ mod tests {
             None,
             SuggestionKind::Directory,
         );
-        format_item(&mut buf, &s, 40, false, &PopupTheme::default());
+        format_item(&mut buf, &s, 40, false, &bordered_theme());
         let output = String::from_utf8_lossy(&buf);
         assert!(
             output.contains("2023-rust/"),
@@ -808,7 +815,7 @@ mod tests {
     fn test_format_item_shows_only_filename_for_file() {
         let mut buf = Vec::new();
         let s = make("src/main/java/App.java", None, SuggestionKind::FilePath);
-        format_item(&mut buf, &s, 40, false, &PopupTheme::default());
+        format_item(&mut buf, &s, 40, false, &bordered_theme());
         let output = String::from_utf8_lossy(&buf);
         assert!(
             output.contains("App.java"),
@@ -824,7 +831,7 @@ mod tests {
     fn test_format_item_no_slash_shows_full_name() {
         let mut buf = Vec::new();
         let s = make("Desktop/", None, SuggestionKind::Directory);
-        format_item(&mut buf, &s, 40, false, &PopupTheme::default());
+        format_item(&mut buf, &s, 40, false, &bordered_theme());
         let output = String::from_utf8_lossy(&buf);
         assert!(
             output.contains("Desktop/"),
@@ -838,7 +845,7 @@ mod tests {
         let long_text = "https://api.github.com/orgs/Example/packages?package_type=container";
         let s = make(long_text, None, SuggestionKind::History);
         let width: u16 = 30;
-        format_item(&mut buf, &s, width, false, &PopupTheme::default());
+        format_item(&mut buf, &s, width, false, &bordered_theme());
         // Count printable characters (no ANSI escape sequences)
         let output = String::from_utf8_lossy(&buf);
         let printable: String = output
@@ -857,7 +864,7 @@ mod tests {
         let mut buf = Vec::new();
         let long_desc = "a".repeat(200);
         let s = make("cmd", Some(&long_desc), SuggestionKind::Command);
-        format_item(&mut buf, &s, 30, false, &PopupTheme::default());
+        format_item(&mut buf, &s, 30, false, &bordered_theme());
         // Output should not exceed width
         assert!(buf.len() < 200, "should truncate description");
     }
@@ -919,7 +926,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -952,7 +959,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1030,7 +1037,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1067,7 +1074,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1098,7 +1105,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             4,
             false,
             &ghostty_profile(),
@@ -1129,7 +1136,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1153,7 +1160,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             4, // prior_deficit from first render
             false,
             &ghostty_profile(),
@@ -1185,7 +1192,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1221,7 +1228,7 @@ mod tests {
             15, // max_visible bigger than screen
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1257,7 +1264,7 @@ mod tests {
             15,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1319,7 +1326,7 @@ mod tests {
         state.selected = Some(0); // Only first item selected
         let theme = PopupTheme {
             item_text_on: b"\x1b[2m".to_vec(), // explicitly dim for this test
-            ..PopupTheme::default()
+            ..bordered_theme()
         };
         render_popup(
             &mut buf,
@@ -1357,7 +1364,7 @@ mod tests {
         let theme = PopupTheme {
             item_text_on: b"\x1b[2m".to_vec(),
             selected_on: b"\x1b[7m".to_vec(),
-            ..PopupTheme::default()
+            ..bordered_theme()
         };
         render_popup(
             &mut buf,
@@ -1387,7 +1394,7 @@ mod tests {
         let state = OverlayState::new(); // Nothing selected
         let theme = PopupTheme {
             item_text_on: vec![], // Empty — no styling
-            ..PopupTheme::default()
+            ..bordered_theme()
         };
         render_popup(
             &mut buf,
@@ -1564,7 +1571,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1592,7 +1599,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1630,7 +1637,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1660,7 +1667,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1691,7 +1698,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1709,7 +1716,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1732,7 +1739,7 @@ mod tests {
         state.selected = Some(0);
         let theme = PopupTheme {
             selected_on: b"\x1b[7m".to_vec(),
-            ..PopupTheme::default()
+            ..bordered_theme()
         };
         render_popup(
             &mut buf,
@@ -1773,7 +1780,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             true,
             &ghostty_profile(),
@@ -1783,10 +1790,11 @@ mod tests {
             output.contains("..."),
             "loading=true should produce '...' indicator: {output}"
         );
-        // Height: 3 content + 2 borders + 1 loading + 1 bottom border below loading = 7
+        // Height: 3 content + 2 borders + 1 loading extra (loading displaces bottom border,
+        // which moves down 1 row, netting 1 extra row beyond layout.height) = 6
         assert_eq!(
-            layout.height, 7,
-            "loading row + bottom border should increase height by 2"
+            layout.height, 6,
+            "loading should increase height by 1 beyond base layout"
         );
     }
 
@@ -1806,7 +1814,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1836,7 +1844,7 @@ mod tests {
             DEFAULT_MAX_VISIBLE,
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
-            &PopupTheme::default(),
+            &bordered_theme(),
             0,
             false,
             &ghostty_profile(),
@@ -1851,5 +1859,136 @@ mod tests {
         );
         assert!(output.contains('─'), "missing horizontal border: {output}");
         assert!(output.contains('│'), "missing vertical border: {output}");
+    }
+
+    // --- borders: false tests (production default) ---
+
+    #[test]
+    fn test_render_no_borders_no_border_chars() {
+        let mut buf = Vec::new();
+        let suggestions = make_suggestions();
+        let state = OverlayState::new();
+        render_popup(
+            &mut buf,
+            &suggestions,
+            &state,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            &PopupTheme::default(), // borders: false
+            0,
+            false,
+            &ghostty_profile(),
+        );
+        let output = String::from_utf8_lossy(&buf);
+        assert!(!output.contains('╭'), "no top-left corner without borders");
+        assert!(!output.contains('╮'), "no top-right corner without borders");
+        assert!(
+            !output.contains('╰'),
+            "no bottom-left corner without borders"
+        );
+        assert!(
+            !output.contains('╯'),
+            "no bottom-right corner without borders"
+        );
+        assert!(!output.contains('│'), "no vertical border without borders");
+    }
+
+    #[test]
+    fn test_render_no_borders_height() {
+        let mut buf = Vec::new();
+        let suggestions = make_suggestions(); // 3 items
+        let state = OverlayState::new();
+        let layout = render_popup(
+            &mut buf,
+            &suggestions,
+            &state,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            &PopupTheme::default(),
+            0,
+            false,
+            &ghostty_profile(),
+        );
+        // 3 content rows, no border padding
+        assert_eq!(layout.height, 3, "borderless height = content rows only");
+    }
+
+    #[test]
+    fn test_layout_no_borders_width() {
+        // Use a suggestion wide enough to exceed min_width so border padding is visible
+        let suggestions = vec![make(
+            "a-sufficiently-long-suggestion-name",
+            None,
+            SuggestionKind::Subcommand,
+        )];
+        let layout = layout::compute_layout(
+            &suggestions,
+            0,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            false, // no borders
+        );
+        let bordered = layout::compute_layout(
+            &suggestions,
+            0,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            true,
+        );
+        assert_eq!(
+            bordered.width - layout.width,
+            2,
+            "bordered should be 2 wider (border padding), got borderless={} bordered={}",
+            layout.width,
+            bordered.width
+        );
+    }
+
+    #[test]
+    fn test_loading_no_borders_height() {
+        let mut buf = Vec::new();
+        let suggestions = make_suggestions();
+        let state = OverlayState::new();
+        let layout = render_popup(
+            &mut buf,
+            &suggestions,
+            &state,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            &PopupTheme::default(), // borders: false
+            0,
+            true,
+            &ghostty_profile(),
+        );
+        // 3 content + 1 loading row, no borders
+        assert_eq!(
+            layout.height, 4,
+            "borderless loading height = content + 1 loading row"
+        );
     }
 }

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -155,13 +155,7 @@ pub fn render_popup(
     // Calculate how much more scrolling is needed
     let space_below = screen_rows.saturating_sub(adj_cursor_row + 1);
     let visible_count = suggestions.len().min(effective_max) as u16;
-    let loading_extra_deficit = if loading && theme.borders {
-        1u16 // loading row displaces bottom border; new border drawn 1 row below layout extent
-    } else if loading {
-        1u16
-    } else {
-        0
-    };
+    let loading_extra_deficit = if loading { 1u16 } else { 0 };
     let total_height_needed = visible_count + border_pad + loading_extra_deficit;
     let new_deficit = total_height_needed.saturating_sub(space_below);
     let total_deficit = prior_deficit + new_deficit;

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -18,6 +18,7 @@ pub struct PopupTheme {
     pub item_text_on: Vec<u8>,
     pub scrollbar_on: Vec<u8>,
     pub border_on: Vec<u8>,
+    pub borders: bool,
 }
 
 impl Default for PopupTheme {
@@ -29,6 +30,7 @@ impl Default for PopupTheme {
             item_text_on: vec![],
             scrollbar_on: b"\x1b[2m".to_vec(),
             border_on: b"\x1b[2m".to_vec(),
+            borders: true,
         }
     }
 }
@@ -126,11 +128,18 @@ pub fn render_popup(
         };
     }
 
+    // Border padding: 2 rows/cols when borders enabled, 0 otherwise
+    let border_pad: u16 = if theme.borders { 2 } else { 0 };
+
     // Cap popup height to screen_rows - 1 (leave room for prompt row)
-    // Subtract 2 for top/bottom border rows
-    let effective_max = if screen_rows > 3 {
-        max_visible.min((screen_rows - 1 - 2) as usize)
+    let min_screen = 1 + border_pad; // need at least 1 content row + borders
+    let effective_max = if screen_rows > min_screen {
+        max_visible.min((screen_rows - 1 - border_pad) as usize)
     } else {
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "ghost-complete: popup suppressed — screen too small ({screen_rows} rows, need > {min_screen})"
+        );
         return PopupLayout {
             start_row: 0,
             start_col: 0,
@@ -144,11 +153,16 @@ pub fn render_popup(
     let adj_cursor_row = cursor_row.saturating_sub(prior_deficit);
 
     // Calculate how much more scrolling is needed
-    // Total popup height = content rows + 2 border rows
     let space_below = screen_rows.saturating_sub(adj_cursor_row + 1);
     let visible_count = suggestions.len().min(effective_max) as u16;
-    let loading_extra_deficit = if loading { 1u16 } else { 0 };
-    let total_height_needed = visible_count + 2 + loading_extra_deficit; // +2 for borders
+    let loading_extra_deficit = if loading && theme.borders {
+        2u16
+    } else if loading {
+        1u16
+    } else {
+        0
+    };
+    let total_height_needed = visible_count + border_pad + loading_extra_deficit;
     let new_deficit = total_height_needed.saturating_sub(space_below);
     let total_deficit = prior_deficit + new_deficit;
     let final_cursor_row = cursor_row.saturating_sub(total_deficit);
@@ -185,6 +199,7 @@ pub fn render_popup(
         effective_max,
         min_width,
         max_width,
+        theme.borders,
     );
 
     if layout.height == 0 {
@@ -198,13 +213,16 @@ pub fn render_popup(
         };
     }
 
-    // Layout includes 2 border columns (left + right) and 1 top + 1 bottom row.
-    // Content area is inside the border.
-    let content_width = layout.width.saturating_sub(2);
-    let content_height = layout.height.saturating_sub(2);
+    // Content dimensions: subtract border padding when borders enabled
+    let content_width = layout.width.saturating_sub(border_pad);
+    let content_height = layout.height.saturating_sub(border_pad);
     let border_col = layout.start_col;
     let top_border_row = layout.start_row;
-    let bottom_border_row = layout.start_row + layout.height - 1;
+    let bottom_border_row = if theme.borders {
+        layout.start_row + layout.height - 1
+    } else {
+        layout.start_row + layout.height // past end, won't be used
+    };
 
     let needs_scrollbar = suggestions.len() > effective_max;
     let (thumb_pos, thumb_size) = if needs_scrollbar {
@@ -222,7 +240,7 @@ pub fn render_popup(
         (0, 0)
     };
     let item_width = if needs_scrollbar {
-        content_width - 1
+        content_width.saturating_sub(1)
     } else {
         content_width
     };
@@ -231,38 +249,39 @@ pub fn render_popup(
     let visible = &suggestions[state.scroll_offset..end];
 
     // Draw top border line: ╭───...───╮
-    ansi::move_to(buf, top_border_row, border_col);
-    if !theme.border_on.is_empty() {
-        buf.extend_from_slice(&theme.border_on);
+    if theme.borders {
+        ansi::move_to(buf, top_border_row, border_col);
+        if !theme.border_on.is_empty() {
+            buf.extend_from_slice(&theme.border_on);
+        }
+        buf.extend_from_slice("╭".as_bytes());
+        for _ in 0..content_width {
+            buf.extend_from_slice("─".as_bytes());
+        }
+        buf.extend_from_slice("╮".as_bytes());
+        ansi::reset(buf);
     }
-    buf.push(b'\xe2');
-    buf.push(b'\x95');
-    buf.push(b'\xad'); // ╭
-    for _ in 0..content_width {
-        buf.push(b'\xe2');
-        buf.push(b'\x94');
-        buf.push(b'\x80'); // ─
-    }
-    buf.push(b'\xe2');
-    buf.push(b'\x95');
-    buf.push(b'\xae'); // ╮
-    ansi::reset(buf);
 
-    // Draw content rows with left/right borders: │content│
+    // Draw content rows (with left/right borders when enabled)
+    let content_start_row = if theme.borders {
+        top_border_row + 1
+    } else {
+        top_border_row
+    };
     for (i, suggestion) in visible.iter().enumerate() {
-        let row = top_border_row + 1 + i as u16;
+        let row = content_start_row + i as u16;
         let is_selected = state.selected == Some(state.scroll_offset + i);
 
         ansi::move_to(buf, row, border_col);
 
         // Left border
-        if !theme.border_on.is_empty() {
-            buf.extend_from_slice(&theme.border_on);
+        if theme.borders {
+            if !theme.border_on.is_empty() {
+                buf.extend_from_slice(&theme.border_on);
+            }
+            buf.extend_from_slice("│".as_bytes());
+            ansi::reset(buf);
         }
-        buf.push(b'\xe2');
-        buf.push(b'\x94');
-        buf.push(b'\x82'); // │
-        ansi::reset(buf);
 
         // Content
         if is_selected {
@@ -279,7 +298,7 @@ pub fn render_popup(
                 if row_idx >= thumb_pos && row_idx < thumb_pos + thumb_size {
                     let _ = buf.write_all("█".as_bytes());
                 } else {
-                    let _ = buf.write_all("│".as_bytes());
+                    let _ = buf.write_all("┆".as_bytes());
                 }
             } else if row_idx >= thumb_pos && row_idx < thumb_pos + thumb_size {
                 if !theme.item_text_on.is_empty() {
@@ -291,33 +310,39 @@ pub fn render_popup(
                 if !theme.scrollbar_on.is_empty() {
                     buf.extend_from_slice(&theme.scrollbar_on);
                 }
-                let _ = buf.write_all("│".as_bytes());
+                let _ = buf.write_all("┆".as_bytes());
             }
         }
 
         // Right border
-        ansi::reset(buf);
-        if !theme.border_on.is_empty() {
-            buf.extend_from_slice(&theme.border_on);
+        if theme.borders {
+            ansi::reset(buf);
+            if !theme.border_on.is_empty() {
+                buf.extend_from_slice(&theme.border_on);
+            }
+            buf.extend_from_slice("│".as_bytes());
+            ansi::reset(buf);
+        } else {
+            ansi::reset(buf);
         }
-        buf.push(b'\xe2');
-        buf.push(b'\x94');
-        buf.push(b'\x82'); // │
-        ansi::reset(buf);
     }
 
     // Render loading indicator row when async generators are in flight
     let loading_extra = if loading {
-        let loading_row = bottom_border_row;
+        let loading_row = if theme.borders {
+            bottom_border_row
+        } else {
+            layout.start_row + layout.height
+        };
         if loading_row < screen_rows {
             ansi::move_to(buf, loading_row, border_col);
-            if !theme.border_on.is_empty() {
-                buf.extend_from_slice(&theme.border_on);
+            if theme.borders {
+                if !theme.border_on.is_empty() {
+                    buf.extend_from_slice(&theme.border_on);
+                }
+                buf.extend_from_slice("│".as_bytes());
+                ansi::reset(buf);
             }
-            buf.push(b'\xe2');
-            buf.push(b'\x94');
-            buf.push(b'\x82'); // │
-            ansi::reset(buf);
             buf.extend_from_slice(&theme.description_on);
             let label = b"  ...";
             let _ = buf.write_all(label);
@@ -326,14 +351,33 @@ pub fn render_popup(
                 let _ = buf.write_all(b" ");
             }
             ansi::reset(buf);
-            if !theme.border_on.is_empty() {
-                buf.extend_from_slice(&theme.border_on);
+            if theme.borders {
+                if !theme.border_on.is_empty() {
+                    buf.extend_from_slice(&theme.border_on);
+                }
+                buf.extend_from_slice("│".as_bytes());
+                ansi::reset(buf);
+
+                // Draw bottom border below loading row
+                let border_below = loading_row + 1;
+                if border_below < screen_rows {
+                    ansi::move_to(buf, border_below, border_col);
+                    if !theme.border_on.is_empty() {
+                        buf.extend_from_slice(&theme.border_on);
+                    }
+                    buf.extend_from_slice("╰".as_bytes());
+                    for _ in 0..content_width {
+                        buf.extend_from_slice("─".as_bytes());
+                    }
+                    buf.extend_from_slice("╯".as_bytes());
+                    ansi::reset(buf);
+                    2 // loading row + bottom border
+                } else {
+                    1 // only loading row fit
+                }
+            } else {
+                1 // no borders, just the loading row
             }
-            buf.push(b'\xe2');
-            buf.push(b'\x94');
-            buf.push(b'\x82'); // │
-            ansi::reset(buf);
-            1
         } else {
             0
         }
@@ -342,22 +386,16 @@ pub fn render_popup(
     };
 
     // Draw bottom border line: ╰───...───╯
-    if loading_extra == 0 {
+    if theme.borders && loading_extra == 0 {
         ansi::move_to(buf, bottom_border_row, border_col);
         if !theme.border_on.is_empty() {
             buf.extend_from_slice(&theme.border_on);
         }
-        buf.push(b'\xe2');
-        buf.push(b'\x95');
-        buf.push(b'\xb0'); // ╰
+        buf.extend_from_slice("╰".as_bytes());
         for _ in 0..content_width {
-            buf.push(b'\xe2');
-            buf.push(b'\x94');
-            buf.push(b'\x80'); // ─
+            buf.extend_from_slice("─".as_bytes());
         }
-        buf.push(b'\xe2');
-        buf.push(b'\x95');
-        buf.push(b'\xaf'); // ╯
+        buf.extend_from_slice("╯".as_bytes());
         ansi::reset(buf);
     }
 
@@ -1372,8 +1410,8 @@ mod tests {
         // 3 content rows × (2 border + 1 desc) + 2 border rows = 11 dim sequences
         let dim_count = output.matches("\x1b[2m").count();
         assert!(
-            dim_count <= 15,
-            "should not have excessive dim sequences, got {dim_count}: {output}"
+            dim_count <= 12,
+            "expected ~11 dim sequences (borders + descriptions), got {dim_count}: {output}"
         );
     }
 
@@ -1533,7 +1571,7 @@ mod tests {
         );
         let output = String::from_utf8_lossy(&buf);
         assert!(
-            output.contains('█') || output.contains('│'),
+            output.contains('█') || output.contains('┆'),
             "scrollbar should be visible with 15 items: {output}"
         );
     }
@@ -1599,7 +1637,7 @@ mod tests {
         );
         let output = String::from_utf8_lossy(&buf);
         assert!(output.contains('█'), "should have thumb indicator");
-        assert!(output.contains('│'), "should have track indicator");
+        assert!(output.contains('┆'), "should have track indicator");
     }
 
     #[test]
@@ -1679,7 +1717,7 @@ mod tests {
 
         let output = String::from_utf8_lossy(&buf_scroll);
         assert!(
-            output.contains('│') || output.contains('█'),
+            output.contains('┆') || output.contains('█'),
             "scrollbar popup should have scrollbar chars"
         );
     }
@@ -1745,8 +1783,11 @@ mod tests {
             output.contains("..."),
             "loading=true should produce '...' indicator: {output}"
         );
-        // Height: 3 content + 2 borders + 1 loading = 6
-        assert_eq!(layout.height, 6, "loading row should increase height by 1");
+        // Height: 3 content + 2 borders + 1 loading + 1 bottom border below loading = 7
+        assert_eq!(
+            layout.height, 7,
+            "loading row + bottom border should increase height by 2"
+        );
     }
 
     #[test]
@@ -1777,5 +1818,38 @@ mod tests {
         );
         // Height: 3 content + 2 borders = 5
         assert_eq!(layout.height, 5);
+    }
+
+    #[test]
+    fn test_border_characters_present() {
+        let mut buf = Vec::new();
+        let suggestions = make_suggestions(); // 3 items
+        let state = OverlayState::new();
+        render_popup(
+            &mut buf,
+            &suggestions,
+            &state,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            &PopupTheme::default(),
+            0,
+            false,
+            &ghostty_profile(),
+        );
+        let output = String::from_utf8_lossy(&buf);
+        assert!(output.contains('╭'), "missing top-left corner: {output}");
+        assert!(output.contains('╮'), "missing top-right corner: {output}");
+        assert!(output.contains('╰'), "missing bottom-left corner: {output}");
+        assert!(
+            output.contains('╯'),
+            "missing bottom-right corner: {output}"
+        );
+        assert!(output.contains('─'), "missing horizontal border: {output}");
+        assert!(output.contains('│'), "missing vertical border: {output}");
     }
 }

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -213,9 +213,9 @@ pub fn render_popup(
     let border_col = layout.start_col;
     let top_border_row = layout.start_row;
     let bottom_border_row = if theme.borders {
-        layout.start_row + layout.height - 1
+        Some(layout.start_row + layout.height - 1)
     } else {
-        layout.start_row + layout.height // past end, won't be used
+        None
     };
 
     let needs_scrollbar = suggestions.len() > effective_max;
@@ -323,11 +323,7 @@ pub fn render_popup(
 
     // Render loading indicator row when async generators are in flight
     let loading_extra = if loading {
-        let loading_row = if theme.borders {
-            bottom_border_row
-        } else {
-            layout.start_row + layout.height
-        };
+        let loading_row = bottom_border_row.unwrap_or(layout.start_row + layout.height);
         if loading_row < screen_rows {
             ansi::move_to(buf, loading_row, border_col);
             if theme.borders {
@@ -380,8 +376,8 @@ pub fn render_popup(
     };
 
     // Draw bottom border line: ╰───...───╯
-    if theme.borders && loading_extra == 0 {
-        ansi::move_to(buf, bottom_border_row, border_col);
+    if let (Some(bbr), 0) = (bottom_border_row, loading_extra) {
+        ansi::move_to(buf, bbr, border_col);
         if !theme.border_on.is_empty() {
             buf.extend_from_slice(&theme.border_on);
         }

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -220,12 +220,15 @@ fn parse_osc7_path(uri: &[u8]) -> Option<PathBuf> {
     let slash_idx = path_part.find('/')?;
     let path = &path_part[slash_idx..];
     // Percent-decode the path (handles all percent-encoded bytes)
-    let decoded = percent_decode(path);
-    Some(PathBuf::from(decoded))
+    Some(percent_decode_path(path))
 }
 
 /// Minimal percent-decoding for file paths.
-fn percent_decode(input: &str) -> String {
+///
+/// Returns a `PathBuf` built directly from raw bytes via `OsStr`, avoiding
+/// lossy UTF-8 conversion. Unix paths are byte sequences, not necessarily
+/// valid UTF-8, so this preserves paths that contain arbitrary bytes.
+fn percent_decode_path(input: &str) -> PathBuf {
     let mut bytes = Vec::with_capacity(input.len());
     let mut iter = input.bytes();
     while let Some(b) = iter.next() {
@@ -255,13 +258,8 @@ fn percent_decode(input: &str) -> String {
             bytes.push(b);
         }
     }
-    String::from_utf8(bytes).unwrap_or_else(|e| {
-        tracing::warn!(
-            "percent_decode produced invalid UTF-8 (lossy replacement applied): {}",
-            e
-        );
-        String::from_utf8_lossy(e.as_bytes()).into_owned()
-    })
+    use std::os::unix::ffi::OsStrExt;
+    PathBuf::from(std::ffi::OsStr::from_bytes(&bytes))
 }
 
 fn hex_val(b: u8) -> Option<u8> {
@@ -674,44 +672,68 @@ mod tests {
 
     #[test]
     fn test_percent_decode() {
-        assert_eq!(percent_decode("/hello%20world"), "/hello world");
-        assert_eq!(percent_decode("/no/encoding"), "/no/encoding");
-        assert_eq!(percent_decode("%2F"), "/");
+        assert_eq!(
+            percent_decode_path("/hello%20world"),
+            PathBuf::from("/hello world")
+        );
+        assert_eq!(
+            percent_decode_path("/no/encoding"),
+            PathBuf::from("/no/encoding")
+        );
+        assert_eq!(percent_decode_path("%2F"), PathBuf::from("/"));
     }
 
     #[test]
     fn test_percent_decode_basic() {
-        assert_eq!(percent_decode("/foo%20bar"), "/foo bar");
-        assert_eq!(percent_decode("/no/encoding"), "/no/encoding");
-        assert_eq!(percent_decode(""), "");
+        assert_eq!(percent_decode_path("/foo%20bar"), PathBuf::from("/foo bar"));
+        assert_eq!(
+            percent_decode_path("/no/encoding"),
+            PathBuf::from("/no/encoding")
+        );
+        assert_eq!(percent_decode_path(""), PathBuf::from(""));
     }
 
     #[test]
     fn test_percent_decode_preserves_malformed() {
         // Invalid hex digits — keep all bytes literal
-        assert_eq!(percent_decode("/foo%zz/bar"), "/foo%zz/bar");
-        assert_eq!(percent_decode("/foo%gh"), "/foo%gh");
+        assert_eq!(
+            percent_decode_path("/foo%zz/bar"),
+            PathBuf::from("/foo%zz/bar")
+        );
+        assert_eq!(percent_decode_path("/foo%gh"), PathBuf::from("/foo%gh"));
     }
 
     #[test]
     fn test_percent_decode_truncated() {
         // % at end of string
-        assert_eq!(percent_decode("/foo%"), "/foo%");
+        assert_eq!(percent_decode_path("/foo%"), PathBuf::from("/foo%"));
         // % with only one byte after
-        assert_eq!(percent_decode("/foo%a"), "/foo%a");
+        assert_eq!(percent_decode_path("/foo%a"), PathBuf::from("/foo%a"));
     }
 
     #[test]
     fn test_percent_decode_utf8() {
         // é = U+00E9 = UTF-8 bytes C3 A9
-        assert_eq!(percent_decode("/caf%C3%A9"), "/café");
+        assert_eq!(percent_decode_path("/caf%C3%A9"), PathBuf::from("/café"));
         // 日 = U+65E5 = UTF-8 bytes E6 97 A5
-        assert_eq!(percent_decode("/%E6%97%A5"), "/日");
+        assert_eq!(percent_decode_path("/%E6%97%A5"), PathBuf::from("/日"));
     }
 
     #[test]
     fn test_percent_decode_literal_percent() {
         // %25 is the encoding for literal %
-        assert_eq!(percent_decode("/100%25done"), "/100%done");
+        assert_eq!(
+            percent_decode_path("/100%25done"),
+            PathBuf::from("/100%done")
+        );
+    }
+
+    #[test]
+    fn test_percent_decode_non_utf8_bytes() {
+        // Bytes 0x80 0x81 are not valid UTF-8, but are valid Unix path bytes
+        use std::os::unix::ffi::OsStrExt;
+        let result = percent_decode_path("/%80%81");
+        let expected = PathBuf::from(std::ffi::OsStr::from_bytes(&[b'/', 0x80, 0x81]));
+        assert_eq!(result, expected);
     }
 }

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -200,6 +200,11 @@ impl Perform for TerminalState {
                 if let Some(path) = parse_osc7_path(params[1]) {
                     tracing::debug!(?path, "OSC 7 — cwd update");
                     self.set_cwd(path);
+                } else {
+                    tracing::debug!(
+                        raw = %String::from_utf8_lossy(params[1]),
+                        "OSC 7 — failed to parse cwd URI"
+                    );
                 }
             }
             _ => {}
@@ -250,7 +255,13 @@ fn percent_decode(input: &str) -> String {
             bytes.push(b);
         }
     }
-    String::from_utf8(bytes).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+    String::from_utf8(bytes).unwrap_or_else(|e| {
+        tracing::warn!(
+            "percent_decode produced invalid UTF-8 (lossy replacement applied): {}",
+            e
+        );
+        String::from_utf8_lossy(e.as_bytes()).into_owned()
+    })
 }
 
 fn hex_val(b: u8) -> Option<u8> {

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -214,32 +214,43 @@ fn parse_osc7_path(uri: &[u8]) -> Option<PathBuf> {
     // Skip the hostname — find the first '/' after the authority
     let slash_idx = path_part.find('/')?;
     let path = &path_part[slash_idx..];
-    // Percent-decode the path (basic: just handle %20 for spaces)
+    // Percent-decode the path (handles all percent-encoded bytes)
     let decoded = percent_decode(path);
     Some(PathBuf::from(decoded))
 }
 
 /// Minimal percent-decoding for file paths.
 fn percent_decode(input: &str) -> String {
-    let mut result = String::with_capacity(input.len());
-    let mut chars = input.bytes();
-    while let Some(b) = chars.next() {
+    let mut bytes = Vec::with_capacity(input.len());
+    let mut iter = input.bytes();
+    while let Some(b) = iter.next() {
         if b == b'%' {
-            let hi = chars.next();
-            let lo = chars.next();
-            if let (Some(hi), Some(lo)) = (hi, lo) {
-                if let (Some(h), Some(l)) = (hex_val(hi), hex_val(lo)) {
-                    result.push((h << 4 | l) as char);
-                    continue;
+            match (iter.next(), iter.next()) {
+                (Some(hi), Some(lo)) => {
+                    if let (Some(h), Some(l)) = (hex_val(hi), hex_val(lo)) {
+                        bytes.push(h << 4 | l);
+                    } else {
+                        // Invalid hex — keep all three bytes literal
+                        bytes.push(b'%');
+                        bytes.push(hi);
+                        bytes.push(lo);
+                    }
+                }
+                (Some(hi), None) => {
+                    // Truncated — keep literal
+                    bytes.push(b'%');
+                    bytes.push(hi);
+                }
+                (None, _) => {
+                    // % at very end
+                    bytes.push(b'%');
                 }
             }
-            // Malformed — keep literal
-            result.push('%');
         } else {
-            result.push(b as char);
+            bytes.push(b);
         }
     }
-    result
+    String::from_utf8(bytes).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
 
 fn hex_val(b: u8) -> Option<u8> {
@@ -655,5 +666,41 @@ mod tests {
         assert_eq!(percent_decode("/hello%20world"), "/hello world");
         assert_eq!(percent_decode("/no/encoding"), "/no/encoding");
         assert_eq!(percent_decode("%2F"), "/");
+    }
+
+    #[test]
+    fn test_percent_decode_basic() {
+        assert_eq!(percent_decode("/foo%20bar"), "/foo bar");
+        assert_eq!(percent_decode("/no/encoding"), "/no/encoding");
+        assert_eq!(percent_decode(""), "");
+    }
+
+    #[test]
+    fn test_percent_decode_preserves_malformed() {
+        // Invalid hex digits — keep all bytes literal
+        assert_eq!(percent_decode("/foo%zz/bar"), "/foo%zz/bar");
+        assert_eq!(percent_decode("/foo%gh"), "/foo%gh");
+    }
+
+    #[test]
+    fn test_percent_decode_truncated() {
+        // % at end of string
+        assert_eq!(percent_decode("/foo%"), "/foo%");
+        // % with only one byte after
+        assert_eq!(percent_decode("/foo%a"), "/foo%a");
+    }
+
+    #[test]
+    fn test_percent_decode_utf8() {
+        // é = U+00E9 = UTF-8 bytes C3 A9
+        assert_eq!(percent_decode("/caf%C3%A9"), "/café");
+        // 日 = U+65E5 = UTF-8 bytes E6 97 A5
+        assert_eq!(percent_decode("/%E6%97%A5"), "/日");
+    }
+
+    #[test]
+    fn test_percent_decode_literal_percent() {
+        // %25 is the encoding for literal %
+        assert_eq!(percent_decode("/100%25done"), "/100%done");
     }
 }

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -95,7 +95,7 @@ pub fn spawn_config_watcher(config_path: PathBuf, handler: Arc<Mutex<InputHandle
                 }
             };
 
-            let theme = match build_popup_theme(&resolved_theme) {
+            let theme = match build_popup_theme(&resolved_theme, config.popup.borders) {
                 Ok(t) => t,
                 Err(e) => {
                     tracing::warn!("config reload failed (theme styles): {e}");
@@ -137,7 +137,7 @@ pub fn spawn_config_watcher(config_path: PathBuf, handler: Arc<Mutex<InputHandle
 }
 
 /// Build a `PopupTheme` from a resolved `ThemeConfig`, parsing each style string.
-fn build_popup_theme(resolved: &gc_config::ThemeConfig) -> Result<PopupTheme> {
+fn build_popup_theme(resolved: &gc_config::ThemeConfig, borders: bool) -> Result<PopupTheme> {
     Ok(PopupTheme {
         selected_on: parse_style(&resolved.selected)
             .map_err(|e| anyhow::anyhow!("invalid theme.selected: {e}"))?,
@@ -151,6 +151,7 @@ fn build_popup_theme(resolved: &gc_config::ThemeConfig) -> Result<PopupTheme> {
             .map_err(|e| anyhow::anyhow!("invalid theme.scrollbar: {e}"))?,
         border_on: parse_style(&resolved.border)
             .map_err(|e| anyhow::anyhow!("invalid theme.border: {e}"))?,
+        borders,
     })
 }
 
@@ -168,7 +169,8 @@ mod tests {
             scrollbar: "dim".into(),
             ..Default::default()
         };
-        let result = build_popup_theme(&theme_config);
+        let result = build_popup_theme(&theme_config, true);
         assert!(result.is_ok());
+        assert!(result.unwrap().borders);
     }
 }

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -86,6 +86,10 @@ pub fn parse_key_name(name: &str) -> anyhow::Result<KeyEvent> {
                         }
                     }
                 }
+                anyhow::bail!(
+                    "ctrl+ must be followed by a single letter (a-z), got: {:?}",
+                    c
+                );
             }
             anyhow::bail!("unknown key name: {:?}", other)
         }
@@ -717,10 +721,10 @@ pub fn key_to_bytes(key: &KeyEvent) -> Vec<u8> {
         KeyEvent::CtrlSlash => vec![0x1F],
         KeyEvent::Backspace => vec![0x7F],
         KeyEvent::Ctrl(c) => {
-            debug_assert!(
-                c.is_ascii_lowercase(),
-                "Ctrl(char) must contain lowercase ASCII"
-            );
+            if !c.is_ascii_lowercase() {
+                tracing::error!(char = ?c, "Ctrl(char) contains non-lowercase ASCII — skipping");
+                return Vec::new();
+            }
             vec![*c as u8 - 0x60]
         }
         KeyEvent::Printable(c) => vec![*c as u8],
@@ -1104,12 +1108,30 @@ mod tests {
         assert!(parse_key_name("ctrl+z").is_err());
         assert!(parse_key_name("ctrl+s").is_err());
         assert!(parse_key_name("ctrl+q").is_err());
+        // Case-insensitive: uppercase input hits same deny-list
+        assert!(parse_key_name("CTRL+C").is_err());
+        assert!(parse_key_name("Ctrl+Z").is_err());
     }
 
     #[test]
     fn test_parse_key_name_rejects_aliased_keys() {
         assert!(parse_key_name("ctrl+i").is_err());
         assert!(parse_key_name("ctrl+m").is_err());
+        assert!(parse_key_name("CTRL+I").is_err());
+    }
+
+    #[test]
+    fn test_parse_key_name_ctrl_multi_char_error() {
+        let err = parse_key_name("ctrl+ab").unwrap_err();
+        assert!(
+            err.to_string().contains("single letter"),
+            "should mention 'single letter': {err}"
+        );
+        let err = parse_key_name("ctrl+1").unwrap_err();
+        assert!(
+            err.to_string().contains("single letter"),
+            "should mention 'single letter' for digits: {err}"
+        );
     }
 
     // --- Keybindings tests ---

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -72,8 +72,19 @@ pub fn parse_key_name(name: &str) -> anyhow::Result<KeyEvent> {
         "arrow_right" => Ok(KeyEvent::ArrowRight),
         other => {
             if let Some(c) = other.strip_prefix("ctrl+") {
-                if c.len() == 1 && c.chars().next().unwrap().is_ascii_lowercase() {
-                    return Ok(KeyEvent::Ctrl(c.chars().next().unwrap()));
+                if let Some(ch) = c.chars().next() {
+                    if c.len() == 1 && ch.is_ascii_lowercase() {
+                        match ch {
+                            'c' => anyhow::bail!("ctrl+c is reserved for SIGINT — cannot be used as a keybinding"),
+                            'd' => anyhow::bail!("ctrl+d is reserved for EOF — cannot be used as a keybinding"),
+                            'z' => anyhow::bail!("ctrl+z is reserved for SIGTSTP — cannot be used as a keybinding"),
+                            's' => anyhow::bail!("ctrl+s is reserved for flow control (XOFF) — cannot be used as a keybinding"),
+                            'q' => anyhow::bail!("ctrl+q is reserved for flow control (XON) — cannot be used as a keybinding"),
+                            'i' => anyhow::bail!("ctrl+i produces the same byte as Tab (0x09) — use 'tab' instead"),
+                            'm' => anyhow::bail!("ctrl+m produces the same byte as Enter (0x0D) — use 'enter' instead"),
+                            _ => return Ok(KeyEvent::Ctrl(ch)),
+                        }
+                    }
                 }
             }
             anyhow::bail!("unknown key name: {:?}", other)
@@ -705,7 +716,13 @@ pub fn key_to_bytes(key: &KeyEvent) -> Vec<u8> {
         KeyEvent::CtrlSpace => vec![0x00],
         KeyEvent::CtrlSlash => vec![0x1F],
         KeyEvent::Backspace => vec![0x7F],
-        KeyEvent::Ctrl(c) => vec![*c as u8 - 0x60],
+        KeyEvent::Ctrl(c) => {
+            debug_assert!(
+                c.is_ascii_lowercase(),
+                "Ctrl(char) must contain lowercase ASCII"
+            );
+            vec![*c as u8 - 0x60]
+        }
         KeyEvent::Printable(c) => vec![*c as u8],
         KeyEvent::CursorPositionReport(_, _) => Vec::new(), // intercepted in proxy
         KeyEvent::Raw(bytes) => bytes.clone(),
@@ -1074,10 +1091,25 @@ mod tests {
     #[test]
     fn test_parse_key_name_ctrl_letters() {
         assert_eq!(parse_key_name("ctrl+a").unwrap(), KeyEvent::Ctrl('a'));
-        assert_eq!(parse_key_name("ctrl+d").unwrap(), KeyEvent::Ctrl('d'));
-        assert_eq!(parse_key_name("ctrl+z").unwrap(), KeyEvent::Ctrl('z'));
-        assert_eq!(parse_key_name("CTRL+C").unwrap(), KeyEvent::Ctrl('c'));
+        assert_eq!(parse_key_name("ctrl+e").unwrap(), KeyEvent::Ctrl('e'));
+        assert_eq!(parse_key_name("ctrl+n").unwrap(), KeyEvent::Ctrl('n'));
+        assert_eq!(parse_key_name("ctrl+p").unwrap(), KeyEvent::Ctrl('p'));
         assert_eq!(parse_key_name("Ctrl+X").unwrap(), KeyEvent::Ctrl('x'));
+    }
+
+    #[test]
+    fn test_parse_key_name_rejects_signal_keys() {
+        assert!(parse_key_name("ctrl+c").is_err());
+        assert!(parse_key_name("ctrl+d").is_err());
+        assert!(parse_key_name("ctrl+z").is_err());
+        assert!(parse_key_name("ctrl+s").is_err());
+        assert!(parse_key_name("ctrl+q").is_err());
+    }
+
+    #[test]
+    fn test_parse_key_name_rejects_aliased_keys() {
+        assert!(parse_key_name("ctrl+i").is_err());
+        assert!(parse_key_name("ctrl+m").is_err());
     }
 
     // --- Keybindings tests ---
@@ -1154,6 +1186,7 @@ mod tests {
             item_text_on: vec![],
             scrollbar_on: vec![0x1B, b'[', b'2', b'm'],
             border_on: vec![0x1B, b'[', b'2', b'm'],
+            borders: true,
         };
 
         handler.update_config(new_theme, Keybindings::default(), &[' ', '/'], 15);

--- a/crates/gc-pty/src/input.rs
+++ b/crates/gc-pty/src/input.rs
@@ -1,7 +1,7 @@
 /// Minimal key event parser for raw terminal stdin bytes.
 ///
-/// Parses known sequences (arrows, Tab, Enter, Escape, Ctrl+Space, Ctrl+/) and
-/// passes through everything else as Raw bytes.
+/// Parses known sequences (arrows, Tab, Enter, Escape, Ctrl+Space, Ctrl+/,
+/// Ctrl+A through Ctrl+Z) and passes through everything else as Raw bytes.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyEvent {

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -135,6 +135,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
         scrollbar_on: parse_style(&resolved_theme.scrollbar)
             .context("invalid theme.scrollbar style")?,
         border_on: parse_style(&resolved_theme.border).context("invalid theme.border style")?,
+        borders: config.popup.borders,
     };
 
     // Initialize suggestion handler with config

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -1176,6 +1176,7 @@ const DEFAULT_CONFIG_TOML: &str = "\
 
 # [popup]
 # max_visible = 10
+# borders = false  # Set to true to enable rounded borders around the popup
 
 # [suggest]
 # max_results = 50

--- a/shell/ghost-complete.bash
+++ b/shell/ghost-complete.bash
@@ -4,6 +4,7 @@
 # Percent-encode a path for use in file:// URIs (RFC 8089).
 _gc_urlencode_path() {
     local input="$1" encoded="" i ch hex
+    local LC_ALL=C  # force byte-level iteration for correct UTF-8 encoding
     for (( i = 0; i < ${#input}; i++ )); do
         ch="${input:$i:1}"
         case "$ch" in

--- a/shell/ghost-complete.bash
+++ b/shell/ghost-complete.bash
@@ -1,12 +1,30 @@
 # Ghost Complete -- Bash integration
 # Source this in .bashrc. Requires Bash 4.4+ for bind -x.
 
+# Percent-encode a path for use in file:// URIs (RFC 8089).
+_gc_urlencode_path() {
+    local input="$1" encoded="" i ch hex
+    for (( i = 0; i < ${#input}; i++ )); do
+        ch="${input:$i:1}"
+        case "$ch" in
+            [a-zA-Z0-9._~:@!\$\&\'\(\)\*+,\;=/-])
+                encoded+="$ch"
+                ;;
+            *)
+                printf -v hex '%%%02X' "'$ch"
+                encoded+="$hex"
+                ;;
+        esac
+    done
+    printf '%s' "$encoded"
+}
+
 _gc_prompt_command() {
     printf '\e]133;A\a'
     # Check GHOSTTY_RESOURCES_DIR too — TERM_PROGRAM is overwritten inside tmux
     [[ "$TERM_PROGRAM" != "ghostty" && -z "$GHOSTTY_RESOURCES_DIR" ]] && printf '\e]7771;A\a'
     # Report current working directory via OSC 7 for filesystem completions
-    printf '\e]7;file://%s%s\a' "$HOSTNAME" "$PWD"
+    printf '\e]7;file://%s%s\a' "${HOSTNAME:-}" "$(_gc_urlencode_path "$PWD")"
 }
 PROMPT_COMMAND="_gc_prompt_command${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 

--- a/shell/ghost-complete.fish
+++ b/shell/ghost-complete.fish
@@ -1,6 +1,21 @@
 # Ghost Complete -- Fish integration
 # Source this in config.fish.
 
+# Percent-encode a path for file:// URIs (RFC 8089).
+function _gc_urlencode_path
+    set -l path $argv[1]
+    set -l encoded ""
+    for i in (seq (string length -- $path))
+        set -l ch (string sub -s $i -l 1 -- $path)
+        if string match -qr '[a-zA-Z0-9._~:@!\$&\'()*+,;=/-]' -- $ch
+            set encoded "$encoded$ch"
+        else
+            set encoded "$encoded"(printf '%%%02X' "'$ch")
+        end
+    end
+    echo -n $encoded
+end
+
 function _gc_prompt --on-event fish_prompt
     printf '\e]133;A\a'
     # OSC 7771: skip on Ghostty where OSC 133 already handles prompt detection.
@@ -9,7 +24,7 @@ function _gc_prompt --on-event fish_prompt
         printf '\e]7771;A\a'
     end
     # Report current working directory via OSC 7 for filesystem completions
-    printf '\e]7;file://%s%s\a' "$hostname" "$PWD"
+    printf '\e]7;file://%s%s\a' "$hostname" (_gc_urlencode_path "$PWD")
 end
 
 function _gc_preexec --on-event fish_preexec

--- a/shell/ghost-complete.fish
+++ b/shell/ghost-complete.fish
@@ -4,10 +4,11 @@
 # Percent-encode a path for file:// URIs (RFC 8089).
 function _gc_urlencode_path
     set -l path $argv[1]
+    set -lx LC_ALL C  # force byte-level iteration for correct UTF-8 encoding
     set -l encoded ""
     for i in (seq (string length -- $path))
         set -l ch (string sub -s $i -l 1 -- $path)
-        if string match -qr '[a-zA-Z0-9._~:@!\$&\'()*+,;=/-]' -- $ch
+        if string match -qr '^[a-zA-Z0-9._~:@!\$&\'()*+,;=/-]$' -- $ch
             set encoded "$encoded$ch"
         else
             set encoded "$encoded"(printf '%%%02X' "'$ch")

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -11,8 +11,9 @@
 # Encodes everything except unreserved chars and '/'.
 _gc_urlencode_path() {
     local input="$1" encoded="" i ch hex
+    local LC_ALL=C  # force byte-level iteration for correct UTF-8 encoding
     for (( i = 1; i <= ${#input}; i++ )); do
-        ch="${input[i]}"
+        ch="${input[$i]}"
         case "$ch" in
             [a-zA-Z0-9._~:@!\$\&\'\(\)\*+,\;=/-])
                 encoded+="$ch"

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -7,6 +7,25 @@
 # OSC 7771: terminal-agnostic prompt boundary for Ghost Complete
 # OSC 7: current working directory reporting
 
+# Percent-encode a path for use in file:// URIs (RFC 8089).
+# Encodes everything except unreserved chars and '/'.
+_gc_urlencode_path() {
+    local input="$1" encoded="" i ch hex
+    for (( i = 1; i <= ${#input}; i++ )); do
+        ch="${input[i]}"
+        case "$ch" in
+            [a-zA-Z0-9._~:@!\$\&\'\(\)\*+,\;=/-])
+                encoded+="$ch"
+                ;;
+            *)
+                printf -v hex '%%%02X' "'$ch"
+                encoded+="$hex"
+                ;;
+        esac
+    done
+    printf '%s' "$encoded"
+}
+
 _gc_precmd() {
     # Mark: prompt is about to be displayed
     printf '\e]133;A\a'
@@ -27,7 +46,7 @@ preexec_functions+=(_gc_preexec)
 # Report current working directory via OSC 7 on directory change.
 # This enables the proxy to track CWD and provide correct filesystem completions.
 _gc_chpwd() {
-    printf '\e]7;file://%s%s\a' "$HOST" "$PWD"
+    printf '\e]7;file://%s%s\a' "$HOST" "$(_gc_urlencode_path "$PWD")"
 }
 
 chpwd_functions+=(_gc_chpwd)
@@ -35,9 +54,9 @@ chpwd_functions+=(_gc_chpwd)
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd _gc_osc7_precmd
 _gc_osc7_precmd() {
-    printf '\e]7;file://%s%s\a' "$HOST" "$PWD"
+    printf '\e]7;file://%s%s\a' "$HOST" "$(_gc_urlencode_path "$PWD")"
     # Remove self after first run — chpwd hook handles subsequent changes
-    precmd_functions=(${precmd_functions:#_gc_osc7_precmd})
+    add-zsh-hook -d precmd _gc_osc7_precmd
 }
 
 # Report current command buffer to the proxy via custom OSC 7770.


### PR DESCRIPTION
## Summary

Comprehensive hardening pass over PRs #52–#54, fixing safety issues, silent data corruption bugs, and rendering defects found during deep code review.

### Safety (HIGH)
- **Signal key deny-list**: `parse_key_name()` now rejects `ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+s`, `ctrl+q` with clear error messages — prevents users from accidentally losing SIGINT/EOF/SIGTSTP in a PTY proxy
- **Dead key rejection**: `ctrl+i` (Tab alias) and `ctrl+m` (Enter alias) rejected with "use 'tab'/'enter' instead" — these bindings silently never fire
- **`percent_decode()` byte loss**: malformed `%XX` sequences no longer drop consumed bytes; fallback preserves all original characters
- **UTF-8 percent decoding**: decoded bytes collected into `Vec<u8>` then `String::from_utf8` instead of per-byte Latin-1 cast — fixes non-ASCII paths like `/café`

### Shell Scripts (HIGH)
- **RFC 8089 percent-encoding**: all 3 shell scripts (`zsh`, `bash`, `fish`) now URL-encode `$PWD` before embedding in OSC 7 `file://` URI — prevents path corruption when directories contain `%` characters
- **Zsh hook cleanup**: `_gc_osc7_precmd` self-removal uses `add-zsh-hook -d` instead of manual array surgery
- **Bash hostname safety**: `${HOSTNAME:-}` fallback for non-login subshells

### Border Rendering (MEDIUM)
- **Missing bottom border during loading**: `╰───╯` now drawn below the loading indicator row instead of being skipped entirely
- **Phantom row clear**: returned layout height matches actual rendered rows (loading row + bottom border = 2 extra, not 1)
- **Scrollbar/border confusion**: scrollbar track changed from `│` to `┆` for visual distinction from border `│`
- **`popup.borders` config flag**: borders default to `false` (no regression for existing users), opt-in via `[popup] borders = true`

### Code Quality (LOW)
- `saturating_sub` for `content_width - 1` and `min_width - 2` potential underflows
- `debug_assert!` on `Ctrl(char)` lowercase invariant in `key_to_bytes`
- Double `.chars().next().unwrap()` bound to local variable
- Module doc on `input.rs` updated for Ctrl+A–Z
- `extend_from_slice` replaces triple `push()` for border UTF-8 bytes
- `dim_count` test bound tightened from `<= 15` to `<= 12`
- New test for border character presence in rendered output
- Debug-only `eprintln!` when popup suppressed at `screen_rows <= 3`

## Test plan
- [x] `cargo test` — 537 tests pass (up from 529, +8 new)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: verify `ctrl+c` config rejection at startup
- [ ] Manual: verify popup renders correctly with `borders = true`
- [ ] Manual: verify popup renders correctly with `borders = false` (default)
- [ ] Manual: verify `cd` to directory with `%` in name produces correct completions