### PR TITLE
fix: prevent recursive launch and enable per-pane proxy in tmux

### DIFF
--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -99,10 +99,26 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             let version = String::from_utf8_lossy(&output.stdout);
             tracing::info!("tmux version: {}", version.trim());
         }
-        // Set GHOST_COMPLETE_ACTIVE in tmux session env so new panes inherit it
-        let _ = std::process::Command::new("tmux")
+        // Propagate GHOST_COMPLETE_ACTIVE into the tmux session env so future
+        // panes inherit it. init.zsh uses PPID + GHOST_COMPLETE_PANE for its
+        // recursion check (not this variable), but session-level propagation
+        // covers edge cases (respawn-pane, programmatic pane creation) and
+        // lets script generators detect the proxy context.
+        match std::process::Command::new("tmux")
             .args(["setenv", "GHOST_COMPLETE_ACTIVE", "1"])
-            .output();
+            .output()
+        {
+            Ok(output) if !output.status.success() => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                tracing::warn!(
+                    "tmux setenv failed (exit {}): {}",
+                    output.status,
+                    stderr.trim()
+                );
+            }
+            Err(e) => tracing::warn!("failed to run tmux setenv: {}", e),
+            _ => {}
+        }
     }
 
     let SpawnedShell { master, mut child } = spawn_shell(shell, args)?;
@@ -409,6 +425,13 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     merge_handle.abort();
     if let Some(h) = debounce_handle {
         h.abort();
+    }
+
+    // Clean up tmux session env if we set it
+    if std::env::var("TMUX").is_ok() {
+        let _ = std::process::Command::new("tmux")
+            .args(["setenv", "-u", "GHOST_COMPLETE_ACTIVE"])
+            .output();
     }
 
     // Flush unsaved frecency records before exit

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -92,13 +92,17 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
         anyhow::bail!("failed to exec shell: {}", err);
     }
 
-    // Log tmux detection for debugging
+    // Log tmux detection and propagate recursion guard to future panes
     if std::env::var("TMUX").is_ok() {
         tracing::info!("tmux session detected — running inside tmux pane");
         if let Ok(output) = std::process::Command::new("tmux").arg("-V").output() {
             let version = String::from_utf8_lossy(&output.stdout);
             tracing::info!("tmux version: {}", version.trim());
         }
+        // Set GHOST_COMPLETE_ACTIVE in tmux session env so new panes inherit it
+        let _ = std::process::Command::new("tmux")
+            .args(["setenv", "GHOST_COMPLETE_ACTIVE", "1"])
+            .output();
     }
 
     let SpawnedShell { master, mut child } = spawn_shell(shell, args)?;

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -427,12 +427,10 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
         h.abort();
     }
 
