### PR TITLE
fix: forward CPR responses to PTY for programs like atuin

### DIFF
--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -21,6 +21,7 @@ pub struct TerminalState {
     cwd_dirty: bool,
     cursor_sync_requested: bool,
     cpr_synced: bool,
+    cpr_pending: u8,
 }
 
 impl TerminalState {
@@ -40,6 +41,7 @@ impl TerminalState {
             cwd_dirty: false,
             cursor_sync_requested: false,
             cpr_synced: false,
+            cpr_pending: 0,
         }
     }
 
@@ -123,6 +125,25 @@ impl TerminalState {
         let synced = self.cpr_synced;
         self.cpr_synced = false;
         synced
+    }
+
+    /// Increment the pending CPR counter. Called when ghost-complete sends
+    /// its own `CSI 6n` request so we know to consume the matching response
+    /// rather than forwarding it to the PTY.
+    pub fn increment_cpr_pending(&mut self) {
+        self.cpr_pending = self.cpr_pending.saturating_add(1);
+    }
+
+    /// Try to claim a pending CPR response. Returns `true` if ghost-complete
+    /// has an outstanding CPR request (response should be consumed), `false`
+    /// if the response belongs to a program inside the PTY (should be forwarded).
+    pub fn claim_cpr_response(&mut self) -> bool {
+        if self.cpr_pending > 0 {
+            self.cpr_pending -= 1;
+            true
+        } else {
+            false
+        }
     }
 
     /// Override the command buffer with a predicted value (e.g., after Tab

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -237,13 +237,27 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
 
             let keys = parse_keys(&buf[..n]);
             for key in &keys {
-                // Intercept CPR (Cursor Position Report) responses —
-                // update parser with real cursor position, don't forward
-                // to the shell PTY.
+                // CPR (Cursor Position Report) responses arrive here
+                // from the real terminal. If we sent the request, consume
+                // it for cursor sync. Otherwise forward it through the
+                // PTY so programs like atuin/crossterm receive it.
                 if let crate::input::KeyEvent::CursorPositionReport(row, col) = key {
                     let mut p = parser_for_stdin.lock().unwrap();
-                    tracing::debug!(row, col, "CPR response — syncing cursor position");
-                    p.state_mut().set_cursor_from_report(*row, *col);
+                    if p.state_mut().claim_cpr_response() {
+                        tracing::debug!(row, col, "CPR response — syncing cursor position (ours)");
+                        p.state_mut().set_cursor_from_report(*row, *col);
+                        continue;
+                    }
+                    tracing::debug!(row, col, "CPR response — forwarding to PTY (not ours)");
+                    drop(p);
+                    // Re-encode as CSI row;col R and forward to PTY
+                    let cpr = format!("\x1b[{row};{col}R");
+                    if pty_writer.write_all(cpr.as_bytes()).is_err() {
+                        return;
+                    }
+                    if pty_writer.flush().is_err() {
+                        return;
+                    }
                     continue;
                 }
 
@@ -310,6 +324,12 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 if needs_cpr {
                     tracing::debug!("sending CPR request (CSI 6n)");
                     let _ = stdout.write_all(b"\x1b[6n");
+                    // Mark this as our own request so Task A knows to
+                    // consume the response instead of forwarding it to
+                    // the PTY (where programs like atuin may be waiting
+                    // for their own CPR responses).
+                    let mut p = parser_for_stdout.lock().unwrap();
+                    p.state_mut().increment_cpr_pending();
                 }
                 if stdout.flush().is_err() {
                     break;


### PR DESCRIPTION
## Summary

- Ghost-complete's PTY proxy was unconditionally consuming all CPR (Cursor Position Report / `CSI 6n`) responses from the terminal, even when they were requested by programs running inside the PTY (e.g., atuin via crossterm)
- This caused crossterm to timeout after 2 seconds waiting for a response that would never arrive, producing: `Error: The cursor position could not be read within a normal duration`
- Added a `cpr_pending` counter to distinguish ghost-complete's own CPR requests from those originating inside the PTY, forwarding unmatched responses through to the shell

## How it works

1. **Task B** (PTY → stdout): When ghost-complete sends its own `\x1b[6n`, it increments `cpr_pending`
2. **Task A** (stdin → PTY): When a CPR response arrives, if `cpr_pending > 0`, consume it for cursor sync; otherwise re-encode and forward it to the PTY

## Test plan

- [ ] Open ghost-complete session, verify inline completions still work
- [ ] Press `Ctrl+R` to trigger atuin interactive search — should open without cursor position error
- [ ] Run any program that calls `crossterm::cursor::position()` inside the proxy — should work normally
- [ ] Verify CPR sync still works (prompt boundary detection, scroll deficit reset)

Fixes compatibility with [atuin](https://github.com/atuinsh/atuin) and any program using crossterm's `cursor::position()` inside the PTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)