### PR TITLE
feat: Add Linux support and bash auto-trigger

### DIFF
--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -3,13 +3,23 @@ use std::fmt;
 /// Supported terminal emulators.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Terminal {
+    // Cross-platform terminals
     Ghostty,
     Kitty,
     WezTerm,
     Alacritty,
     Rio,
+    // macOS-only terminals
     ITerm2,
     TerminalApp,
+    // Linux terminals
+    GnomeTerminal,
+    Konsole,
+    Tilix,
+    Foot,
+    Terminator,
+    Xterm,
+    // Fallback
     Unknown(String),
 }
 
@@ -22,13 +32,22 @@ impl Terminal {
     /// Display names of all supported terminals (for diagnostics).
     pub fn supported_terminals() -> &'static [&'static str] {
         &[
+            // Cross-platform
             "Ghostty",
             "Kitty",
             "WezTerm",
             "Alacritty",
             "Rio",
+            // macOS
             "iTerm2",
             "Terminal.app",
+            // Linux
+            "GNOME Terminal",
+            "Konsole",
+            "Tilix",
+            "Foot",
+            "Terminator",
+            "xterm",
         ]
     }
 }
@@ -36,13 +55,23 @@ impl Terminal {
 impl fmt::Display for Terminal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            // Cross-platform
             Terminal::Ghostty => write!(f, "Ghostty"),
             Terminal::Kitty => write!(f, "Kitty"),
             Terminal::WezTerm => write!(f, "WezTerm"),
             Terminal::Alacritty => write!(f, "Alacritty"),
             Terminal::Rio => write!(f, "Rio"),
+            // macOS
             Terminal::ITerm2 => write!(f, "iTerm2"),
             Terminal::TerminalApp => write!(f, "Terminal.app"),
+            // Linux
+            Terminal::GnomeTerminal => write!(f, "GNOME Terminal"),
+            Terminal::Konsole => write!(f, "Konsole"),
+            Terminal::Tilix => write!(f, "Tilix"),
+            Terminal::Foot => write!(f, "Foot"),
+            Terminal::Terminator => write!(f, "Terminator"),
+            Terminal::Xterm => write!(f, "xterm"),
+            // Fallback
             Terminal::Unknown(name) => write!(f, "{name}"),
         }
     }
