### PR TITLE
fix: prevent proxy from stealing shell CPR responses

### DIFF
--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -90,6 +90,14 @@ impl Perform for TerminalState {
             // ANSI save/restore cursor (SCO sequences)
             's' => self.save_cursor(),
             'u' => self.restore_cursor(),
+            // DSR — Device Status Report (CSI 6n = cursor position query)
+            // When a shell program sends this, we flag it so the proxy
+            // defers its own CSI 6n to avoid stealing the response.
+            'n' => {
+                if csi_param(params, 0, 0) == 6 {
+                    self.set_shell_cpr_in_flight();
+                }
+            }
             _ => {}
         }
     }
@@ -729,11 +737,43 @@ mod tests {
     }
 
     #[test]
+    fn test_csi_6n_sets_shell_cpr_in_flight() {
+        let mut p = make_parser();
+        assert!(!p.state().is_shell_cpr_in_flight());
+        // CSI 6n — Device Status Report (cursor position query)
+        p.process_bytes(b"\x1b[6n");
+        assert!(p.state().is_shell_cpr_in_flight());
+    }
+
+    #[test]
+    fn test_csi_6n_does_not_trigger_on_other_dsr() {
+        let mut p = make_parser();
+        // CSI 5n — Device Status Report (terminal ok query), NOT cursor position
+        p.process_bytes(b"\x1b[5n");
+        assert!(!p.state().is_shell_cpr_in_flight());
+    }
+
+    #[test]
     fn test_percent_decode_non_utf8_bytes() {
         // Bytes 0x80 0x81 are not valid UTF-8, but are valid Unix path bytes
         use std::os::unix::ffi::OsStrExt;
         let result = percent_decode_path("/%80%81");
         let expected = PathBuf::from(std::ffi::OsStr::from_bytes(&[b'/', 0x80, 0x81]));
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_shell_cpr_in_flight_default_false() {
+        let p = make_parser();
+        assert!(!p.state().is_shell_cpr_in_flight());
+    }
+
+    #[test]
+    fn test_shell_cpr_in_flight_set_and_clear() {
+        let mut p = make_parser();
+        p.state_mut().set_shell_cpr_in_flight();
+        assert!(p.state().is_shell_cpr_in_flight());
+        p.state_mut().clear_shell_cpr_in_flight();
+        assert!(!p.state().is_shell_cpr_in_flight());
     }
 }

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::time::Instant;
 
 /// Tracks terminal state derived from the VT escape sequence stream.
 ///
@@ -22,6 +23,7 @@ pub struct TerminalState {
     cursor_sync_requested: bool,
     cpr_synced: bool,
     cpr_pending: u8,
+    shell_cpr_in_flight: Option<Instant>,
 }
 
 impl TerminalState {
@@ -42,6 +44,7 @@ impl TerminalState {
             cursor_sync_requested: false,
             cpr_synced: false,
             cpr_pending: 0,
+            shell_cpr_in_flight: None,
         }
     }
 
@@ -104,7 +107,7 @@ impl TerminalState {
     }
 
     /// Request a CPR-based cursor sync on the next opportunity.
-    pub(crate) fn request_cursor_sync(&mut self) {
+    pub fn request_cursor_sync(&mut self) {
         self.cursor_sync_requested = true;
     }
 
@@ -143,6 +146,30 @@ impl TerminalState {
             true
         } else {
             false
+        }
+    }
+
+    /// Returns true if a shell program has an outstanding CPR request.
+    pub fn is_shell_cpr_in_flight(&self) -> bool {
+        self.shell_cpr_in_flight.is_some()
+    }
+
+    /// Mark that a shell program sent CSI 6n through the PTY.
+    pub fn set_shell_cpr_in_flight(&mut self) {
+        self.shell_cpr_in_flight = Some(std::time::Instant::now());
+    }
+
+    /// Clear the shell CPR in-flight flag.
+    pub fn clear_shell_cpr_in_flight(&mut self) {
+        self.shell_cpr_in_flight = None;
+    }
+
+    /// Clear the flag if it's been set longer than `timeout`.
+    pub fn expire_shell_cpr_in_flight(&mut self, timeout: std::time::Duration) {
+        if let Some(set_at) = self.shell_cpr_in_flight {
+            if set_at.elapsed() >= timeout {
+                self.shell_cpr_in_flight = None;
+            }
         }
     }
 

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -258,6 +258,12 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     if pty_writer.flush().is_err() {
                         return;
                     }
