### PR TITLE
feat: add auto_trigger config flag

### DIFF
--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -60,6 +60,7 @@ impl Default for KeybindingsConfig {
 pub struct TriggerConfig {
     pub auto_chars: Vec<char>,
     pub delay_ms: u64,
+    pub auto_trigger: bool,
 }
 
 impl Default for TriggerConfig {
@@ -67,6 +68,7 @@ impl Default for TriggerConfig {
         Self {
             auto_chars: vec![' ', '/', '-', '.'],
             delay_ms: 150,
+            auto_trigger: true,
         }
     }
 }
@@ -264,6 +266,7 @@ mod tests {
         let config = GhostConfig::default();
         assert_eq!(config.trigger.auto_chars, vec![' ', '/', '-', '.']);
         assert_eq!(config.trigger.delay_ms, 150);
+        assert!(config.trigger.auto_trigger);
         assert_eq!(config.popup.max_visible, 10);
         assert_eq!(config.suggest.max_results, 50);
         assert_eq!(config.suggest.max_history_results, 5);
@@ -571,5 +574,24 @@ max_visible = 5
 "#;
         let config: GhostConfig = toml::from_str(toml_str).unwrap();
         assert!(!config.experimental.multi_terminal);
+    }
+
+    #[test]
+    fn test_auto_trigger_defaults_to_true() {
+        let config = GhostConfig::default();
+        assert!(config.trigger.auto_trigger);
+    }
+
+    #[test]
+    fn test_auto_trigger_false_from_toml() {
+        let toml_str = r#"
+[trigger]
+auto_trigger = false
+"#;
+        let config: GhostConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.trigger.auto_trigger);
+        // Other trigger defaults preserved
+        assert_eq!(config.trigger.auto_chars, vec![' ', '/', '-', '.']);
+        assert_eq!(config.trigger.delay_ms, 150);
     }
 }

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -3,6 +3,7 @@
 //! Watches `config.toml` for modifications and live-updates the handler's
 //! theme, keybindings, trigger chars, and popup dimensions without restarting.
 
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -113,7 +114,7 @@ pub fn spawn_config_watcher(config_path: PathBuf, handler: Arc<Mutex<InputHandle
             };
 
             // Apply to handler