@@ -128,11 +157,22 @@ impl TerminalProfile {
     pub fn detect() -> Self {
         let term_program = std::env::var("TERM_PROGRAM").unwrap_or_default();
         let in_tmux = std::env::var("TMUX").is_ok();
+
+        // Cross-platform terminal env vars
         let has_ghostty_res = std::env::var("GHOSTTY_RESOURCES_DIR").is_ok();
         let has_iterm_session = std::env::var("ITERM_SESSION_ID").is_ok();
         let has_kitty_window_id = std::env::var("KITTY_WINDOW_ID").is_ok();
         let has_wezterm_socket = std::env::var("WEZTERM_UNIX_SOCKET").is_ok();
         let has_alacritty_socket = std::env::var("ALACRITTY_SOCKET").is_ok();
+
+        // Linux-specific terminal env vars
+        let has_vte_version = std::env::var("VTE_VERSION").is_ok();
+        let has_gnome_terminal = std::env::var("GNOME_TERMINAL_SCREEN").is_ok();
+        let has_konsole = std::env::var("KONSOLE_VERSION").is_ok();
+        let has_tilix = std::env::var("TILIX_ID").is_ok();
+        let has_foot = std::env::var("FOOT_SERVER_SOCKET").is_ok();
+        let has_terminator = std::env::var("TERMINATOR_UUID").is_ok();
+        let has_xterm = std::env::var("XTERM_VERSION").is_ok();
 
         Self::detect_from_env(
             &term_program,
@@ -142,6 +182,13 @@ impl TerminalProfile {
             has_kitty_window_id,
             has_wezterm_socket,
             has_alacritty_socket,
+            has_vte_version,
+            has_gnome_terminal,
+            has_konsole,
+            has_tilix,
+            has_foot,
+            has_terminator,
+            has_xterm,
         )
     }
 
@@ -154,20 +201,55 @@ impl TerminalProfile {
         has_kitty_window_id: bool,
         has_wezterm_socket: bool,
         has_alacritty_socket: bool,
+        // Linux env vars
+        has_vte_version: bool,
+        has_gnome_terminal: bool,
+        has_konsole: bool,
+        has_tilix: bool,
+        has_foot: bool,
+        has_terminator: bool,
+        has_xterm: bool,
     ) -> Self {
         // Direct terminal detection (not inside tmux)
         if !in_tmux {
-            // Kitty reports TERM_PROGRAM=xterm-kitty, so use KITTY_WINDOW_ID instead.
+            // Cross-platform terminals (check specific env vars first)
             if has_kitty_window_id {
                 return Self::new(Terminal::Kitty, false);
             }
             if has_wezterm_socket {
                 return Self::new(Terminal::WezTerm, false);
             }
-            // Alacritty doesn't set TERM_PROGRAM — detect via ALACRITTY_SOCKET.
             if has_alacritty_socket {
                 return Self::new(Terminal::Alacritty, false);
             }
+            if has_ghostty_res {
+                return Self::new(Terminal::Ghostty, false);
+            }
+
+            // Linux-specific terminals
+            if has_konsole {
+                return Self::new(Terminal::Konsole, false);
+            }
+            if has_tilix {
+                return Self::new(Terminal::Tilix, false);
+            }
+            if has_foot {
+                return Self::new(Terminal::Foot, false);
+            }
+            if has_terminator {
+                return Self::new(Terminal::Terminator, false);
+            }
+            if has_gnome_terminal {
+                return Self::new(Terminal::GnomeTerminal, false);
+            }
+            // VTE-based terminal without specific identification
+            if has_vte_version && term_program.is_empty() {
+                return Self::new(Terminal::GnomeTerminal, false);
+            }
+            if has_xterm {
+                return Self::new(Terminal::Xterm, false);
+            }
+
             return Self::from_term_program(term_program, false);
         }
 
@@ -188,6 +270,22 @@ impl TerminalProfile {
         if has_iterm_session {
             return Self::new(Terminal::ITerm2, true);
         }
+        // Linux terminals in tmux
+        if has_konsole {
+            return Self::new(Terminal::Konsole, true);
+        }
+        if has_tilix {
+            return Self::new(Terminal::Tilix, true);
+        }
+        if has_foot {
+            return Self::new(Terminal::Foot, true);
+        }
+        if has_terminator {
+            return Self::new(Terminal::Terminator, true);
+        }
+        if has_gnome_terminal || has_vte_version {
+            return Self::new(Terminal::GnomeTerminal, true);
+        }
 
         // Fallback: try TERM_PROGRAM (some terminals set it even in tmux)
         Self::from_term_program(term_program, true)
@@ -195,12 +293,22 @@ impl TerminalProfile {
 
     fn from_term_program(term_program: &str, in_tmux: bool) -> Self {
         let terminal = match term_program {
+            // Cross-platform
             "ghostty" => Terminal::Ghostty,
-            "iTerm.app" => Terminal::ITerm2,
-            "Apple_Terminal" => Terminal::TerminalApp,
             "WezTerm" => Terminal::WezTerm,
             "alacritty" => Terminal::Alacritty,
             "rio" => Terminal::Rio,
+            // macOS
+            "iTerm.app" => Terminal::ITerm2,
+            "Apple_Terminal" => Terminal::TerminalApp,
+            // Linux
+            "gnome-terminal" => Terminal::GnomeTerminal,
+            "tilix" => Terminal::Tilix,
+            "xterm" => Terminal::Xterm,
+            "konsole" => Terminal::Konsole,
+            "foot" => Terminal::Foot,
+            "terminator" => Terminal::Terminator,
+            // Fallback
             "" => Terminal::Unknown("unknown".into()),
             other => Terminal::Unknown(other.into()),
         };
@@ -218,8 +326,20 @@ impl TerminalProfile {
                 RenderStrategy::Synchronized,
                 PromptDetection::ShellIntegration,
             ),
-            // Legacy: no DECSET 2026, use pre-render buffer + shell integration
-            Terminal::ITerm2 | Terminal::TerminalApp | Terminal::Unknown(_) => (
+            // Linux terminals with synchronized output (DECSET 2026) support
+            // Foot and Konsole support synchronized output
+            Terminal::Foot | Terminal::Konsole => (
+                RenderStrategy::Synchronized,
+                PromptDetection::ShellIntegration,
+            ),
+            // VTE-based terminals (GNOME Terminal, Tilix, Terminator)
+            // VTE supports DECSET 2026 since version 0.66
+            Terminal::GnomeTerminal | Terminal::Tilix | Terminal::Terminator => (
+                RenderStrategy::Synchronized,
+                PromptDetection::ShellIntegration,
+            ),
+            // Legacy terminals without synchronized output support
+            Terminal::Xterm | Terminal::ITerm2 | Terminal::TerminalApp | Terminal::Unknown(_) => (
                 RenderStrategy::PreRenderBuffer,
                 PromptDetection::ShellIntegration,
             ),
@@ -272,6 +392,36 @@ impl TerminalProfile {
     pub fn for_unknown(name: &str) -> Self {
         Self::new(Terminal::Unknown(name.into()), false)
     }
+
+    /// Test constructor: GNOME Terminal profile (Synchronized, ShellIntegration).
+    pub fn for_gnome_terminal() -> Self {
+        Self::new(Terminal::GnomeTerminal, false)
+    }
+
+    /// Test constructor: Konsole profile (Synchronized, ShellIntegration).
+    pub fn for_konsole() -> Self {
+        Self::new(Terminal::Konsole, false)
+    }
+
+    /// Test constructor: Tilix profile (Synchronized, ShellIntegration).
+    pub fn for_tilix() -> Self {
+        Self::new(Terminal::Tilix, false)
+    }
+
+    /// Test constructor: Foot profile (Synchronized, ShellIntegration).
+    pub fn for_foot() -> Self {
+        Self::new(Terminal::Foot, false)
+    }
+
+    /// Test constructor: Terminator profile (Synchronized, ShellIntegration).
+    pub fn for_terminator() -> Self {
+        Self::new(Terminal::Terminator, false)
+    }
+
+    /// Test constructor: xterm profile (PreRenderBuffer, ShellIntegration).
+    pub fn for_xterm() -> Self {
+        Self::new(Terminal::Xterm, false)
+    }
 }
 
 #[cfg(test)]
@@ -289,14 +439,22 @@ mod tests {
         assert!(Terminal::Rio.is_known());
         assert!(Terminal::ITerm2.is_known());
         assert!(Terminal::TerminalApp.is_known());
-        assert!(!Terminal::Unknown("foot".into()).is_known());
+        // Linux terminals
+        assert!(Terminal::GnomeTerminal.is_known());
+        assert!(Terminal::Konsole.is_known());
+        assert!(Terminal::Tilix.is_known());
+        assert!(Terminal::Foot.is_known());
+        assert!(Terminal::Terminator.is_known());
+        assert!(Terminal::Xterm.is_known());
+        // Unknown
+        assert!(!Terminal::Unknown("other".into()).is_known());
         assert!(!Terminal::Unknown("unknown".into()).is_known());
     }
 
     #[test]
     fn test_supported_terminals_count() {
-        // 7 supported terminals: Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app
-        assert_eq!(Terminal::supported_terminals().len(), 7);
+        // 13 supported terminals: 7 original + 6 Linux
+        assert_eq!(Terminal::supported_terminals().len(), 13);
     }
 
     #[test]
@@ -304,13 +462,22 @@ mod tests {
         assert_eq!(
             Terminal::supported_terminals(),
             &[
+                // Cross-platform
                 "Ghostty",
                 "Kitty",
                 "WezTerm",
                 "Alacritty",
                 "Rio",
+                // macOS
                 "iTerm2",
                 "Terminal.app",
+                // Linux
+                "GNOME Terminal",
+                "Konsole",
+                "Tilix",
+                "Foot",
+                "Terminator",
+                "xterm",
             ]
         );
     }
@@ -377,7 +544,7 @@ mod tests {
 
     #[test]
     fn test_unknown_terminal_profile() {
-        let profile = TerminalProfile::from_term_program("foot", false);
+        let profile = TerminalProfile::from_term_program("some-unknown-terminal", false);
         assert!(matches!(profile.terminal(), Terminal::Unknown(_)));
         assert_eq!(profile.render_strategy(), RenderStrategy::PreRenderBuffer);
         assert_eq!(
@@ -437,6 +604,7 @@ mod tests {
         wezterm_sock: bool,
         alacritty_sock: bool,
     ) -> TerminalProfile {
+        // Call with Linux params all false for backward compatibility
         TerminalProfile::detect_from_env(
             term_program,
             in_tmux,
@@ -445,6 +613,43 @@ mod tests {
             kitty_wid,
             wezterm_sock,
             alacritty_sock,
+            false, // vte_version
+            false, // gnome_terminal
+            false, // konsole
+            false, // tilix
+            false, // foot
+            false, // terminator
+            false, // xterm
+        )
+    }
+
+    // Helper for Linux terminal detection tests
+    fn detect_linux(
+        term_program: &str,
+        in_tmux: bool,
+        vte_version: bool,
+        gnome_terminal: bool,
+        konsole: bool,
+        tilix: bool,
+        foot: bool,
+        terminator: bool,
+        xterm: bool,
+    ) -> TerminalProfile {
+        TerminalProfile::detect_from_env(
+            term_program,
+            in_tmux,
+            false, // ghostty_res
+            false, // iterm_session
+            false, // kitty_wid
+            false, // wezterm_sock
+            false, // alacritty_sock
+            vte_version,
+            gnome_terminal,
+            konsole,
+            tilix,
+            foot,
+            terminator,
+            xterm,
         )
     }
 
@@ -656,8 +861,8 @@ mod tests {
 
     #[test]
     fn test_for_unknown() {
-        let p = TerminalProfile::for_unknown("foot");
-        assert!(matches!(p.terminal(), Terminal::Unknown(s) if s == "foot"));
+        let p = TerminalProfile::for_unknown("some-terminal");
+        assert!(matches!(p.terminal(), Terminal::Unknown(s) if s == "some-terminal"));
         assert_eq!(p.render_strategy(), RenderStrategy::PreRenderBuffer);
     }
 
@@ -701,5 +906,80 @@ mod tests {
         assert!(PromptDetection::ShellIntegration
             .to_string()
             .contains("7771"));
+    }
+
+    // -- Linux terminal detection tests --
+
+    #[test]
+    fn test_detect_gnome_terminal_via_env() {
+        let p = detect_linux("", false, false, true, false, false, false, false, false);
+        assert_eq!(*p.terminal(), Terminal::GnomeTerminal);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_konsole_via_env() {
+        let p = detect_linux("", false, false, false, true, false, false, false, false);
+        assert_eq!(*p.terminal(), Terminal::Konsole);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_tilix_via_env() {
+        let p = detect_linux("", false, false, false, false, true, false, false, false);
+        assert_eq!(*p.terminal(), Terminal::Tilix);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_foot_via_env() {
+        let p = detect_linux("", false, false, false, false, false, true, false, false);
+        assert_eq!(*p.terminal(), Terminal::Foot);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_terminator_via_env() {
+        let p = detect_linux("", false, false, false, false, false, false, true, false);
+        assert_eq!(*p.terminal(), Terminal::Terminator);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_xterm_via_env() {
+        let p = detect_linux("", false, false, false, false, false, false, false, true);
+        assert_eq!(*p.terminal(), Terminal::Xterm);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_linux_terminal_display_names() {
+        assert_eq!(Terminal::GnomeTerminal.to_string(), "GNOME Terminal");
+        assert_eq!(Terminal::Konsole.to_string(), "Konsole");
+        assert_eq!(Terminal::Tilix.to_string(), "Tilix");
+        assert_eq!(Terminal::Foot.to_string(), "Foot");
+        assert_eq!(Terminal::Terminator.to_string(), "Terminator");
+        assert_eq!(Terminal::Xterm.to_string(), "xterm");
+    }
+
+    #[test]
+    fn test_foot_profile() {
+        let profile = TerminalProfile::from_term_program("foot", false);
+        assert_eq!(*profile.terminal(), Terminal::Foot);
+        assert_eq!(profile.render_strategy(), RenderStrategy::Synchronized);
+    }
+
+    #[test]
+    fn test_gnome_terminal_profile() {
+        let profile = TerminalProfile::from_term_program("gnome-terminal", false);
+        assert_eq!(*profile.terminal(), Terminal::GnomeTerminal);
+        assert_eq!(profile.render_strategy(), RenderStrategy::Synchronized);
+    }
+
+    #[test]
+    fn test_konsole_profile() {
+        let profile = TerminalProfile::from_term_program("konsole", false);
+        assert_eq!(*profile.terminal(), Terminal::Konsole);
+        assert_eq!(profile.render_strategy(), RenderStrategy::Synchronized);
     }
 }

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 
 const ZSH_INTEGRATION: &str = include_str!("../../../shell/ghost-complete.zsh");
 const ZSH_INIT: &str = include_str!("../../../shell/init.zsh");
+const BASH_INTEGRATION: &str = include_str!("../../../shell/ghost-complete.bash");
+const BASH_INIT: &str = include_str!("../../../shell/init.bash");
 
 const EMBEDDED_SPECS: &[(&str, &str)] = &[
     ("-.json", include_str!("../../../specs/-.json")),
@@ -1297,7 +1299,7 @@ fn print_shell_blocks(init_path: &Path, script_path: &Path) {
     println!("    \x1b[36m{indented_shell}\x1b[0m\n");
 }
 
-fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()> {
+fn install_zsh_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()> {
     // 1. Write zsh shell scripts
     let shell_dir = config_dir.join("shell");
     let init_path = shell_dir.join("init.zsh");
@@ -1383,7 +1385,7 @@ fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()>
     match fs::write(zshrc_path, &new_zshrc) {
         Ok(()) => {
             println!("  Updated {}", zshrc_path.display());
-            println!("\nghost-complete installed successfully!");
+            println!("\nghost-complete installed successfully for zsh!");
             println!("Restart your shell or run: source ~/.zshrc");
         }
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -1407,7 +1409,175 @@ fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()>
     Ok(())
 }
 
-fn uninstall_from(zshrc_path: &Path, config_dir: &Path) -> Result<()> {
+fn install_bash_to(bashrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()> {
+    // 1. Write bash shell scripts
+    let shell_dir = config_dir.join("shell");
+    let init_path = shell_dir.join("init.bash");
+    let script_path = shell_dir.join("ghost-complete.bash");
+
+    if dry_run {
+        println!("  Would write init script to {}", init_path.display());
+        println!(
+            "  Would write bash integration to {}",
+            script_path.display()
+        );
+        println!(
+            "  Would install {} completion specs to {}",
+            EMBEDDED_SPECS.len(),
+            config_dir.join("specs").display()
+        );
+        let config_path = config_dir.join("config.toml");
+        if !config_path.exists() {
+            println!("  Would write default config to {}", config_path.display());
+        } else {
+            println!("  Config already exists at {}", config_path.display());
+        }
+        println!("  Would update {}\n", bashrc_path.display());
+        println!("  \x1b[36m\u{2139}\x1b[0m  The following would be added to your shell config:\n");
+        print_shell_blocks(&init_path, &script_path);
+        return Ok(());
+    }
+
+    fs::create_dir_all(&shell_dir)
+        .with_context(|| format!("failed to create {}", shell_dir.display()))?;
+
+    fs::write(&init_path, BASH_INIT)
+        .with_context(|| format!("failed to write {}", init_path.display()))?;
+    println!("  Wrote init script to {}", init_path.display());
+
+    fs::write(&script_path, BASH_INTEGRATION)
+        .with_context(|| format!("failed to write {}", script_path.display()))?;
+    println!("  Wrote bash integration to {}", script_path.display());
+
+    // 1b. Copy completion specs
+    copy_specs(config_dir)?;
+
+    // 1c. Write default config.toml if one doesn't exist (never clobber)
+    let config_path = config_dir.join("config.toml");
+    if !config_path.exists() {
+        fs::write(&config_path, DEFAULT_CONFIG_TOML)
+            .with_context(|| format!("failed to write {}", config_path.display()))?;
+        println!("  Wrote default config to {}", config_path.display());
+    } else {
+        println!("  Config already exists at {}", config_path.display());
+    }
+
+    // 2. Read existing .bashrc (or empty)
+    let existing = if bashrc_path.exists() {
+        fs::read_to_string(bashrc_path)
+            .with_context(|| format!("failed to read {}", bashrc_path.display()))?
+    } else {
+        String::new()
+    };
+
+    // 3. Backup
+    if bashrc_path.exists() {
+        let backup = bashrc_path.with_extension("backup.ghost-complete");
+        fs::copy(bashrc_path, &backup)
+            .with_context(|| format!("failed to backup to {}", backup.display()))?;
+        println!("  Backed up .bashrc to {}", backup.display());
+    }
+
+    // 4. Strip existing managed blocks (idempotent)
+    let (content, _) = remove_block(&existing, INIT_BEGIN, INIT_END);
+    let (content, _) = remove_block(&content, SHELL_BEGIN, SHELL_END);
+
+    // 5. Prepend init block, append shell integration block
+    let content = content.trim().to_string();
+    let mut new_bashrc = String::new();
+    new_bashrc.push_str(&init_block(&init_path));
+    new_bashrc.push('\n');
+    if !content.is_empty() {
+        new_bashrc.push_str(&content);
+        new_bashrc.push('\n');
+    }
+    new_bashrc.push_str(&shell_integration_block(&script_path));
+    new_bashrc.push('\n');
+
+    // 6. Write .bashrc — graceful fallback if permission denied (e.g. nix-managed)
+    match fs::write(bashrc_path, &new_bashrc) {
+        Ok(()) => {
+            println!("  Updated {}", bashrc_path.display());
+            println!("\nghost-complete installed successfully for bash!");
+            println!("Restart your shell or run: source ~/.bashrc");
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            println!(
+                "\n  \x1b[33m\u{26a0}  Could not write to {} (permission denied)\x1b[0m\n",
+                bashrc_path.display()
+            );
+            print_shell_blocks(&init_path, &script_path);
+            println!(
+                "  \x1b[32m\u{2713}\x1b[0m  Installation complete (manual shell configuration required)."
+            );
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "failed to write {}: {}",
+                bashrc_path.display(),
+                e
+            ));
+        }
+    }
+    Ok(())
+}
+
+// Keep backward-compatible install_to that uses zsh
+fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()> {
+    install_zsh_to(zshrc_path, config_dir, dry_run)
+}
+
+fn uninstall_from(rc_path: &Path, config_dir: &Path, shell_name: &str) -> Result<()> {
+    // 1. Strip managed blocks from rc file
+    if rc_path.exists() {
+        let content = fs::read_to_string(rc_path)
+            .with_context(|| format!("failed to read {}", rc_path.display()))?;
+
+        let (content, found_init) = remove_block(&content, INIT_BEGIN, INIT_END);
+        let (content, found_shell) = remove_block(&content, SHELL_BEGIN, SHELL_END);
+
+        if found_init || found_shell {
+            fs::write(rc_path, &content)
+                .with_context(|| format!("failed to write {}", rc_path.display()))?;
+            println!("  Removed managed blocks from {}", rc_path.display());
+        } else {
+            println!("  No ghost-complete blocks found in {}", rc_path.display());
+        }
+    } else {
+        println!("  {} does not exist, nothing to do", rc_path.display());
+    }
+
+    // 2. Remove shell integration scripts for this shell
+    let scripts_to_remove = if shell_name == "bash" {
+        vec!["init.bash", "ghost-complete.bash"]
+    } else {
+        vec!["init.zsh", "ghost-complete.zsh"]
+    };
+
+    for name in scripts_to_remove {
+        let script_path = config_dir.join("shell").join(name);
+        if script_path.exists() {
+            fs::remove_file(&script_path)
+                .with_context(|| format!("failed to remove {}", script_path.display()))?;
+            println!("  Removed {}", script_path.display());
+        }
+    }
+
+    // 3. Clean up empty shell/ directory (best-effort)
+    let shell_dir = config_dir.join("shell");
+    if shell_dir.exists() {
+        let _ = fs::remove_dir(&shell_dir); // only succeeds if empty
+    }
+
+    println!(
+        "\nghost-complete uninstalled successfully for {}!",
+        shell_name
+    );
+    Ok(())
+}
+
+// Legacy wrapper for backward compatibility with tests
+fn uninstall_from_zsh(zshrc_path: &Path, config_dir: &Path) -> Result<()> {
     // 1. Strip managed blocks from .zshrc
     if zshrc_path.exists() {
         let content = fs::read_to_string(zshrc_path)
@@ -1434,6 +1604,7 @@ fn uninstall_from(zshrc_path: &Path, config_dir: &Path) -> Result<()> {
     for name in &[
         "init.zsh",
         "ghost-complete.zsh",
+        "init.bash",
         "ghost-complete.bash",
         "ghost-complete.fish",
     ] {
@@ -1455,26 +1626,106 @@ fn uninstall_from(zshrc_path: &Path, config_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Detect the user's login shell
+fn detect_shell() -> Option<String> {
+    // First try SHELL environment variable
+    if let Ok(shell) = std::env::var("SHELL") {
+        let shell_name = std::path::Path::new(&shell)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string());
+        if shell_name.is_some() {
+            return shell_name;
+        }
+    }
+    None
+}
+
 pub fn run_install(dry_run: bool) -> Result<()> {
     let home = dirs::home_dir().context("could not determine home directory")?;
-    let zshrc = home.join(".zshrc");
     let config_dir = gc_config::config_dir().context("could not determine home directory")?;
+
+    let shell = detect_shell().unwrap_or_else(|| "bash".to_string());
 
     if dry_run {
         println!("Dry run: ghost-complete install\n");
     } else {
         println!("Installing ghost-complete...\n");
     }
-    install_to(&zshrc, &config_dir, dry_run)
+
+    match shell.as_str() {
+        "bash" => {
+            let bashrc = home.join(".bashrc");
+            println!("  Detected shell: bash");
+            install_bash_to(&bashrc, &config_dir, dry_run)
+        }
+        "zsh" => {
+            let zshrc = home.join(".zshrc");
+            println!("  Detected shell: zsh");
+            install_zsh_to(&zshrc, &config_dir, dry_run)
+        }
+        other => {
+            // For other shells, try to install bash support as fallback
+            println!(
+                "  Detected shell: {} (unsupported, falling back to bash)",
+                other
+            );
+            let bashrc = home.join(".bashrc");
+            install_bash_to(&bashrc, &config_dir, dry_run)
+        }
+    }
 }
 
 pub fn run_uninstall() -> Result<()> {
     let home = dirs::home_dir().context("could not determine home directory")?;
-    let zshrc = home.join(".zshrc");
     let config_dir = gc_config::config_dir().context("could not determine home directory")?;
 
     println!("Uninstalling ghost-complete...\n");
-    uninstall_from(&zshrc, &config_dir)
+
+    // Uninstall from both bash and zsh if they exist
+    let bashrc = home.join(".bashrc");
+    let zshrc = home.join(".zshrc");
+
+    let mut uninstalled_any = false;
+
+    // Check and uninstall from bashrc
+    if bashrc.exists() {
+        let content = fs::read_to_string(&bashrc)?;
+        if content.contains(INIT_BEGIN) || content.contains(SHELL_BEGIN) {
+            uninstall_from(&bashrc, &config_dir, "bash")?;
+            uninstalled_any = true;
+        }
+    }
+
+    // Check and uninstall from zshrc
+    if zshrc.exists() {
+        let content = fs::read_to_string(&zshrc)?;
+        if content.contains(INIT_BEGIN) || content.contains(SHELL_BEGIN) {
+            uninstall_from(&zshrc, &config_dir, "zsh")?;
+            uninstalled_any = true;
+        }
+    }
+
+    if !uninstalled_any {
+        // Clean up any remaining shell scripts
+        for name in &[
+            "init.zsh",
+            "ghost-complete.zsh",
+            "init.bash",
+            "ghost-complete.bash",
+            "ghost-complete.fish",
+        ] {
+            let script_path = config_dir.join("shell").join(name);
+            if script_path.exists() {
+                fs::remove_file(&script_path)
+                    .with_context(|| format!("failed to remove {}", script_path.display()))?;
+                println!("  Removed {}", script_path.display());
+            }
+        }
+        println!("\nNo ghost-complete configuration found in shell rc files.");
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1569,7 +1820,7 @@ mod tests {
 
         // Direct terminal detection (non-tmux)
         assert!(non_tmux_branch.contains("case \"$TERM_PROGRAM\""));
-        assert!(non_tmux_branch.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal)"));
+        assert!(non_tmux_branch.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|gnome-terminal|tilix|xterm|konsole|foot|terminator)"));
     }
 
     #[test]
@@ -1694,7 +1945,7 @@ mod tests {
 
         // Install then uninstall
         install_to(&zshrc, &config, false).unwrap();
-        uninstall_from(&zshrc, &config).unwrap();
+        uninstall_from_zsh(&zshrc, &config).unwrap();
 
         // Blocks should be gone
         let content = fs::read_to_string(&zshrc).unwrap();
@@ -1843,5 +2094,108 @@ mod tests {
         assert_eq!(fs::read_to_string(&config_path).unwrap(), custom_config);
         // No shell scripts should have been created
         assert!(!config.join("shell").exists());
+    }
+
+    // ==================== BASH INSTALLATION TESTS ====================
+
+    #[test]
+    fn test_bash_install_creates_files() {
+        let dir = TempDir::new().unwrap();
+        let bashrc = dir.path().join(".bashrc");
+        let config = dir.path().join("config");
+
+        install_bash_to(&bashrc, &config, false).unwrap();
+
+        // .bashrc should exist with both blocks
+        let content = fs::read_to_string(&bashrc).unwrap();
+        assert!(content.contains(INIT_BEGIN));
+        assert!(content.contains(INIT_END));
+        assert!(content.contains(SHELL_BEGIN));
+        assert!(content.contains(SHELL_END));
+
+        // Init script should be written and sourced
+        let init_script = config.join("shell/init.bash");
+        assert!(init_script.exists());
+        let init_content = fs::read_to_string(&init_script).unwrap();
+        assert_eq!(init_content, BASH_INIT);
+
+        // Bash shell integration script should be written and sourced
+        let script = config.join("shell/ghost-complete.bash");
+        assert!(script.exists());
+        let script_content = fs::read_to_string(&script).unwrap();
+        assert_eq!(script_content, BASH_INTEGRATION);
+    }
+
+    #[test]
+    fn test_bash_install_preserves_existing_content() {
+        let dir = TempDir::new().unwrap();
+        let bashrc = dir.path().join(".bashrc");
+        let config = dir.path().join("config");
+
+        let existing = "export PATH=\"/usr/local/bin:$PATH\"\nalias ll='ls -la'\n";
+        fs::write(&bashrc, existing).unwrap();
+
+        install_bash_to(&bashrc, &config, false).unwrap();
+
+        let content = fs::read_to_string(&bashrc).unwrap();
+        assert!(content.contains("export PATH=\"/usr/local/bin:$PATH\""));
+        assert!(content.contains("alias ll='ls -la'"));
+        assert!(content.contains(INIT_BEGIN));
+        assert!(content.contains(SHELL_BEGIN));
+
+        // Init block should be before user content
+        let init_pos = content.find(INIT_BEGIN).unwrap();
+        let user_pos = content.find("export PATH").unwrap();
+        let shell_pos = content.find(SHELL_BEGIN).unwrap();
+        assert!(init_pos < user_pos);
+        assert!(user_pos < shell_pos);
+    }
+
+    #[test]
+    fn test_bash_idempotency() {
+        let dir = TempDir::new().unwrap();
+        let bashrc = dir.path().join(".bashrc");
+        let config = dir.path().join("config");
+
+        let existing = "export FOO=bar\n";
+        fs::write(&bashrc, existing).unwrap();
+
+        install_bash_to(&bashrc, &config, false).unwrap();
+        let first = fs::read_to_string(&bashrc).unwrap();
+
+        install_bash_to(&bashrc, &config, false).unwrap();
+        let second = fs::read_to_string(&bashrc).unwrap();
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_bash_init_script_content() {
+        // Verify the external bash init script has all the required detection logic
+        let script = BASH_INIT;
+        assert!(script.contains("__ghost_complete_init()"));
+        assert!(script.contains("unset -f __ghost_complete_init"));
+        assert!(script.contains("exec ghost-complete"));
+        assert!(script.contains("command -v ghost-complete"));
+
+        // Should have Linux terminal detection
+        assert!(script.contains("KONSOLE_VERSION"));
+        assert!(script.contains("GNOME_TERMINAL_SCREEN"));
+        assert!(script.contains("VTE_VERSION"));
+        assert!(script.contains("TILIX_ID"));
+        assert!(script.contains("FOOT_SERVER_SOCKET"));
+        assert!(script.contains("TERMINATOR_UUID"));
+    }
+
+    #[test]
+    fn test_bash_integration_has_auto_trigger() {
+        // Verify the bash integration script has auto-trigger support
+        let script = BASH_INTEGRATION;
+        assert!(script.contains("_gc_self_insert_and_report"));
+        assert!(script.contains("_gc_space"));
+        assert!(script.contains("_gc_slash"));
+        assert!(script.contains("_gc_dash"));
+        assert!(script.contains("_gc_dot"));
+        assert!(script.contains("GC_NO_AUTO_TRIGGER"));
     }
 }

--- a/crates/ghost-complete/src/main.rs
+++ b/crates/ghost-complete/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
     init_tracing(&cli.log_level, log_file.as_deref())?;
 
     let (shell, args) = if cli.shell_args.is_empty() {
-        let default_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        let default_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
         (default_shell, vec![])
     } else {
         let mut iter = cli.shell_args.into_iter();

--- a/shell/ghost-complete.bash
+++ b/shell/ghost-complete.bash
@@ -53,3 +53,83 @@ _gc_report_buffer() {
 
 # Bind Ctrl+/ as manual trigger (0x1F)
 bind -x '"\C-_": _gc_report_buffer'
+
+# ============================================================================
+# AUTO-TRIGGER SUPPORT
+# ============================================================================
+# Auto-trigger completions on certain characters (space, /, -, .)
+# This works by binding keys to self-insert + report buffer.
+# ============================================================================
+
+# Check if auto-trigger is enabled (can be disabled by setting GC_NO_AUTO_TRIGGER=1)
+if [[ -z "$GC_NO_AUTO_TRIGGER" ]]; then
+    
+    # Helper: insert character and report buffer
+    _gc_self_insert_and_report() {
+        local char="$1"
+        # Insert the character at cursor position
+        if [[ $READLINE_POINT -eq ${#READLINE_LINE} ]]; then
+            READLINE_LINE="${READLINE_LINE}${char}"
+        else
+            READLINE_LINE="${READLINE_LINE:0:$READLINE_POINT}${char}${READLINE_LINE:$READLINE_POINT}"
+        fi
+        ((READLINE_POINT++))
+        # Report buffer to proxy
+        printf '\e]7770;%d;%s\a' "$READLINE_POINT" "$READLINE_LINE"
+    }
+
+    # Auto-trigger on space
+    _gc_space() { _gc_self_insert_and_report ' '; }
+    bind -x '" ": _gc_space'
+
+    # Auto-trigger on forward slash (path completion)
+    _gc_slash() { _gc_self_insert_and_report '/'; }
+    bind -x '"/": _gc_slash'
+
+    # Auto-trigger on dash (option completion)
+    _gc_dash() { _gc_self_insert_and_report '-'; }
+    bind -x '"-": _gc_dash'
+
+    # Auto-trigger on dot (file extension, hidden files)
+    _gc_dot() { _gc_self_insert_and_report '.'; }
+    bind -x '".": _gc_dot'
+
+    # Auto-trigger on equals (--option=value completion)
+    _gc_equals() { _gc_self_insert_and_report '='; }
+    bind -x '"=": _gc_equals'
+
+    # Auto-trigger on colon (for paths like user@host:path)
+    _gc_colon() { _gc_self_insert_and_report ':'; }
+    bind -x '":": _gc_colon'
+
+    # Also report buffer on backspace/delete for live updates
+    _gc_backward_delete() {
+        if [[ $READLINE_POINT -gt 0 ]]; then
+            READLINE_LINE="${READLINE_LINE:0:$((READLINE_POINT-1))}${READLINE_LINE:$READLINE_POINT}"
+            ((READLINE_POINT--))
+        fi
+        printf '\e]7770;%d;%s\a' "$READLINE_POINT" "$READLINE_LINE"
+    }
+    bind -x '"\C-h": _gc_backward_delete'
+    bind -x '"\C-?": _gc_backward_delete'
+
+    # Report on cursor movement for context updates
+    _gc_forward_char() {
+        if [[ $READLINE_POINT -lt ${#READLINE_LINE} ]]; then
+            ((READLINE_POINT++))
+        fi
+        printf '\e]7770;%d;%s\a' "$READLINE_POINT" "$READLINE_LINE"
+    }
+    bind -x '"\C-f": _gc_forward_char'
+    bind -x '"\e[C": _gc_forward_char'
+
+    _gc_backward_char() {
+        if [[ $READLINE_POINT -gt 0 ]]; then
+            ((READLINE_POINT--))
+        fi
+        printf '\e]7770;%d;%s\a' "$READLINE_POINT" "$READLINE_LINE"
+    }
+    bind -x '"\C-b": _gc_backward_char'
+    bind -x '"\e[D": _gc_backward_char'
+
+fi

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -1,0 +1,64 @@
+# Ghost Complete — terminal init for Bash
+# Source this near the top of .bashrc to enable Ghost Complete PTY proxy.
+# Detects the terminal emulator and exec's ghost-complete as a PTY proxy.
+
+__ghost_complete_init() {
+    # Only run in interactive mode
+    [[ $- != *i* ]] && return
+
+    if [[ -n "$TMUX" ]]; then
+        # Inside tmux: guards prevent stacking proxies.
+        # PPID check catches direct child shell.
+        # GHOST_COMPLETE_PANE catches subshells.
+        [[ "$(ps -o comm= -p "$PPID" 2>/dev/null)" == "ghost-complete" ]] && return
+        [[ -n "$GHOST_COMPLETE_PANE" && "$GHOST_COMPLETE_PANE" == "$TMUX_PANE" ]] && return
+        
+        if [[ -n "$GHOSTTY_RESOURCES_DIR" ]] || \
+           [[ -n "$KITTY_WINDOW_ID" ]] || \
+           [[ -n "$WEZTERM_UNIX_SOCKET" ]] || \
+           [[ -n "$ALACRITTY_SOCKET" ]] || \
+           [[ -n "$ITERM_SESSION_ID" ]] || \
+           [[ "$TERM_PROGRAM" == "rio" ]] || \
+           [[ -n "$KONSOLE_VERSION" ]] || \
+           [[ -n "$GNOME_TERMINAL_SCREEN" ]] || \
+           [[ -n "$VTE_VERSION" ]] || \
+           [[ -n "$TILIX_ID" ]] || \
+           [[ -n "$FOOT_SERVER_SOCKET" ]] || \
+           [[ -n "$TERMINATOR_UUID" ]]; then
+            if command -v ghost-complete >/dev/null 2>&1; then
+                export GHOST_COMPLETE_ACTIVE=1
+                exec ghost-complete
+            fi
+        fi
+    else
+        # Outside tmux: GHOST_COMPLETE_ACTIVE is a reliable recursion guard
+        [[ -n "$GHOST_COMPLETE_ACTIVE" ]] && return
+        
+        local supported=0
+        if [[ -n "$KITTY_WINDOW_ID" ]] || \
+           [[ -n "$ALACRITTY_SOCKET" ]] || \
+           [[ -n "$GHOSTTY_RESOURCES_DIR" ]] || \
+           [[ -n "$KONSOLE_VERSION" ]] || \
+           [[ -n "$GNOME_TERMINAL_SCREEN" ]] || \
+           [[ -n "$VTE_VERSION" ]] || \
+           [[ -n "$TILIX_ID" ]] || \
+           [[ -n "$FOOT_SERVER_SOCKET" ]] || \
+           [[ -n "$TERMINATOR_UUID" ]]; then
+            supported=1
+        else
+            case "$TERM_PROGRAM" in
+                ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|gnome-terminal|tilix|xterm|konsole|foot|terminator)
+                    supported=1
+                    ;;
+            esac
+        fi
+        
+        if [[ $supported -eq 1 ]] && command -v ghost-complete >/dev/null 2>&1; then
+            export GHOST_COMPLETE_ACTIVE=1
+            exec ghost-complete
+        fi
+    fi
+}
+
+__ghost_complete_init
+unset -f __ghost_complete_init

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -22,7 +22,13 @@ __ghost_complete_init() {
        [[ -n "$WEZTERM_UNIX_SOCKET" ]] || \
        [[ -n "$ALACRITTY_SOCKET" ]] || \
        [[ -n "$ITERM_SESSION_ID" ]] || \
-       [[ "$TERM_PROGRAM" == "rio" ]]; then
+       [[ "$TERM_PROGRAM" == "rio" ]] || \
+       [[ -n "$KONSOLE_VERSION" ]] || \
+       [[ -n "$GNOME_TERMINAL_SCREEN" ]] || \
+       [[ -n "$VTE_VERSION" ]] || \
+       [[ -n "$TILIX_ID" ]] || \
+       [[ -n "$FOOT_SERVER_SOCKET" ]] || \
+       [[ -n "$TERMINATOR_UUID" ]]; then
       if command -v ghost-complete >/dev/null 2>&1; then
         export GHOST_COMPLETE_ACTIVE=1
         exec ghost-complete
@@ -33,11 +39,19 @@ __ghost_complete_init() {
     # because no multiplexer re-injects it into unrelated shell sessions.
     [[ -n "$GHOST_COMPLETE_ACTIVE" ]] && return
     local supported=0
-    if [[ -n "$KITTY_WINDOW_ID" ]] || [[ -n "$ALACRITTY_SOCKET" ]]; then
+    if [[ -n "$KITTY_WINDOW_ID" ]] || \
+       [[ -n "$ALACRITTY_SOCKET" ]] || \
+       [[ -n "$GHOSTTY_RESOURCES_DIR" ]] || \
+       [[ -n "$KONSOLE_VERSION" ]] || \
+       [[ -n "$GNOME_TERMINAL_SCREEN" ]] || \
+       [[ -n "$VTE_VERSION" ]] || \
+       [[ -n "$TILIX_ID" ]] || \
+       [[ -n "$FOOT_SERVER_SOCKET" ]] || \
+       [[ -n "$TERMINATOR_UUID" ]]; then
       supported=1
     else
       case "$TERM_PROGRAM" in
-        ghostty|WezTerm|rio|iTerm.app|Apple_Terminal) supported=1 ;;
+        ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|gnome-terminal|tilix|xterm|konsole|foot|terminator) supported=1 ;;
       esac
     fi
     if [[ $supported -eq 1 ]] && command -v ghost-complete >/dev/null 2>&1; then


### PR DESCRIPTION
- Add support for Linux terminals (GNOME Terminal, Konsole, Tilix, Foot, Terminator, xterm)
- Add bash shell integration with auto-trigger support
- Update install script to detect and support bash
- Add init.bash for bash PTY proxy initialization
- Update shell scripts with Linux terminal environment variable detection
- Change default shell fallback from zsh to bash for Linux compatibility
- Add comprehensive tests for Linux terminal detection and bash installation

Key Changes:
* gc-terminal: Added Linux terminal variants and detection logic
* install.rs: Added bash installation functions and shell detection
* init.bash: New file for bash PTY proxy initialization with Linux terminal support
* ghost-complete.bash: Added auto-trigger on space, /, -, ., =, : with live buffer updates
* init.zsh: Added Linux terminal environment variable checks for tmux compatibility

Testing:
* All 59 gc-terminal tests pass
* All 29 ghost-complete installation tests pass
* Verified installation and functionality on Ubuntu with Ghostty terminal

## What

<!-- Brief description of the change -->

## Why

<!-- Motivation / context for the change -->

## Testing

- [ ] `cargo test` passes
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] Manually tested in Ghostty with zsh