-    // Clean up tmux session env if we set it
-    if std::env::var("TMUX").is_ok() {
-        let _ = std::process::Command::new("tmux")
-            .args(["setenv", "-u", "GHOST_COMPLETE_ACTIVE"])
-            .output();
-    }
+    // Note: we do NOT clean up `tmux setenv GHOST_COMPLETE_ACTIVE` on exit.
+    // Multiple panes share the session env, so the first pane to exit would
+    // remove it for all others. Leaving it set is harmless — init.zsh's tmux
+    // branch uses PPID + GHOST_COMPLETE_PANE, not this variable.
 
     // Flush unsaved frecency records before exit
     match handler.lock() {

--- a/crates/gc-pty/src/spawn.rs
+++ b/crates/gc-pty/src/spawn.rs
@@ -24,8 +24,17 @@ pub fn spawn_shell(shell: &str, args: &[String]) -> Result<SpawnedShell> {
     for (key, value) in std::env::vars() {
         cmd.env(key, value);
     }
-    // Ensure recursion guard is always set, even if the parent env lost it
+    // Belt-and-suspenders recursion guard. init.zsh checks this in the
+    // non-tmux path; setting it here covers manual `ghost-complete` invocations
+    // that bypass init.zsh entirely.
     cmd.env("GHOST_COMPLETE_ACTIVE", "1");
+
+    // Pane-local recursion guard for tmux. init.zsh compares this against the
+    // live $TMUX_PANE — matches inside the same pane (blocking subshells),
+    // mismatches in new panes (allowing a fresh proxy).
+    if let Ok(pane) = std::env::var("TMUX_PANE") {
+        cmd.env("GHOST_COMPLETE_PANE", pane);
+    }
 
     let child = slave
         .spawn_command(cmd)

--- a/crates/gc-pty/src/spawn.rs
+++ b/crates/gc-pty/src/spawn.rs
@@ -24,6 +24,8 @@ pub fn spawn_shell(shell: &str, args: &[String]) -> Result<SpawnedShell> {
     for (key, value) in std::env::vars() {
         cmd.env(key, value);
     }
+    // Ensure recursion guard is always set, even if the parent env lost it
+    cmd.env("GHOST_COMPLETE_ACTIVE", "1");
 
     let child = slave
         .spawn_command(cmd)

--- a/crates/gc-pty/src/spawn.rs
+++ b/crates/gc-pty/src/spawn.rs
@@ -32,8 +32,15 @@ pub fn spawn_shell(shell: &str, args: &[String]) -> Result<SpawnedShell> {
     // Pane-local recursion guard for tmux. init.zsh compares this against the
     // live $TMUX_PANE — matches inside the same pane (blocking subshells),
     // mismatches in new panes (allowing a fresh proxy).
-    if let Ok(pane) = std::env::var("TMUX_PANE") {
-        cmd.env("GHOST_COMPLETE_PANE", pane);
+    if std::env::var("TMUX").is_ok() {
+        match std::env::var("TMUX_PANE") {
+            Ok(pane) => {
+                cmd.env("GHOST_COMPLETE_PANE", pane);
+            }
+            Err(_) => tracing::warn!(
+                "TMUX is set but TMUX_PANE is not — subshell recursion guard degraded"
+            ),
+        }
     }
 
     let child = slave

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::Path;
 
 const ZSH_INTEGRATION: &str = include_str!("../../../shell/ghost-complete.zsh");
+const ZSH_INIT: &str = include_str!("../../../shell/init.zsh");
 
 const EMBEDDED_SPECS: &[(&str, &str)] = &[
     ("-.json", include_str!("../../../specs/-.json")),
@@ -1216,47 +1217,14 @@ const SHELL_END: &str = "# <<< ghost-complete shell integration <<<";
 const MANAGED_WARNING: &str =
     "# !! Contents within this block are managed by 'ghost-complete install' !!";
 
-fn init_block() -> String {
+fn init_block(script_path: &Path) -> String {
     format!(
-        r#"{INIT_BEGIN}
-{MANAGED_WARNING}
-if [[ -n "$KITTY_WINDOW_ID" && -z "$GHOST_COMPLETE_ACTIVE" ]]; then
-  if command -v ghost-complete >/dev/null 2>&1; then
-    export GHOST_COMPLETE_ACTIVE=1
-    exec ghost-complete
-  fi
-fi
-if [[ -n "$ALACRITTY_SOCKET" && -z "$GHOST_COMPLETE_ACTIVE" ]]; then
-  if command -v ghost-complete >/dev/null 2>&1; then
-    export GHOST_COMPLETE_ACTIVE=1
-    exec ghost-complete
-  fi
-fi
-case "$TERM_PROGRAM" in
-  ghostty|WezTerm|rio|iTerm.app|Apple_Terminal)
-    if [[ -z "$GHOST_COMPLETE_ACTIVE" ]]; then
-      if command -v ghost-complete >/dev/null 2>&1; then
-        export GHOST_COMPLETE_ACTIVE=1
-        exec ghost-complete
-      fi
-    fi
-    ;;
-esac
-if [[ -n "$TMUX" && -z "$GHOST_COMPLETE_ACTIVE" && \
-   "$(ps -o comm= -p $PPID 2>/dev/null)" != "ghost-complete" ]]; then
-  if [[ -n "$GHOSTTY_RESOURCES_DIR" ]] || \
-     [[ -n "$KITTY_WINDOW_ID" ]] || \
-     [[ -n "$WEZTERM_UNIX_SOCKET" ]] || \
-     [[ -n "$ALACRITTY_SOCKET" ]] || \
-     [[ -n "$ITERM_SESSION_ID" ]] || \
-     [[ "$TERM_PROGRAM" == "rio" ]]; then
-    if command -v ghost-complete >/dev/null 2>&1; then
-      export GHOST_COMPLETE_ACTIVE=1
-      exec ghost-complete
-    fi
-  fi
-fi
-{INIT_END}"#,
+        "{INIT_BEGIN}\n\
+         {MANAGED_WARNING}\n\
+         [[ -f \"{}\" ]] && builtin source \"{}\"\n\
+         {INIT_END}",
+        script_path.display(),
+        script_path.display()
     )
 }
 
@@ -1309,8 +1277,8 @@ fn copy_specs(config_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn print_shell_blocks(script_path: &Path) {
-    let init = init_block();
+fn print_shell_blocks(init_path: &Path, script_path: &Path) {
+    let init = init_block(init_path);
     let shell = shell_integration_block(script_path);
     let indented_init = init.replace('\n', "\n    ");
     let indented_shell = shell.replace('\n', "\n    ");
@@ -1326,11 +1294,13 @@ fn print_shell_blocks(script_path: &Path) {
 }
 
 fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()> {
-    // 1. Write zsh shell integration script
+    // 1. Write zsh shell scripts
     let shell_dir = config_dir.join("shell");
+    let init_path = shell_dir.join("init.zsh");
     let script_path = shell_dir.join("ghost-complete.zsh");
 
     if dry_run {
+        println!("  Would write init script to {}", init_path.display());
         println!("  Would write zsh integration to {}", script_path.display());
         println!(
             "  Would install {} completion specs to {}",
@@ -1345,12 +1315,16 @@ fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()>
         }
         println!("  Would update {}\n", zshrc_path.display());
         println!("  \x1b[36m\u{2139}\x1b[0m  The following would be added to your shell config:\n");
-        print_shell_blocks(&script_path);
+        print_shell_blocks(&init_path, &script_path);
         return Ok(());
     }
 
     fs::create_dir_all(&shell_dir)
         .with_context(|| format!("failed to create {}", shell_dir.display()))?;
+
+    fs::write(&init_path, ZSH_INIT)
+        .with_context(|| format!("failed to write {}", init_path.display()))?;
+    println!("  Wrote init script to {}", init_path.display());
 
     fs::write(&script_path, ZSH_INTEGRATION)
         .with_context(|| format!("failed to write {}", script_path.display()))?;
@@ -1392,7 +1366,7 @@ fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()>
     // 5. Prepend init block, append shell integration block
     let content = content.trim().to_string();
     let mut new_zshrc = String::new();
-    new_zshrc.push_str(&init_block());
+    new_zshrc.push_str(&init_block(&init_path));
     new_zshrc.push('\n');
     if !content.is_empty() {
         new_zshrc.push_str(&content);
@@ -1413,7 +1387,7 @@ fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()>
                 "\n  \x1b[33m\u{26a0}  Could not write to {} (permission denied)\x1b[0m\n",
                 zshrc_path.display()
             );
-            print_shell_blocks(&script_path);
+            print_shell_blocks(&init_path, &script_path);
             println!(
                 "  \x1b[32m\u{2713}\x1b[0m  Installation complete (manual shell configuration required)."
             );
@@ -1454,6 +1428,7 @@ fn uninstall_from(zshrc_path: &Path, config_dir: &Path) -> Result<()> {
 
     // 2. Remove shell integration scripts
     for name in &[
+        "init.zsh",
         "ghost-complete.zsh",
         "ghost-complete.bash",
         "ghost-complete.fish",
@@ -1523,31 +1498,40 @@ mod tests {
 
     #[test]
     fn test_init_block_content() {
-        let block = init_block();
+        let path = Path::new("/some/path/init.zsh");
+        let block = init_block(path);
         assert!(block.contains(INIT_BEGIN));
         assert!(block.contains(INIT_END));
         assert!(block.contains(MANAGED_WARNING));
-        assert!(block.contains("exec ghost-complete"));
-        assert!(block.contains("command -v ghost-complete"));
-        // Kitty detection (uses KITTY_WINDOW_ID because TERM_PROGRAM is xterm-kitty)
-        assert!(block.contains("$KITTY_WINDOW_ID"));
-        // Allowlist: case statement with all supported terminals
-        assert!(block.contains("case \"$TERM_PROGRAM\""));
-        assert!(block.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal)"));
-        // Alacritty detection (uses ALACRITTY_SOCKET)
-        assert!(block.contains("$ALACRITTY_SOCKET"));
-        assert!(block.contains("GHOST_COMPLETE_ACTIVE"));
-        // tmux detection: TMUX + PPID guard
-        assert!(block.contains("$TMUX"));
-        assert!(block.contains("$PPID"));
-        assert!(block.contains("ghost-complete\""));
-        assert!(block.contains("\"$TERM_PROGRAM\" == \"rio\""));
-        // tmux env var detection for all supported terminals
-        assert!(block.contains("$GHOSTTY_RESOURCES_DIR"));
-        assert!(block.contains("$KITTY_WINDOW_ID"));
-        assert!(block.contains("$WEZTERM_UNIX_SOCKET"));
-        assert!(block.contains("$ALACRITTY_SOCKET"));
-        assert!(block.contains("$ITERM_SESSION_ID"));
+        // Thin source line pointing to external script
+        assert!(block.contains("builtin source \"/some/path/init.zsh\""));
+        assert!(block.contains("-f \"/some/path/init.zsh\""));
+    }
+
+    #[test]
+    fn test_init_script_content() {
+        // Verify the external init script has all the required detection logic
+        let script = ZSH_INIT;
+        assert!(script.contains("__ghost_complete_init()"));
+        assert!(script.contains("unset -f __ghost_complete_init"));
+        assert!(script.contains("exec ghost-complete"));
+        assert!(script.contains("command -v ghost-complete"));
+        // Guard: env var (non-tmux path)
+        assert!(script.contains("GHOST_COMPLETE_ACTIVE"));
+        // Guard: PPID check (tmux path)
+        assert!(script.contains("$PPID"));
+        assert!(script.contains("ghost-complete\""));
+        // tmux branch: detect outer terminal via env vars
+        assert!(script.contains("$TMUX"));
+        assert!(script.contains("$GHOSTTY_RESOURCES_DIR"));
+        assert!(script.contains("$KITTY_WINDOW_ID"));
+        assert!(script.contains("$WEZTERM_UNIX_SOCKET"));
+        assert!(script.contains("$ALACRITTY_SOCKET"));
+        assert!(script.contains("$ITERM_SESSION_ID"));
+        assert!(script.contains("\"$TERM_PROGRAM\" == \"rio\""));
+        // Direct terminal detection
+        assert!(script.contains("case \"$TERM_PROGRAM\""));
+        assert!(script.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal)"));
     }
 
     #[test]
@@ -1574,25 +1558,33 @@ mod tests {
         assert!(content.contains(INIT_END));
         assert!(content.contains(SHELL_BEGIN));
         assert!(content.contains(SHELL_END));
-        assert!(content.contains("GHOST_COMPLETE_ACTIVE"));
+        // Init script should be written and sourced
+        let init_script = config.join("shell/init.zsh");
+        assert!(init_script.exists());
+        let init_content = fs::read_to_string(&init_script).unwrap();
+        assert_eq!(init_content, ZSH_INIT);
+        let expected_init_source = format!("builtin source \"{}\"", init_script.display());
+        assert!(
+            content.contains(&expected_init_source),
+            "init source path mismatch: .zshrc does not contain '{}'",
+            expected_init_source
+        );
 
-        // Zsh shell script should be written
+        // Zsh shell integration script should be written and sourced
         let script = config.join("shell/ghost-complete.zsh");
         assert!(script.exists());
         let script_content = fs::read_to_string(&script).unwrap();
         assert_eq!(script_content, ZSH_INTEGRATION);
-
-        // Bash/fish are not deployed
-        assert!(!config.join("shell/ghost-complete.bash").exists());
-        assert!(!config.join("shell/ghost-complete.fish").exists());
-
-        // Source path in .zshrc must match actual script location
         let expected_source = format!("source \"{}\"", script.display());
         assert!(
             content.contains(&expected_source),
             "source path mismatch: .zshrc does not contain '{}'",
             expected_source
         );
+
+        // Bash/fish are not deployed
+        assert!(!config.join("shell/ghost-complete.bash").exists());
+        assert!(!config.join("shell/ghost-complete.fish").exists());
     }
 
     #[test]
@@ -1672,7 +1664,8 @@ mod tests {
         assert!(!content.contains(SHELL_BEGIN));
         assert!(content.contains("export FOO=bar"));
 
-        // Zsh script should be removed
+        // Shell scripts should be removed
+        assert!(!config.join("shell/init.zsh").exists());
         assert!(!config.join("shell/ghost-complete.zsh").exists());
     }
 
@@ -1772,6 +1765,7 @@ mod tests {
         assert!(result.is_ok());
 
         // File deployments should still have happened
+        assert!(config.join("shell/init.zsh").exists());
         assert!(config.join("shell/ghost-complete.zsh").exists());
         assert!(config.join("specs").exists());
     }

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -1218,13 +1218,17 @@ const MANAGED_WARNING: &str =
     "# !! Contents within this block are managed by 'ghost-complete install' !!";
 
 fn init_block(script_path: &Path) -> String {
+    let path = script_path.display();
     format!(
         "{INIT_BEGIN}\n\
          {MANAGED_WARNING}\n\
-         [[ -f \"{}\" ]] && builtin source \"{}\"\n\
-         {INIT_END}",
-        script_path.display(),
-        script_path.display()
+         if [[ -f \"{path}\" ]]; then\n  \
+         builtin source \"{path}\"\n\
+         else\n  \
+         echo \"ghost-complete: init script missing: {path}\" >&2\n  \
+         echo \"ghost-complete: run 'ghost-complete install' to restore it\" >&2\n\
+         fi\n\
+         {INIT_END}"
     )
 }
 
@@ -1503,9 +1507,12 @@ mod tests {
         assert!(block.contains(INIT_BEGIN));
         assert!(block.contains(INIT_END));
         assert!(block.contains(MANAGED_WARNING));
-        // Thin source line pointing to external script
+        // Source line pointing to external script
         assert!(block.contains("builtin source \"/some/path/init.zsh\""));
         assert!(block.contains("-f \"/some/path/init.zsh\""));
+        // Missing-file warning (else branch)
+        assert!(block.contains("ghost-complete: init script missing:"));
+        assert!(block.contains("ghost-complete install"));
     }
 
     #[test]
@@ -1516,22 +1523,53 @@ mod tests {
         assert!(script.contains("unset -f __ghost_complete_init"));
         assert!(script.contains("exec ghost-complete"));
         assert!(script.contains("command -v ghost-complete"));
-        // Guard: env var (non-tmux path)
-        assert!(script.contains("GHOST_COMPLETE_ACTIVE"));
-        // Guard: PPID check (tmux path)
-        assert!(script.contains("$PPID"));
-        assert!(script.contains("ghost-complete\""));
+
+        // --- Structural validation: guards must be in the correct branch ---
+
+        // Split on the else branch to get tmux vs non-tmux sections
+        let tmux_marker = "if [[ -n \"$TMUX\" ]]; then";
+        assert!(script.contains(tmux_marker), "missing tmux branch");
+        let tmux_start = script.find(tmux_marker).unwrap();
+        let else_marker = script[tmux_start..].find("\n  else\n").unwrap();
+        let tmux_branch = &script[tmux_start..tmux_start + else_marker];
+        let non_tmux_branch = &script[tmux_start + else_marker..];
+
+        // tmux branch: PPID check (quoted) + GHOST_COMPLETE_PANE check
+        assert!(
+            tmux_branch.contains("ps -o comm= -p \"$PPID\""),
+            "tmux branch must have quoted PPID check"
+        );
+        assert!(
+            tmux_branch.contains("GHOST_COMPLETE_PANE"),
+            "tmux branch must have GHOST_COMPLETE_PANE subshell guard"
+        );
+        assert!(
+            tmux_branch.contains("$TMUX_PANE"),
+            "tmux branch must compare GHOST_COMPLETE_PANE against TMUX_PANE"
+        );
+        // tmux branch must NOT use GHOST_COMPLETE_ACTIVE as a guard
+        assert!(
+            !tmux_branch.contains("[[ -n \"$GHOST_COMPLETE_ACTIVE\" ]] && return"),
+            "tmux branch must not use GHOST_COMPLETE_ACTIVE as recursion guard"
+        );
+
+        // non-tmux branch: GHOST_COMPLETE_ACTIVE guard
+        assert!(
+            non_tmux_branch.contains("GHOST_COMPLETE_ACTIVE"),
+            "non-tmux branch must use GHOST_COMPLETE_ACTIVE guard"
+        );
+
         // tmux branch: detect outer terminal via env vars
-        assert!(script.contains("$TMUX"));
-        assert!(script.contains("$GHOSTTY_RESOURCES_DIR"));
-        assert!(script.contains("$KITTY_WINDOW_ID"));
-        assert!(script.contains("$WEZTERM_UNIX_SOCKET"));
-        assert!(script.contains("$ALACRITTY_SOCKET"));
-        assert!(script.contains("$ITERM_SESSION_ID"));
-        assert!(script.contains("\"$TERM_PROGRAM\" == \"rio\""));
-        // Direct terminal detection
-        assert!(script.contains("case \"$TERM_PROGRAM\""));
-        assert!(script.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal)"));
+        assert!(tmux_branch.contains("$GHOSTTY_RESOURCES_DIR"));
+        assert!(tmux_branch.contains("$KITTY_WINDOW_ID"));
+        assert!(tmux_branch.contains("$WEZTERM_UNIX_SOCKET"));
+        assert!(tmux_branch.contains("$ALACRITTY_SOCKET"));
+        assert!(tmux_branch.contains("$ITERM_SESSION_ID"));
+        assert!(tmux_branch.contains("\"$TERM_PROGRAM\" == \"rio\""));
+
+        // Direct terminal detection (non-tmux)
+        assert!(non_tmux_branch.contains("case \"$TERM_PROGRAM\""));
+        assert!(non_tmux_branch.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal)"));
     }
 
     #[test]

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -2,11 +2,21 @@
 # Detects the terminal emulator and exec's ghost-complete as a PTY proxy.
 __ghost_complete_init() {
   if [[ -n "$TMUX" ]]; then
-    # Inside tmux: launch per-pane. Skip GHOST_COMPLETE_ACTIVE (leaks from
-    # outer shell and would block the per-pane proxy we actually want).
-    # PPID check prevents recursion: ghost-complete spawns the inner shell,
-    # so the inner shell's PPID is ghost-complete.
-    [[ "$(ps -o comm= -p $PPID 2>/dev/null)" == "ghost-complete" ]] && return
+    # Inside tmux: two guards prevent stacking proxies.
+    #
+    # 1) PPID check — catches the direct child shell. Works because
+    #    `exec ghost-complete` replaces the shell process, so the spawned
+    #    inner shell's PPID is the ghost-complete binary itself.
+    # 2) GHOST_COMPLETE_PANE — catches subshells (zsh/bash typed at the
+    #    prompt). spawn.rs sets GHOST_COMPLETE_PANE=$TMUX_PANE in the child
+    #    env; subshells inherit it. A new tmux pane gets a fresh env without
+    #    this variable, so it correctly launches a new proxy.
+    #
+    # We cannot use GHOST_COMPLETE_ACTIVE here because it is always present
+    # in tmux — set by proxy.rs (tmux setenv) for future-pane propagation,
+    # and inherited from the outer terminal shell that launched tmux.
+    [[ "$(ps -o comm= -p "$PPID" 2>/dev/null)" == "ghost-complete" ]] && return
+    [[ -n "$GHOST_COMPLETE_PANE" && "$GHOST_COMPLETE_PANE" == "$TMUX_PANE" ]] && return
     if [[ -n "$GHOSTTY_RESOURCES_DIR" ]] || \
        [[ -n "$KITTY_WINDOW_ID" ]] || \
        [[ -n "$WEZTERM_UNIX_SOCKET" ]] || \
@@ -19,7 +29,8 @@ __ghost_complete_init() {
       fi
     fi
   else
-    # Outside tmux: env var guard is reliable (no multiplexer to strip it)
+    # Outside tmux: GHOST_COMPLETE_ACTIVE is a reliable recursion guard
+    # because no multiplexer re-injects it into unrelated shell sessions.
     [[ -n "$GHOST_COMPLETE_ACTIVE" ]] && return
     local supported=0
     if [[ -n "$KITTY_WINDOW_ID" ]] || [[ -n "$ALACRITTY_SOCKET" ]]; then

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -1,0 +1,39 @@
+# Ghost Complete — terminal init (sourced near the top of .zshrc)
+# Detects the terminal emulator and exec's ghost-complete as a PTY proxy.
+__ghost_complete_init() {
+  if [[ -n "$TMUX" ]]; then
+    # Inside tmux: launch per-pane. Skip GHOST_COMPLETE_ACTIVE (leaks from
+    # outer shell and would block the per-pane proxy we actually want).
+    # PPID check prevents recursion: ghost-complete spawns the inner shell,
+    # so the inner shell's PPID is ghost-complete.
+    [[ "$(ps -o comm= -p $PPID 2>/dev/null)" == "ghost-complete" ]] && return
+    if [[ -n "$GHOSTTY_RESOURCES_DIR" ]] || \
+       [[ -n "$KITTY_WINDOW_ID" ]] || \
+       [[ -n "$WEZTERM_UNIX_SOCKET" ]] || \
+       [[ -n "$ALACRITTY_SOCKET" ]] || \
+       [[ -n "$ITERM_SESSION_ID" ]] || \
+       [[ "$TERM_PROGRAM" == "rio" ]]; then
+      if command -v ghost-complete >/dev/null 2>&1; then
+        export GHOST_COMPLETE_ACTIVE=1
+        exec ghost-complete
+      fi
+    fi
+  else
+    # Outside tmux: env var guard is reliable (no multiplexer to strip it)
+    [[ -n "$GHOST_COMPLETE_ACTIVE" ]] && return
+    local supported=0
+    if [[ -n "$KITTY_WINDOW_ID" ]] || [[ -n "$ALACRITTY_SOCKET" ]]; then
+      supported=1
+    else
+      case "$TERM_PROGRAM" in
+        ghostty|WezTerm|rio|iTerm.app|Apple_Terminal) supported=1 ;;
+      esac
+    fi
+    if [[ $supported -eq 1 ]] && command -v ghost-complete >/dev/null 2>&1; then
+      export GHOST_COMPLETE_ACTIVE=1
+      exec ghost-complete
+    fi
+  fi
+}
+__ghost_complete_init
+unset -f __ghost_complete_init


### PR DESCRIPTION
## Summary

- **Fixed tmux recursive launch bug** — `GHOST_COMPLETE_ACTIVE` leaked from the outer Ghostty shell into tmux, blocking per-pane proxy launch. The outer proxy (wrapping tmux) can't render popups because tmux owns the terminal coordinate space, leaving users with zero completions inside tmux.
- **Restructured init block with dual-path guards** — tmux panes use PPID check (env var is unreliable through tmux); direct terminal uses env var guard (fast, reliable). Each tmux pane now gets its own ghost-complete proxy.
- **Extracted init logic from .zshrc** — moved the 35-line init function into `~/.config/ghost-complete/shell/init.zsh`, sourced via a single line in .zshrc. Same clean pattern as Kiro CLI.
- **Belt-and-suspenders on Rust side** — `spawn.rs` explicitly sets `GHOST_COMPLETE_ACTIVE=1` on child shell; `proxy.rs` calls `tmux setenv` to propagate guard to future panes.

## Test plan

- [x] `cargo test` — all 34 tests pass
- [x] `cargo clippy --all-targets` — clean
- [ ] Manual: Ghostty direct (no tmux) — ghost-complete launches once, popups work
- [ ] Manual: Ghostty → tmux — per-pane ghost-complete, popups render correctly
- [ ] Manual: Ghostty → tmux → new pane — no recursion, popups work
- [ ] Manual: `ghost-complete install` — .zshrc has thin source line, init.zsh deployed
- [ ] Manual: `ghost-complete uninstall` — init.zsh cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)