-            {
+            let cleanup = {
                 let mut h = match handler.lock() {
                     Ok(h) => h,
                     Err(e) => {
@@ -127,7 +128,12 @@ pub fn spawn_config_watcher(config_path: PathBuf, handler: Arc<Mutex<InputHandle
                     &config.trigger.auto_chars,
                     config.popup.max_visible,
                     config.trigger.auto_trigger,
-                );
+                )
+            };
+            if !cleanup.is_empty() {
+                let mut stdout = std::io::stdout().lock();
+                let _ = stdout.write_all(&cleanup);
+                let _ = stdout.flush();
             }
 
             tracing::info!("config reloaded successfully");

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -126,6 +126,7 @@ pub fn spawn_config_watcher(config_path: PathBuf, handler: Arc<Mutex<InputHandle
                     keybindings,
                     &config.trigger.auto_chars,
                     config.popup.max_visible,
+                    config.trigger.auto_trigger,
                 );
             }
 

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -198,6 +198,7 @@ impl InputHandler {
 
     /// Update runtime-configurable fields without restarting the proxy.
     /// Called by the config file watcher when config.toml changes on disk.
+    /// Returns cleanup bytes to write to stdout (e.g. popup clear on auto_trigger toggle).
     pub fn update_config(
         &mut self,
         theme: PopupTheme,
@@ -205,12 +206,29 @@ impl InputHandler {
         trigger_chars: &[char],
         max_visible: usize,
         auto_trigger: bool,
-    ) {
+    ) -> Vec<u8> {
+        let mut cleanup = Vec::new();
+
+        // If auto_trigger is being disabled while popup is visible, clear it.
+        if self.auto_trigger && !auto_trigger && self.visible {
+            if let Some(ref layout) = self.last_layout {
+                clear_popup(&mut cleanup, layout, &self.terminal_profile);
+            }
+            self.visible = false;
+            self.suggestions.clear();
+            self.overlay.reset();
+            self.last_layout = None;
+            self.dynamic_rx = None;
+            self.trigger_requested = false;
+        }
+
         self.theme = theme;
         self.keybindings = keybindings;
         self.trigger_chars = trigger_chars.iter().copied().collect();
         self.max_visible = max_visible;
         self.auto_trigger = auto_trigger;
+
+        cleanup
     }
 
     #[allow(dead_code)]
@@ -1345,6 +1363,50 @@ mod tests {
         );
 
         assert!(!handler.auto_trigger_enabled());
+    }
+
+    #[test]
+    fn test_update_config_dismisses_popup_on_auto_trigger_disable() {
+        let suggestion = Suggestion {
+            text: "test".into(),
+            ..Default::default()
+        };
+        let mut handler = make_visible_handler(vec![suggestion]);
+        assert!(handler.is_visible());
+        assert!(handler.auto_trigger_enabled());
+
+        let cleanup = handler.update_config(
+            PopupTheme::default(),
+            Keybindings::default(),
+            &[' ', '/', '-', '.'],
+            10,
+            false,
+        );
+
+        assert!(!handler.is_visible());
+        assert!(!handler.auto_trigger_enabled());
+        assert!(!cleanup.is_empty(), "should emit popup clear sequences");
+    }
+
+    #[test]
+    fn test_update_config_keeps_popup_when_auto_trigger_stays_true() {
+        let suggestion = Suggestion {
+            text: "test".into(),
+            ..Default::default()
+        };
+        let mut handler = make_visible_handler(vec![suggestion]);
+        assert!(handler.is_visible());
+
+        let cleanup = handler.update_config(
+            PopupTheme::default(),
+            Keybindings::default(),
+            &[' ', '/', '-', '.'],
+            10,
+            true,
+        );
+
+        assert!(handler.is_visible());
+        assert!(cleanup.is_empty(), "no cleanup when auto_trigger unchanged");
     }
 
     // --- Debounce suppression tests ---

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -106,6 +106,7 @@ pub struct InputHandler {
     max_visible: usize,
     trigger_chars: HashSet<char>,
     debounce_suppressed: bool,
+    auto_trigger: bool,
     keybindings: Keybindings,
     theme: PopupTheme,
     dynamic_rx: Option<mpsc::Receiver<Vec<Suggestion>>>,
@@ -129,6 +130,7 @@ impl InputHandler {
             max_visible: DEFAULT_MAX_VISIBLE,
             trigger_chars: DEFAULT_TRIGGER_CHARS.iter().copied().collect(),
             debounce_suppressed: false,
+            auto_trigger: true,
             keybindings: Keybindings::default(),
             theme: PopupTheme::default(),
             dynamic_rx: None,
@@ -149,6 +151,11 @@ impl InputHandler {
 
     pub fn with_trigger_chars(mut self, chars: &[char]) -> Self {
         self.trigger_chars = chars.iter().copied().collect();
+        self
+    }
+
+    pub fn with_auto_trigger(mut self, auto_trigger: bool) -> Self {
+        self.auto_trigger = auto_trigger;
         self
     }
 
@@ -197,11 +204,13 @@ impl InputHandler {
         keybindings: Keybindings,
         trigger_chars: &[char],
         max_visible: usize,
+        auto_trigger: bool,
     ) {
         self.theme = theme;
         self.keybindings = keybindings;
         self.trigger_chars = trigger_chars.iter().copied().collect();
         self.max_visible = max_visible;
+        self.auto_trigger = auto_trigger;
     }
 
     #[allow(dead_code)]
@@ -219,6 +228,10 @@ impl InputHandler {
 
     pub fn is_debounce_suppressed(&self) -> bool {
         self.debounce_suppressed
+    }
+
+    pub fn auto_trigger_enabled(&self) -> bool {
+        self.auto_trigger
     }
 
     /// Process a single key event. Returns the raw bytes to forward to the PTY,
@@ -401,7 +414,7 @@ impl InputHandler {
             KeyEvent::Printable(c) => {
                 self.debounce_suppressed = false;
                 let forward = vec![*c as u8];
-                if self.trigger_chars.contains(c) {
+                if self.auto_trigger && self.trigger_chars.contains(c) {
                     // Defer trigger to Task B after shell processes the keystroke
                     self.trigger_requested = true;
                 }
@@ -861,6 +874,7 @@ mod tests {
             max_visible: DEFAULT_MAX_VISIBLE,
             trigger_chars: DEFAULT_TRIGGER_CHARS.iter().copied().collect(),
             debounce_suppressed: false,
+            auto_trigger: true,
             keybindings: Keybindings::default(),
             theme: PopupTheme::default(),
             dynamic_rx: None,
@@ -1227,7 +1241,7 @@ mod tests {
             borders: true,
         };
 
-        handler.update_config(new_theme, Keybindings::default(), &[' ', '/'], 15);
+        handler.update_config(new_theme, Keybindings::default(), &[' ', '/'], 15, true);
 
         assert_eq!(handler.theme.selected_on, vec![0x1B, b'[', b'1', b'm']);
         assert_eq!(handler.theme.description_on, vec![0x1B, b'[', b'2', b'm']);
@@ -1246,7 +1260,7 @@ mod tests {
             trigger: KeyEvent::Tab,
         };
 
-        handler.update_config(PopupTheme::default(), new_kb.clone(), &[' ', '/'], 10);
+        handler.update_config(PopupTheme::default(), new_kb.clone(), &[' ', '/'], 10, true);
 
         assert_eq!(handler.keybindings, new_kb);
     }
@@ -1260,6 +1274,7 @@ mod tests {
             Keybindings::default(),
             &['@', '#'],
             20,
+            true,
         );
 
         assert_eq!(handler.max_visible, 20);
@@ -1274,6 +1289,7 @@ mod tests {
             Keybindings::default(),
             &['@', '#', '!'],
             10,
+            true,
         );
 
         let expected: HashSet<char> = ['@', '#', '!'].iter().copied().collect();

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -1296,6 +1296,57 @@ mod tests {
         assert_eq!(handler.trigger_chars, expected);
     }
 
+    // --- auto_trigger tests ---
+
+    #[test]
+    fn test_auto_trigger_false_suppresses_trigger_on_space() {
+        let mut handler = make_handler().with_auto_trigger(false);
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        handler.process_key(&KeyEvent::Printable(' '), &parser, &mut buf);
+        assert!(!handler.has_pending_trigger());
+    }
+
+    #[test]
+    fn test_auto_trigger_false_allows_manual_trigger() {
+        let mut handler = make_handler().with_auto_trigger(false);
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        handler.process_key(&KeyEvent::CtrlSlash, &parser, &mut buf);
+        // Manual trigger fires immediately — not gated by auto_trigger
+        assert!(!handler.has_pending_trigger());
+    }
+
+    #[test]
+    fn test_auto_trigger_false_suppresses_trigger_on_all_auto_chars() {
+        let mut handler = make_handler().with_auto_trigger(false);
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        for c in [' ', '/', '-', '.'] {
+            handler.process_key(&KeyEvent::Printable(c), &parser, &mut buf);
+            assert!(
+                !handler.has_pending_trigger(),
+                "auto_trigger=false should suppress trigger on '{c}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_update_config_sets_auto_trigger_false() {
+        let mut handler = make_handler();
+        assert!(handler.auto_trigger_enabled());
+
+        handler.update_config(
+            PopupTheme::default(),
+            Keybindings::default(),
+            &[' ', '/', '-', '.'],
+            10,
+            false,
+        );
+
+        assert!(!handler.auto_trigger_enabled());
+    }
+
     // --- Debounce suppression tests ---
 
     #[test]

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -352,7 +352,10 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     if h.has_pending_trigger() {
                         h.clear_trigger_request();
                         h.trigger(&parser_for_stdout, &mut render_buf);
-                    } else if delay_ms > 0 && h.auto_trigger_enabled() && !h.is_debounce_suppressed() {
+                    } else if delay_ms > 0
+                        && h.auto_trigger_enabled()
+                        && !h.is_debounce_suppressed()
+                    {
                         debounce_notify_b.notify_one();
                     }
                 }

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -351,7 +351,9 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     let mut h = handler_for_stdout.lock().unwrap();
                     if h.has_pending_trigger() {
                         h.clear_trigger_request();
-                        h.trigger(&parser_for_stdout, &mut render_buf);
+                        if h.auto_trigger_enabled() {
+                            h.trigger(&parser_for_stdout, &mut render_buf);
+                        }
                     } else if delay_ms > 0
                         && h.auto_trigger_enabled()
                         && !h.is_debounce_suppressed()
@@ -366,8 +368,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            // CD chaining: auto-trigger suggestions when CWD changes (OSC 7).
-            // No has_pending_trigger() gate — CWD change is unconditional.
+            // CD chaining: trigger suggestions on CWD change (OSC 7), gated by auto_trigger.
             let cwd_dirty = {
                 let mut p = parser_for_stdout.lock().unwrap();
                 p.state_mut().take_cwd_dirty()
@@ -506,7 +507,7 @@ async fn debounce_loop(
                     continue;
                 }
             };
-            if h.is_debounce_suppressed() {
+            if h.is_debounce_suppressed() || !h.auto_trigger_enabled() {
                 continue;
             }
             h.trigger(&parser, &mut render_buf);

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -377,7 +377,9 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 let mut render_buf = Vec::new();
                 {
                     let mut h = handler_for_stdout.lock().unwrap();
-                    h.trigger(&parser_for_stdout, &mut render_buf);
+                    if h.auto_trigger_enabled() {
+                        h.trigger(&parser_for_stdout, &mut render_buf);
+                    }
                 }
                 if !render_buf.is_empty() {
                     let mut stdout = std::io::stdout().lock();

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -172,6 +172,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             .with_theme(theme)
             .with_popup_config(config.popup.max_visible)
             .with_trigger_chars(&config.trigger.auto_chars)
+            .with_auto_trigger(config.trigger.auto_trigger)
             .with_suggest_config(
                 config.suggest.max_results,
                 config.suggest.providers.commands,
@@ -351,7 +352,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     if h.has_pending_trigger() {
                         h.clear_trigger_request();
                         h.trigger(&parser_for_stdout, &mut render_buf);
-                    } else if delay_ms > 0 && !h.is_debounce_suppressed() {
+                    } else if delay_ms > 0 && h.auto_trigger_enabled() && !h.is_debounce_suppressed() {
                         debounce_notify_b.notify_one();
                     }
                 }

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -1174,6 +1174,7 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # [trigger]
 # auto_chars = [' ', '/', '-', '.']
 # delay_ms = 150
+# auto_trigger = true  # Set to false to disable all automatic triggers (manual keybinding only)
 
 # [popup]
 # max_visible = 10

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,7 +14,7 @@ Controls when the autocomplete popup appears.
 |-------|------|---------|-------------|
 | `auto_chars` | char[] | `[' ', '/', '-', '.']` | Characters that trigger suggestion after typing |
 | `delay_ms` | integer | `150` | Milliseconds to wait after typing pauses before showing suggestions. Set to `0` to disable debounce (trigger immediately). |
-| `auto_trigger` | boolean | `true` | When `false`, disables all automatic popup triggers (debounce + `auto_chars`). Only the manual keybinding opens the popup. |
+| `auto_trigger` | boolean | `true` | When `false`, disables all automatic popup triggers. Only the manual keybinding opens the popup. |
 
 ```toml
 [trigger]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,11 +14,13 @@ Controls when the autocomplete popup appears.
 |-------|------|---------|-------------|
 | `auto_chars` | char[] | `[' ', '/', '-', '.']` | Characters that trigger suggestion after typing |
 | `delay_ms` | integer | `150` | Milliseconds to wait after typing pauses before showing suggestions. Set to `0` to disable debounce (trigger immediately). |
+| `auto_trigger` | boolean | `true` | When `false`, disables all automatic popup triggers (debounce + `auto_chars`). Only the manual keybinding opens the popup. |
 
 ```toml
 [trigger]
 auto_chars = [' ', '/', '-', '.']
 delay_ms = 150
+auto_trigger = true
 ```
 
 ### `[popup]`
@@ -237,6 +239,7 @@ match_highlight = "underline"
 | `[keybindings]` | All fields | Yes |
 | `[trigger]` | `auto_chars` | Yes |
 | `[trigger]` | `delay_ms` | No |
+| `[trigger]` | `auto_trigger` | Yes |
 | `[popup]` | `max_visible` | Yes |
 | `[suggest]` | All fields | No |
 | `[suggest.providers]` | All fields | No |


### PR DESCRIPTION
## Summary

- Adds `auto_trigger` boolean to `[trigger]` config (defaults `true`, zero breaking changes)
- When `false`, disables ALL automatic popup triggers: debounce timer, `auto_chars`, and CWD change
- Only the manual keybinding (default Ctrl+/) opens the popup
- Hot-reloadable via config file watcher — toggle without restarting

Closes #63

## Behavior Matrix

| `auto_trigger` | Typing auto_char | Typing then pause | Manual trigger | CWD change |
|---|---|---|---|---|
| `true` (default) | ✅ popup | ✅ popup | ✅ popup | ✅ popup |
| `false` | ❌ no popup | ❌ no popup | ✅ popup | ❌ no popup |

## Changes

- `gc-config`: New `auto_trigger: bool` field on `TriggerConfig` + 2 tests
- `gc-pty/handler.rs`: Field, builder, getter, hot-reload, gates `auto_chars` in `process_key_hidden()`
- `gc-pty/proxy.rs`: Gates debounce notification and CWD change trigger on `auto_trigger_enabled()`
- `gc-pty/config_watch.rs`: Passes `auto_trigger` through hot-reload
- `install.rs`: Default config template updated
- `CONFIGURATION.md`: Documented new field + hot-reload support

## Config Example

```toml
[trigger]
auto_trigger = false  # manual keybinding only

[keybindings]
trigger = "ctrl+space"  # customize your manual trigger key
```

## Test plan

- [x] 559 tests passing
- [x] clippy clean
- [x] rustfmt clean
- [x] `ghost-complete config` shows `auto_trigger = true`
- [x] Manual test: `auto_trigger = false` → typing produces no popup
- [x] Manual test: `auto_trigger = false` → Ctrl+/ opens popup
- [x] Manual test: `auto_trigger = false` → CWD change produces no popup
- [x] Manual test: hot-reload toggle works without restart