+                    // Shell's CPR round-trip is complete — unblock
+                    // ghost-complete's deferred CPR requests.
+                    {
+                        let mut p = parser_for_stdin.lock().unwrap();
+                        p.state_mut().clear_shell_cpr_in_flight();
+                    }
                     continue;
                 }
 
@@ -304,32 +310,37 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             };
 
             // Feed bytes through the VT parser to track terminal state
-            let needs_cpr = {
+            let (needs_cpr, shell_cpr) = {
                 let mut p = parser_for_stdout.lock().unwrap();
                 p.process_bytes(&buf[..n]);
-                p.state_mut().take_cursor_sync_requested()
+                p.state_mut().expire_shell_cpr_in_flight(
+                    std::time::Duration::from_millis(500),
+                );
+                let needs_cpr = p.state_mut().take_cursor_sync_requested();
+                let shell_cpr = p.state().is_shell_cpr_in_flight();
+                (needs_cpr, shell_cpr)
             };
 
             // Briefly lock stdout for each write — do NOT hold the lock
             // across the entire loop or it deadlocks with Task A.
             {
                 let mut stdout = std::io::stdout().lock();
-                if stdout.write_all(&buf[..n]).is_err() {
+                // Strip ghost-complete's internal OSC sequences (7770, 7771)
+                // before forwarding to the terminal — they can interfere with
+                // prompt rendering (e.g., powerlevel10k right-prompt alignment).
+                let cleaned = strip_internal_osc(&buf[..n]);
+                if stdout.write_all(&cleaned).is_err() {
                     break;
                 }
-                // Send CPR request (CSI 6n) to the REAL terminal so it
-                // reports its actual cursor position. The response
-                // (CSI row;col R) arrives on stdin and is intercepted by
-                // Task A to sync our VT parser's cursor tracking.
-                if needs_cpr {
+                if needs_cpr && !shell_cpr {
                     tracing::debug!("sending CPR request (CSI 6n)");
                     let _ = stdout.write_all(b"\x1b[6n");
-                    // Mark this as our own request so Task A knows to
-                    // consume the response instead of forwarding it to
-                    // the PTY (where programs like atuin may be waiting
-                    // for their own CPR responses).
                     let mut p = parser_for_stdout.lock().unwrap();
                     p.state_mut().increment_cpr_pending();
+                } else if needs_cpr && shell_cpr {
+                    tracing::debug!("deferring CPR request — shell CPR in flight");
+                    let mut p = parser_for_stdout.lock().unwrap();
+                    p.state_mut().request_cursor_sync();
                 }
                 if stdout.flush().is_err() {
                     break;
@@ -595,6 +606,55 @@ fn expand_tilde(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
+/// Strip ghost-complete's internal OSC sequences (7770, 7771) from the byte
+/// stream before forwarding to the terminal. These are protocol sequences
+/// between the shell integration and the proxy — the terminal doesn't need
+/// them and they can interfere with prompt rendering (e.g., powerlevel10k
+/// right-prompt width calculation).
+fn strip_internal_osc(buf: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(buf.len());
+    let mut i = 0;
+    while i < buf.len() {
+        // Look for ESC ] (OSC start)
+        if buf[i] == 0x1b && i + 1 < buf.len() && buf[i + 1] == b']' {
+            // Check if this is OSC 7770 or OSC 7771
+            let osc_start = i;
+            let after_bracket = i + 2;
+            let is_internal = if after_bracket + 4 <= buf.len() && &buf[after_bracket..after_bracket + 4] == b"7770" {
+                true
+            } else if after_bracket + 4 <= buf.len() && &buf[after_bracket..after_bracket + 4] == b"7771" {
+                true
+            } else {
+                false
+            };
+
+            if is_internal {
+                // Skip until BEL (\x07) or ST (ESC \)
+                i = after_bracket;
+                while i < buf.len() {
+                    if buf[i] == 0x07 {
+                        i += 1; // skip BEL
+                        break;
+                    }
+                    if buf[i] == 0x1b && i + 1 < buf.len() && buf[i + 1] == b'\\' {
+                        i += 2; // skip ST
+                        break;
+                    }
+                    i += 1;
+                }
+                // If we reached EOF without finding terminator, skip from osc_start
+                if i >= buf.len() {
+                    break;
+                }
+                continue;
+            }
+        }
+        out.push(buf[i]);
+        i += 1;
+    }
+    out
+}
+
 /// Returns true if ghost-complete should replace itself with a plain shell
 /// because multi-terminal support is disabled and we're not on Ghostty.
 pub fn should_fallback_to_shell(
@@ -649,5 +709,42 @@ mod tests {
             &Terminal::Unknown("foot".into()),
             true
         ));
+    }
+
+    #[test]
+    fn test_strip_internal_osc_7770_bel() {
+        let input = b"hello\x1b]7770;3;git\x07world";
+        assert_eq!(strip_internal_osc(input), b"helloworld");
+    }
+
+    #[test]
+    fn test_strip_internal_osc_7771_bel() {
+        let input = b"\x1b]7771;A\x07prompt";
+        assert_eq!(strip_internal_osc(input), b"prompt");
+    }
+
+    #[test]
+    fn test_strip_internal_osc_st_terminator() {
+        let input = b"before\x1b]7770;0;\x1b\\after";
+        assert_eq!(strip_internal_osc(input), b"beforeafter");
+    }
+
+    #[test]
+    fn test_strip_preserves_other_osc() {
+        // OSC 133 (semantic prompt) should NOT be stripped
+        let input = b"\x1b]133;A\x07prompt";
+        assert_eq!(strip_internal_osc(input), input.to_vec());
+    }
+
+    #[test]
+    fn test_strip_no_osc() {
+        let input = b"plain text\r\n";
+        assert_eq!(strip_internal_osc(input), input.to_vec());
+    }
+
+    #[test]
+    fn test_strip_multiple_osc() {
+        let input = b"\x1b]7771;A\x07text\x1b]7770;5;hello\x07end";
+        assert_eq!(strip_internal_osc(input), b"textend");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #64 — ghost-complete's PTY proxy steals CPR (Cursor Position Report) responses from shell programs like z4h, crossterm, and atuin, causing a 5-second timeout on every prompt display and Ctrl+L.

## Root cause

In `proxy.rs` Task B, when forwarding shell output to stdout, the proxy simultaneously appends its own `CSI 6n` request (triggered by OSC 133;A during prompt rendering). This causes two CPR requests to reach the terminal, and `claim_cpr_response()` consumes the first response (which belongs to the shell), leaving the shell waiting until its `read -srt 5` times out.

**Confirmed via debug tracing:** zero "forwarding to PTY (not ours)" log entries — every CPR response was consumed by ghost-complete. The 5.38s gap in logs matches z4h's 5-second `read` timeout exactly.

## Changes

- **Detect shell CSI 6n in VT parser** — new `'n'` case in `csi_dispatch` sets a `shell_cpr_in_flight` flag when param=6
- **Defer proxy's own CPR** — Task B checks the flag before sending its own `CSI 6n`; if a shell CPR is in-flight, re-queues via `request_cursor_sync()` for the next iteration
- **Clear flag after forwarding** — Task A clears `shell_cpr_in_flight` after forwarding a non-owned CPR response to the PTY
- **500ms expiry timeout** — safety net to prevent rendering suppression if the terminal never responds
- **Strip internal OSC from terminal stream** — removes OSC 7770/7771 sequences before forwarding to the terminal, as they can interfere with prompt rendering (e.g., powerlevel10k RPROMPT width calculation)

## Test plan

- [x] All 561 existing tests pass
- [x] 10 new unit tests added (CPR flag lifecycle, CSI 6n detection, OSC stripping)
- [x] Manual test: Ctrl+L instant (was 5s timeout)
- [x] Manual test: `gh auth status` returns in <1s (was 5s)
- [x] Manual test: ghost-complete suggestions still appear
- [ ] Manual test: verify with crossterm/atuin CPR queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)