### PR TITLE
fix: CPR coordination via FIFO queue + RPROMPT widget chaining (#64)

### DIFF
--- a/crates/gc-parser/src/lib.rs
+++ b/crates/gc-parser/src/lib.rs
@@ -6,7 +6,7 @@
 mod performer;
 mod state;
 
-pub use state::TerminalState;
+pub use state::{CprOwner, CprToken, TerminalState};
 
 /// Wraps `vte::Parser` and `TerminalState` into a single unit.
 ///

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -114,9 +114,13 @@ impl Perform for TerminalState {
             // `CSI row;col R`. Enqueue with `CprOwner::Shell` so Task A
             // forwards the response back to the program inside the PTY
             // that asked for it. Other DSR variants (e.g. CSI 5n) do not
-            // produce a CPR response and must NOT enqueue.
+            // produce a CPR response and must NOT enqueue. The local
+            // intermediates guard is defensive: the blanket-discard
+            // above already drops sequences with intermediates, but
+            // scoping the check here keeps DEC private DSR (`CSI ? 6n`)
+            // safe even if the outer filter is ever relocated.
             'n' => {
-                if csi_param(params, 0, 0) == 6 {
+                if intermediates.is_empty() && csi_param(params, 0, 0) == 6 {
                     self.enqueue_cpr(CprOwner::Shell);
                 }
             }

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -109,6 +109,17 @@ impl Perform for TerminalState {
             // ANSI save/restore cursor (SCO sequences)
             's' => self.save_cursor(),
             'u' => self.restore_cursor(),
+            // DSR — Device Status Report. Param 6 is "report cursor
+            // position" (CSI 6n); the terminal will reply with
+            // `CSI row;col R`. Enqueue with `CprOwner::Shell` so Task A
+            // forwards the response back to the program inside the PTY
+            // that asked for it. Other DSR variants (e.g. CSI 5n) do not
+            // produce a CPR response and must NOT enqueue.
+            'n' => {
+                if csi_param(params, 0, 0) == 6 {
+                    self.enqueue_cpr(crate::state::CprOwner::Shell);
+                }
+            }
             _ => {}
         }
     }
@@ -999,5 +1010,32 @@ mod tests {
         let mut p = make_parser();
         p.process_bytes(&seq);
         assert_eq!(p.state().command_buffer(), Some("café"));
+    }
+
+    // -- CPR auto-enqueue on CSI 6n --
+
+    #[test]
+    fn csi_6n_enqueues_shell() {
+        let mut p = make_parser();
+        assert_eq!(p.state().cpr_queue_len(), 0);
+        p.process_bytes(b"\x1b[6n");
+        assert_eq!(p.state().cpr_queue_len(), 1);
+        assert_eq!(p.state_mut().claim_next_cpr(), Some(crate::CprOwner::Shell));
+    }
+
+    #[test]
+    fn csi_5n_does_not_enqueue() {
+        let mut p = make_parser();
+        p.process_bytes(b"\x1b[5n");
+        assert_eq!(p.state().cpr_queue_len(), 0);
+    }
+
+    #[test]
+    fn multiple_csi_6n_each_enqueue() {
+        let mut p = make_parser();
+        p.process_bytes(b"\x1b[6n\x1b[6n");
+        assert_eq!(p.state().cpr_queue_len(), 2);
+        assert_eq!(p.state_mut().claim_next_cpr(), Some(crate::CprOwner::Shell));
+        assert_eq!(p.state_mut().claim_next_cpr(), Some(crate::CprOwner::Shell));
     }
 }

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use unicode_width::UnicodeWidthChar;
 use vte::Perform;
 
-use crate::state::TerminalState;
+use crate::state::{CprOwner, TerminalState};
 
 /// Helper: extract the first value from a CSI param subslice, or return the given default.
 fn csi_param(params: &vte::Params, index: usize, default: u16) -> u16 {
@@ -117,7 +117,7 @@ impl Perform for TerminalState {
             // produce a CPR response and must NOT enqueue.
             'n' => {
                 if csi_param(params, 0, 0) == 6 {
-                    self.enqueue_cpr(crate::state::CprOwner::Shell);
+                    self.enqueue_cpr(CprOwner::Shell);
                 }
             }
             _ => {}
@@ -1037,5 +1037,15 @@ mod tests {
         assert_eq!(p.state().cpr_queue_len(), 2);
         assert_eq!(p.state_mut().claim_next_cpr(), Some(crate::CprOwner::Shell));
         assert_eq!(p.state_mut().claim_next_cpr(), Some(crate::CprOwner::Shell));
+    }
+
+    #[test]
+    fn csi_private_6n_does_not_enqueue() {
+        // CSI ? 6n is DEC private DSR — carries an intermediate byte `?`.
+        // The blanket-discard at the top of csi_dispatch drops it before
+        // the 'n' arm fires, so no Shell entry should be enqueued.
+        let mut p = make_parser();
+        p.process_bytes(b"\x1b[?6n");
+        assert_eq!(p.state().cpr_queue_len(), 0);
     }
 }

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -194,12 +194,19 @@ impl TerminalState {
     }
 
     /// Remove the entry identified by `token` if it is still pending.
-    /// Returns `true` if an entry was removed, `false` if the token had
-    /// already been claimed (or never existed). Used by Task B to undo a
-    /// queued `Ours` entry when the corresponding `CSI 6n` write fails —
-    /// without rollback, the orphan entry would shift dispatch alignment
-    /// for every subsequent CPR until pruned.
+    /// Returns `true` if the entry was removed, `false` if it was already
+    /// claimed by [`Self::claim_next_cpr`] before rollback could run
+    /// (i.e., the response arrived after the write-failure was triggered
+    /// but before Task B reached this code path).
+    ///
+    /// Used by Task B to undo a queued `Ours` entry when the corresponding
+    /// `CSI 6n` write fails — without rollback, the orphan would shift
+    /// dispatch alignment for every subsequent CPR until pruned.
     pub fn rollback_cpr(&mut self, token: CprToken) -> bool {
+        // Queue depth is bounded 0–2 in practice (one Ours + one Shell
+        // in flight at most). VecDeque::remove is O(n) on the slice,
+        // but n is negligible here and rollback is off the hot path —
+        // it fires only on stdout write/flush failure.
         if let Some(pos) = self.cpr_queue.iter().position(|e| e.id == token.0) {
             self.cpr_queue.remove(pos);
             true

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -1,4 +1,29 @@
+use std::collections::VecDeque;
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// Origin of a pending CPR (Cursor Position Report) request. Used by the
+/// proxy to decide whether an incoming `CSI row;col R` response should be
+/// consumed for ghost-complete's own cursor sync (`Ours`) or forwarded to
+/// the program inside the PTY that asked for it (`Shell`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CprOwner {
+    Ours,
+    Shell,
+}
+
+/// Opaque handle returned by [`TerminalState::enqueue_cpr`]. Pass it to
+/// [`TerminalState::rollback_cpr`] when a `CSI 6n` write fails partway so
+/// the queued entry is removed without corrupting dispatch alignment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CprToken(u64);
+
+#[derive(Debug)]
+struct CprEntry {
+    owner: CprOwner,
+    id: u64,
+    enqueued_at: Instant,
+}
 
 /// Tracks terminal state derived from the VT escape sequence stream.
 ///
@@ -21,30 +46,18 @@ pub struct TerminalState {
     cwd_dirty: bool,
     cursor_sync_requested: bool,
     cpr_synced: bool,
-    /// Count of outstanding CPR (Cursor Position Report) requests that
-    /// ghost-complete itself sent, so Task A can distinguish "our" CPR
-    /// responses (consume for cursor sync) from responses belonging to a
-    /// program running inside the PTY like atuin/crossterm (forward to PTY).
+    /// FIFO queue of pending CPR requests in send-order.
     ///
-    /// Access pattern (see `gc-pty/src/proxy.rs`):
-    /// - **Writer:** Task B (PTY → stdout) calls `increment_cpr_pending`
-    ///   strictly BEFORE writing `CSI 6n` to stdout. This ordering matters —
-    ///   Phase 2 MED-15 fix. If Task B incremented AFTER the flush, a fast
-    ///   terminal could reply before Task A saw a pending count, and Task A
-    ///   would forward our own CPR response into the PTY, corrupting the
-    ///   cursor sync cycle.
-    /// - **Reader:** Task A (stdin → PTY) calls `claim_cpr_response` when a
-    ///   CPR arrives from the real terminal. A non-zero count means the
-    ///   response is ours; Task A decrements and consumes it. A zero count
-    ///   means the response belongs to a PTY program and should be forwarded.
-    /// - **Rollback writer:** Task B also calls `claim_cpr_response` on a
-    ///   failed write/flush to undo its own increment, because no response
-    ///   will ever arrive and a permanent leak would make Task A steal the
-    ///   next legitimate application CPR.
-    ///
-    /// External code (any crate other than `gc-pty::proxy`) must not touch
-    /// these helpers — the three call sites above are the entire contract.
-    cpr_pending: u8,
+    /// Terminals respond to `CSI 6n` requests in the same order they
+    /// receive them. The queue head is therefore the owner of the next
+    /// `CSI row;col R` response that will arrive on stdin. Task B pushes
+    /// when it sends or observes a request; Task A pops the head when a
+    /// response arrives. See `gc-pty/src/proxy.rs` for the call sites.
+    cpr_queue: VecDeque<CprEntry>,
+    /// Monotonic counter assigning unique IDs to CPR queue entries so
+    /// `rollback_cpr` can locate and remove an entry even after Task A has
+    /// popped earlier siblings.
+    next_cpr_id: u64,
 }
 
 impl TerminalState {
@@ -64,7 +77,8 @@ impl TerminalState {
             cwd_dirty: false,
             cursor_sync_requested: false,
             cpr_synced: false,
-            cpr_pending: 0,
+            cpr_queue: VecDeque::new(),
+            next_cpr_id: 0,
         }
     }
 
@@ -157,23 +171,10 @@ impl TerminalState {
         synced
     }
 
-    /// Increment the pending CPR counter. Called when ghost-complete sends
-    /// its own `CSI 6n` request so we know to consume the matching response
-    /// rather than forwarding it to the PTY.
-    pub fn increment_cpr_pending(&mut self) {
-        self.cpr_pending = self.cpr_pending.saturating_add(1);
-    }
-
-    /// Try to claim a pending CPR response. Returns `true` if ghost-complete
-    /// has an outstanding CPR request (response should be consumed), `false`
-    /// if the response belongs to a program inside the PTY (should be forwarded).
-    pub fn claim_cpr_response(&mut self) -> bool {
-        if self.cpr_pending > 0 {
-            self.cpr_pending -= 1;
-            true
-        } else {
-            false
-        }
+    /// Number of outstanding CPR requests across both owners. Diagnostics
+    /// and tests only — no dispatch logic should branch on this.
+    pub fn cpr_queue_len(&self) -> usize {
+        self.cpr_queue.len()
     }
 
     /// Override the command buffer with a predicted value (e.g., after Tab
@@ -437,5 +438,11 @@ mod tests {
         let (rows, cols) = state.screen_dimensions();
         assert_eq!(rows, 1);
         assert_eq!(cols, 1);
+    }
+
+    #[test]
+    fn cpr_queue_empty_by_default() {
+        let state = TerminalState::new(24, 80);
+        assert_eq!(state.cpr_queue_len(), 0);
     }
 }

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -171,6 +171,28 @@ impl TerminalState {
         synced
     }
 
+    /// Push a CPR request onto the back of the queue. Returns a token
+    /// usable by [`Self::rollback_cpr`] if the corresponding `CSI 6n`
+    /// write later fails.
+    pub fn enqueue_cpr(&mut self, owner: CprOwner) -> CprToken {
+        let id = self.next_cpr_id;
+        self.next_cpr_id = self.next_cpr_id.wrapping_add(1);
+        self.cpr_queue.push_back(CprEntry {
+            owner,
+            id,
+            enqueued_at: Instant::now(),
+        });
+        CprToken(id)
+    }
+
+    /// Pop the oldest pending CPR entry. The owner identifies whether the
+    /// matching response should be consumed locally (`Ours`) or forwarded
+    /// to the PTY (`Shell`). Returns `None` if no request is outstanding —
+    /// caller should log defensively and forward to the PTY in that case.
+    pub fn claim_next_cpr(&mut self) -> Option<CprOwner> {
+        self.cpr_queue.pop_front().map(|e| e.owner)
+    }
+
     /// Number of outstanding CPR requests across both owners. Diagnostics
     /// and tests only — no dispatch logic should branch on this.
     pub fn cpr_queue_len(&self) -> usize {
@@ -444,5 +466,40 @@ mod tests {
     fn cpr_queue_empty_by_default() {
         let state = TerminalState::new(24, 80);
         assert_eq!(state.cpr_queue_len(), 0);
+    }
+
+    #[test]
+    fn enqueue_then_claim_returns_owner() {
+        let mut state = TerminalState::new(24, 80);
+        state.enqueue_cpr(CprOwner::Ours);
+        assert_eq!(state.cpr_queue_len(), 1);
+        assert_eq!(state.claim_next_cpr(), Some(CprOwner::Ours));
+        assert_eq!(state.cpr_queue_len(), 0);
+    }
+
+    #[test]
+    fn claim_returns_none_when_empty() {
+        let mut state = TerminalState::new(24, 80);
+        assert_eq!(state.claim_next_cpr(), None);
+    }
+
+    #[test]
+    fn interleaved_enqueue_claims_in_fifo_order() {
+        let mut state = TerminalState::new(24, 80);
+        state.enqueue_cpr(CprOwner::Ours);
+        state.enqueue_cpr(CprOwner::Shell);
+        state.enqueue_cpr(CprOwner::Ours);
+        assert_eq!(state.claim_next_cpr(), Some(CprOwner::Ours));
+        assert_eq!(state.claim_next_cpr(), Some(CprOwner::Shell));
+        assert_eq!(state.claim_next_cpr(), Some(CprOwner::Ours));
+        assert_eq!(state.claim_next_cpr(), None);
+    }
+
+    #[test]
+    fn enqueue_returns_unique_tokens() {
+        let mut state = TerminalState::new(24, 80);
+        let a = state.enqueue_cpr(CprOwner::Ours);
+        let b = state.enqueue_cpr(CprOwner::Shell);
+        assert_ne!(a, b);
     }
 }

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -193,6 +193,21 @@ impl TerminalState {
         self.cpr_queue.pop_front().map(|e| e.owner)
     }
 
+    /// Remove the entry identified by `token` if it is still pending.
+    /// Returns `true` if an entry was removed, `false` if the token had
+    /// already been claimed (or never existed). Used by Task B to undo a
+    /// queued `Ours` entry when the corresponding `CSI 6n` write fails —
+    /// without rollback, the orphan entry would shift dispatch alignment
+    /// for every subsequent CPR until pruned.
+    pub fn rollback_cpr(&mut self, token: CprToken) -> bool {
+        if let Some(pos) = self.cpr_queue.iter().position(|e| e.id == token.0) {
+            self.cpr_queue.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Number of outstanding CPR requests across both owners. Diagnostics
     /// and tests only — no dispatch logic should branch on this.
     pub fn cpr_queue_len(&self) -> usize {
@@ -501,5 +516,34 @@ mod tests {
         let a = state.enqueue_cpr(CprOwner::Ours);
         let b = state.enqueue_cpr(CprOwner::Shell);
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn rollback_removes_matching_token() {
+        let mut state = TerminalState::new(24, 80);
+        let token = state.enqueue_cpr(CprOwner::Ours);
+        assert!(state.rollback_cpr(token));
+        assert_eq!(state.cpr_queue_len(), 0);
+    }
+
+    #[test]
+    fn rollback_returns_false_when_already_claimed() {
+        let mut state = TerminalState::new(24, 80);
+        let token = state.enqueue_cpr(CprOwner::Ours);
+        let _ = state.claim_next_cpr();
+        assert!(!state.rollback_cpr(token));
+    }
+
+    #[test]
+    fn rollback_locates_entry_after_earlier_pops() {
+        let mut state = TerminalState::new(24, 80);
+        state.enqueue_cpr(CprOwner::Shell);
+        let target = state.enqueue_cpr(CprOwner::Ours);
+        state.enqueue_cpr(CprOwner::Shell);
+        // Task A pops the first Shell entry.
+        assert_eq!(state.claim_next_cpr(), Some(CprOwner::Shell));
+        assert!(state.rollback_cpr(target));
+        assert_eq!(state.cpr_queue_len(), 1);
+        assert_eq!(state.claim_next_cpr(), Some(CprOwner::Shell));
     }
 }

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -215,6 +215,20 @@ impl TerminalState {
         }
     }
 
+    /// Drop CPR entries whose age exceeds `max_age`. A misbehaving terminal
+    /// can fail to respond to a `CSI 6n`, leaving orphans in the queue
+    /// forever. This is the leak guard — call once per Task B iteration
+    /// with a generous timeout (e.g. 30s, well past z4h's 5s `read -srt 5`
+    /// deadline). Returns the number of entries dropped so the caller can
+    /// emit a `tracing::warn!`.
+    pub fn prune_stale_cpr(&mut self, max_age: Duration) -> usize {
+        let now = Instant::now();
+        let before = self.cpr_queue.len();
+        self.cpr_queue
+            .retain(|e| now.duration_since(e.enqueued_at) < max_age);
+        before - self.cpr_queue.len()
+    }
+
     /// Number of outstanding CPR requests across both owners. Diagnostics
     /// and tests only — no dispatch logic should branch on this.
     pub fn cpr_queue_len(&self) -> usize {
@@ -550,6 +564,30 @@ mod tests {
         // Task A pops the first Shell entry.
         assert_eq!(state.claim_next_cpr(), Some(CprOwner::Shell));
         assert!(state.rollback_cpr(target));
+        assert_eq!(state.cpr_queue_len(), 1);
+        assert_eq!(state.claim_next_cpr(), Some(CprOwner::Shell));
+    }
+
+    #[test]
+    fn prune_stale_drops_zero_when_all_fresh() {
+        let mut state = TerminalState::new(24, 80);
+        state.enqueue_cpr(CprOwner::Ours);
+        state.enqueue_cpr(CprOwner::Shell);
+        let dropped = state.prune_stale_cpr(Duration::from_secs(30));
+        assert_eq!(dropped, 0);
+        assert_eq!(state.cpr_queue_len(), 2);
+    }
+
+    #[test]
+    fn prune_stale_drops_old_entries_only() {
+        let mut state = TerminalState::new(24, 80);
+        state.enqueue_cpr(CprOwner::Ours);
+        // Ensure the first entry is measurably "old" before the second push.
+        std::thread::sleep(Duration::from_millis(15));
+        state.enqueue_cpr(CprOwner::Shell);
+        // Prune anything older than 10ms — should drop only the first.
+        let dropped = state.prune_stale_cpr(Duration::from_millis(10));
+        assert_eq!(dropped, 1);
         assert_eq!(state.cpr_queue_len(), 1);
         assert_eq!(state.claim_next_cpr(), Some(CprOwner::Shell));
     }

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -281,9 +281,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                             let mut p = match parser_for_stdin.lock() {
                                 Ok(p) => p,
                                 Err(e) => {
-                                    tracing::warn!(
-                                        "parser mutex poisoned in stdin task: {e}"
-                                    );
+                                    tracing::warn!("parser mutex poisoned in stdin task: {e}");
                                     break 'stdin;
                                 }
                             };

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -18,6 +18,13 @@ use crate::input::parse_keys;
 use crate::resize::{get_terminal_size, resize_pty};
 use crate::spawn::{spawn_shell, SpawnedShell};
 
+/// Upper bound on how long a queued CPR entry may sit before we prune it.
+/// A misbehaving terminal that silently drops `CSI 6n` would otherwise leak
+/// queue entries forever. A late response after prune lands as
+/// `CprAction::DropEmpty` and is forwarded defensively, which is why the
+/// threshold is generous.
+const CPR_STALE_THRESHOLD: Duration = Duration::from_secs(30);
+
 /// Drop guard that ensures raw mode is always restored, even on panic.
 struct RawModeGuard;
 
@@ -464,13 +471,9 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 break;
             }
 
-            // Safety net: drop entries older than 30s. A misbehaving
-            // terminal that drops a CPR request without responding would
-            // otherwise leak entries indefinitely. 30s is well past
-            // z4h's 5s `read -srt 5` deadline.
             {
                 let dropped = match parser_for_stdout.lock() {
-                    Ok(mut p) => p.state_mut().prune_stale_cpr(Duration::from_secs(30)),
+                    Ok(mut p) => p.state_mut().prune_stale_cpr(CPR_STALE_THRESHOLD),
                     Err(e) => {
                         tracing::warn!("parser mutex poisoned during CPR prune: {e}");
                         0
@@ -851,10 +854,10 @@ mod tests {
 
     #[test]
     fn deferred_sync_reschedules_when_shell_cpr_in_flight() {
-        // Push Shell first (e.g., z4h sent CSI 6n), then Ours (proxy queued
-        // its own request next). The first response goes to Shell, the
-        // second to Ours — never the reverse. This is the bug class
-        // issue #64 exposed.
+        // Push Shell first (e.g., the shell sent CSI 6n), then Ours (proxy
+        // queued its own request next). Responses must dispatch in that
+        // same send-order — never the reverse. This is the bug class the
+        // FIFO ordering fixes.
         let mut p = make_state(24, 80);
         p.state_mut().enqueue_cpr(CprOwner::Shell);
         p.state_mut().enqueue_cpr(CprOwner::Ours);
@@ -883,5 +886,24 @@ mod tests {
             dispatch_cpr_response(p.state_mut(), 5, 5),
             CprAction::ForwardToPty(5, 5)
         );
+    }
+
+    #[test]
+    fn rollback_ours_after_shell_preserves_shell_dispatch() {
+        // Task B enqueues Ours on top of an already-pending Shell entry,
+        // then the stdout write fails before `CSI 6n` reached the terminal.
+        // Rolling back the Ours token must leave the queue with just the
+        // Shell entry, and the next CPR response must still dispatch to
+        // ForwardToPty with no Ours residue.
+        let mut p = make_state(24, 80);
+        p.state_mut().enqueue_cpr(CprOwner::Shell);
+        let ours = p.state_mut().enqueue_cpr(CprOwner::Ours);
+        assert!(p.state_mut().rollback_cpr(ours));
+        assert_eq!(p.state().cpr_queue_len(), 1);
+        assert_eq!(
+            dispatch_cpr_response(p.state_mut(), 7, 3),
+            CprAction::ForwardToPty(7, 3)
+        );
+        assert_eq!(p.state().cpr_queue_len(), 0);
     }
 }

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -269,10 +269,15 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                                 break 'stdin;
                             }
                         };
-                        p.state_mut().claim_next_cpr()
+                        dispatch_cpr_response(p.state_mut(), *row, *col)
                     };
                     match action {
-                        Some(CprOwner::Ours) => {
+                        CprAction::SyncOurs(r, c) => {
+                            // Deliberate re-acquire after the claim-only
+                            // lock above. Narrowing the hold keeps parser
+                            // contention off the dispatch decision; the
+                            // sync below is the only path that needs the
+                            // lock again.
                             let mut p = match parser_for_stdin.lock() {
                                 Ok(p) => p,
                                 Err(e) => {
@@ -283,31 +288,31 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                                 }
                             };
                             let state = p.state_mut();
-                            if state.validate_cpr_coordinates(*row, *col) {
+                            if state.validate_cpr_coordinates(r, c) {
                                 tracing::debug!(
-                                    row,
-                                    col,
+                                    row = r,
+                                    col = c,
                                     "CPR response — syncing cursor position (ours)"
                                 );
-                                state.set_cursor_from_report(*row, *col);
+                                state.set_cursor_from_report(r, c);
                             } else {
                                 let (screen_rows, screen_cols) = state.screen_dimensions();
                                 tracing::warn!(
-                                    row,
-                                    col,
+                                    row = r,
+                                    col = c,
                                     screen_rows,
                                     screen_cols,
                                     "CPR coordinates out of screen bounds — ignoring"
                                 );
                             }
                         }
-                        Some(CprOwner::Shell) => {
+                        CprAction::ForwardToPty(r, c) => {
                             tracing::debug!(
-                                row,
-                                col,
+                                row = r,
+                                col = c,
                                 "CPR response — forwarding to PTY (shell)"
                             );
-                            let cpr = format!("\x1b[{row};{col}R");
+                            let cpr = format!("\x1b[{r};{c}R");
                             if pty_writer.write_all(cpr.as_bytes()).is_err() {
                                 return;
                             }
@@ -315,13 +320,13 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                                 return;
                             }
                         }
-                        None => {
+                        CprAction::DropEmpty(r, c) => {
                             tracing::warn!(
-                                row,
-                                col,
+                                row = r,
+                                col = c,
                                 "CPR response with empty queue — forwarding defensively"
                             );
-                            let cpr = format!("\x1b[{row};{col}R");
+                            let cpr = format!("\x1b[{r};{c}R");
                             if pty_writer.write_all(cpr.as_bytes()).is_err() {
                                 return;
                             }
@@ -439,7 +444,11 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     match parser_for_stdout.lock() {
                         Ok(mut p) => {
                             if !p.state_mut().rollback_cpr(token) {
-                                tracing::warn!(
+                                // Benign race: write reported failure but the
+                                // bytes already reached the terminal, which
+                                // responded; Task A claimed the entry before
+                                // we got here. No orphan, no action needed.
+                                tracing::debug!(
                                     "CPR rollback no-op — entry already claimed by Task A"
                                 );
                             }
@@ -453,7 +462,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         }
                     }
                 }
-                tracing::warn!("Task B stdout write failed: {e}");
+                tracing::debug!("Task B stdout write/flush failed: {e}");
                 break;
             }
 
@@ -747,6 +756,27 @@ pub fn should_fallback_to_shell(
     matches!(terminal, gc_terminal::Terminal::Unknown(_)) && !multi_terminal_enabled
 }
 
+/// Outcome of dispatching a CPR response back through the proxy. Pure
+/// transformation over `TerminalState` — extracted from Task A so the
+/// FIFO ordering invariant can be unit-tested without spawning the
+/// full proxy. Both `ForwardToPty` and `DropEmpty` carry the
+/// coordinates so the caller can re-encode and write to the PTY; the
+/// only difference is whether the empty-queue case warrants a warn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CprAction {
+    SyncOurs(u16, u16),
+    ForwardToPty(u16, u16),
+    DropEmpty(u16, u16),
+}
+
+fn dispatch_cpr_response(state: &mut gc_parser::TerminalState, row: u16, col: u16) -> CprAction {
+    match state.claim_next_cpr() {
+        Some(CprOwner::Ours) => CprAction::SyncOurs(row, col),
+        Some(CprOwner::Shell) => CprAction::ForwardToPty(row, col),
+        None => CprAction::DropEmpty(row, col),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -790,5 +820,70 @@ mod tests {
             &Terminal::Unknown("foot".into()),
             true
         ));
+    }
+
+    use gc_parser::TerminalParser;
+
+    fn make_state(rows: u16, cols: u16) -> TerminalParser {
+        TerminalParser::new(rows, cols)
+    }
+
+    #[test]
+    fn dispatch_with_ours_at_head_syncs() {
+        let mut p = make_state(24, 80);
+        p.state_mut().enqueue_cpr(CprOwner::Ours);
+        let action = dispatch_cpr_response(p.state_mut(), 5, 10);
+        assert_eq!(action, CprAction::SyncOurs(5, 10));
+    }
+
+    #[test]
+    fn dispatch_with_shell_at_head_forwards() {
+        let mut p = make_state(24, 80);
+        p.state_mut().enqueue_cpr(CprOwner::Shell);
+        let action = dispatch_cpr_response(p.state_mut(), 3, 7);
+        assert_eq!(action, CprAction::ForwardToPty(3, 7));
+    }
+
+    #[test]
+    fn dispatch_with_empty_queue_returns_drop() {
+        let mut p = make_state(24, 80);
+        let action = dispatch_cpr_response(p.state_mut(), 1, 1);
+        assert_eq!(action, CprAction::DropEmpty(1, 1));
+    }
+
+    #[test]
+    fn deferred_sync_reschedules_when_shell_cpr_in_flight() {
+        // Push Shell first (e.g., z4h sent CSI 6n), then Ours (proxy queued
+        // its own request next). The first response goes to Shell, the
+        // second to Ours — never the reverse. This is the bug class
+        // issue #64 exposed.
+        let mut p = make_state(24, 80);
+        p.state_mut().enqueue_cpr(CprOwner::Shell);
+        p.state_mut().enqueue_cpr(CprOwner::Ours);
+        assert_eq!(
+            dispatch_cpr_response(p.state_mut(), 1, 1),
+            CprAction::ForwardToPty(1, 1)
+        );
+        assert_eq!(
+            dispatch_cpr_response(p.state_mut(), 2, 2),
+            CprAction::SyncOurs(2, 2)
+        );
+    }
+
+    #[test]
+    fn shell_cpr_arrives_while_our_cpr_pending() {
+        // Reverse order: proxy queued Ours first, then a shell program
+        // sent CSI 6n. Responses must dispatch in that same order.
+        let mut p = make_state(24, 80);
+        p.state_mut().enqueue_cpr(CprOwner::Ours);
+        p.state_mut().enqueue_cpr(CprOwner::Shell);
+        assert_eq!(
+            dispatch_cpr_response(p.state_mut(), 4, 4),
+            CprAction::SyncOurs(4, 4)
+        );
+        assert_eq!(
+            dispatch_cpr_response(p.state_mut(), 5, 5),
+            CprAction::ForwardToPty(5, 5)
+        );
     }
 }

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -1,8 +1,9 @@
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
-use gc_parser::TerminalParser;
+use gc_parser::{CprOwner, TerminalParser};
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::{mpsc, Notify};
 
@@ -260,50 +261,74 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 // it for cursor sync. Otherwise forward it through the
                 // PTY so programs like atuin/crossterm receive it.
                 if let crate::input::KeyEvent::CursorPositionReport(row, col) = key {
-                    let mut p = match parser_for_stdin.lock() {
-                        Ok(p) => p,
-                        Err(e) => {
-                            tracing::warn!("parser mutex poisoned in stdin task: {e}");
-                            break 'stdin;
-                        }
+                    let action = {
+                        let mut p = match parser_for_stdin.lock() {
+                            Ok(p) => p,
+                            Err(e) => {
+                                tracing::warn!("parser mutex poisoned in stdin task: {e}");
+                                break 'stdin;
+                            }
+                        };
+                        p.state_mut().claim_next_cpr()
                     };
-                    if p.state_mut().claim_cpr_response() {
-                        let state = p.state_mut();
-                        if state.validate_cpr_coordinates(*row, *col) {
+                    match action {
+                        Some(CprOwner::Ours) => {
+                            let mut p = match parser_for_stdin.lock() {
+                                Ok(p) => p,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "parser mutex poisoned in stdin task: {e}"
+                                    );
+                                    break 'stdin;
+                                }
+                            };
+                            let state = p.state_mut();
+                            if state.validate_cpr_coordinates(*row, *col) {
+                                tracing::debug!(
+                                    row,
+                                    col,
+                                    "CPR response — syncing cursor position (ours)"
+                                );
+                                state.set_cursor_from_report(*row, *col);
+                            } else {
+                                let (screen_rows, screen_cols) = state.screen_dimensions();
+                                tracing::warn!(
+                                    row,
+                                    col,
+                                    screen_rows,
+                                    screen_cols,
+                                    "CPR coordinates out of screen bounds — ignoring"
+                                );
+                            }
+                        }
+                        Some(CprOwner::Shell) => {
                             tracing::debug!(
                                 row,
                                 col,
-                                "CPR response — syncing cursor position (ours)"
+                                "CPR response — forwarding to PTY (shell)"
                             );
-                            state.set_cursor_from_report(*row, *col);
-                        } else {
-                            let (screen_rows, screen_cols) = state.screen_dimensions();
+                            let cpr = format!("\x1b[{row};{col}R");
+                            if pty_writer.write_all(cpr.as_bytes()).is_err() {
+                                return;
+                            }
+                            if pty_writer.flush().is_err() {
+                                return;
+                            }
+                        }
+                        None => {
                             tracing::warn!(
                                 row,
                                 col,
-                                screen_rows,
-                                screen_cols,
-                                "CPR coordinates out of screen bounds — ignoring"
+                                "CPR response with empty queue — forwarding defensively"
                             );
-                            // Do NOT retry with a new CSI 6n: we can't tell if
-                            // this was the terminal's real response (resize race)
-                            // or an injected fake. Retrying would send a CSI 6n
-                            // whose response may have no matching cpr_pending,
-                            // leaking an unsolicited CPR into the PTY. Instead,
-                            // accept the temporary cursor desync — the next
-                            // prompt (OSC 133) triggers a fresh sync cycle.
+                            let cpr = format!("\x1b[{row};{col}R");
+                            if pty_writer.write_all(cpr.as_bytes()).is_err() {
+                                return;
+                            }
+                            if pty_writer.flush().is_err() {
+                                return;
+                            }
                         }
-                        continue;
-                    }
-                    tracing::debug!(row, col, "CPR response — forwarding to PTY (not ours)");
-                    drop(p);
-                    // Re-encode as CSI row;col R and forward to PTY
-                    let cpr = format!("\x1b[{row};{col}R");
-                    if pty_writer.write_all(cpr.as_bytes()).is_err() {
-                        return;
-                    }
-                    if pty_writer.flush().is_err() {
-                        return;
                     }
                     continue;
                 }
@@ -369,42 +394,29 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 p.state_mut().take_cursor_sync_requested()
             };
 
-            // Briefly lock stdout for each write — do NOT hold the lock
-            // across the entire loop or it deadlocks with Task A.
-            //
-            // CPR accounting invariant: cpr_pending must be incremented
-            // if and only if a corresponding CSI 6n was successfully
-            // flushed to the terminal. Violating this in either direction
-            // causes cursor-sync corruption — under-counting makes Task A
-            // forward our own CPR response to the PTY, over-counting makes
-            // Task A steal the next application CPR response.
-            //
-            // Lock ordering: acquire the parser mutex and drop it BEFORE
-            // taking the stdout lock. A nested (stdout → parser) path is a
-            // latent deadlock trap for any future code that legitimately
-            // takes parser then stdout. cpr_pending is a counter, so
-            // incrementing earlier (before the main buffer write) is
-            // semantically equivalent — Task A always decrements on the
-            // matching CPR response, and we roll back on write failure.
-            let mut cpr_incremented = false;
-            if needs_cpr {
+            // Lock ordering: take the parser lock to enqueue Ours, drop
+            // it BEFORE acquiring stdout. Task A holds parser briefly to
+            // pop the queue head; nesting (stdout → parser) here would
+            // deadlock the moment Task A tried to acquire parser while
+            // Task B held stdout.
+            let cpr_token = if needs_cpr {
                 match parser_for_stdout.lock() {
-                    Ok(mut p) => {
-                        p.state_mut().increment_cpr_pending();
-                        cpr_incremented = true;
-                    }
+                    Ok(mut p) => Some(p.state_mut().enqueue_cpr(CprOwner::Ours)),
                     Err(e) => {
                         tracing::warn!(
-                            "parser mutex poisoned before CPR increment: {e} \
+                            "parser mutex poisoned before CPR enqueue: {e} \
                              — skipping CPR"
                         );
+                        None
                     }
                 }
-            }
-            // If we couldn't increment (poisoned mutex), don't emit the
-            // CSI 6n — under-counting cpr_pending would make Task A
+            } else {
+                None
+            };
+            // If we couldn't enqueue (poisoned mutex), don't emit the
+            // CSI 6n — sending without a queue entry would make Task A
             // forward our response to the PTY.
-            let send_cpr = needs_cpr && cpr_incremented;
+            let send_cpr = cpr_token.is_some();
 
             let write_result: std::io::Result<()> = {
                 let mut stdout = std::io::stdout().lock();
@@ -419,38 +431,47 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             };
 
             if let Err(e) = write_result {
-                // Rollback the CPR increment if the write/flush failed
-                // partway through — the CSI 6n did not reach the terminal
-                // (or at least can't be guaranteed to have reached it) so
-                // no response will arrive. A permanent leak here would
-                // make Task A steal the next application CPR response.
-                if cpr_incremented {
+                // Rollback: the CSI 6n didn't reach the terminal (or we
+                // can't prove it did), so no response will arrive. Remove
+                // the orphan entry before it shifts dispatch alignment
+                // for every subsequent CPR.
+                if let Some(token) = cpr_token {
                     match parser_for_stdout.lock() {
                         Ok(mut p) => {
-                            // claim_cpr_response decrements cpr_pending.
-                            p.state_mut().claim_cpr_response();
+                            if !p.state_mut().rollback_cpr(token) {
+                                tracing::warn!(
+                                    "CPR rollback no-op — entry already claimed by Task A"
+                                );
+                            }
                         }
                         Err(poison_err) => {
-                            // If the rollback lock itself fails we can't
-                            // recover — the parser mutex is poisoned AND
-                            // cpr_pending is permanently elevated by 1,
-                            // which would make Task A steal the next real
-                            // application CPR response (from atuin,
-                            // crossterm, etc.) and corrupt downstream
-                            // parsing. Proxy state is corrupted; cascade
-                            // into the same break pattern as the parser
-                            // mutex poison sites earlier in this loop and
-                            // exit Task B immediately.
                             tracing::error!(
                                 "parser mutex poisoned during CPR rollback: {poison_err} \
-                                 — cpr_pending permanently elevated, exiting Task B"
+                                 — orphan entry leaked, exiting Task B"
                             );
                             break;
                         }
                     }
                 }
-                tracing::debug!("stdout write/flush failed: {e}");
+                tracing::warn!("Task B stdout write failed: {e}");
                 break;
+            }
+
+            // Safety net: drop entries older than 30s. A misbehaving
+            // terminal that drops a CPR request without responding would
+            // otherwise leak entries indefinitely. 30s is well past
+            // z4h's 5s `read -srt 5` deadline.
+            {
+                let dropped = match parser_for_stdout.lock() {
+                    Ok(mut p) => p.state_mut().prune_stale_cpr(Duration::from_secs(30)),
+                    Err(e) => {
+                        tracing::warn!("parser mutex poisoned during CPR prune: {e}");
+                        0
+                    }
+                };
+                if dropped > 0 {
+                    tracing::warn!(dropped, "pruned stale CPR queue entries");
+                }
             }
 
             // Check if shell reported a buffer update via OSC 7770.

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -74,16 +74,21 @@ _gc_report_buffer() {
 _gc_install_zle_hook() {
     # Idempotent: skip if our wrapper or the direct-install fallback is
     # already in place. The two exact strings correspond to the two
-    # branches below — anything else falls through to re-install.
+    # install branches below — anything else falls through to re-evaluate.
     local current="${widgets[zle-line-pre-redraw]:-}"
     if [[ "$current" == "user:_gc_zle_line_pre_redraw" || "$current" == "user:_gc_report_buffer" ]]; then
         return
     fi
-    # Only chain when the existing registration is a plain user widget.
-    # `completion:` / `builtin:` prefixes don't survive `${existing#user:}`
-    # cleanly, and `zle -N` with the prefix baked in produces a nonsense
-    # widget name — safer to direct-install and accept the lost hook.
-    if (( ${+widgets[zle-line-pre-redraw]} )) && [[ "${widgets[zle-line-pre-redraw]}" == user:* ]]; then
+    # Three-way dispatch:
+    #   1. No widget registered         → direct-install _gc_report_buffer.
+    #   2. Existing plain user widget   → chain over it so $WIDGET is preserved.
+    #   3. Existing non-user widget
+    #      (completion:/builtin:/…)     → leave it alone. We can't chain a
+    #      non-user widget safely, and silently clobbering someone else's
+    #      registration is worse than losing our buffer hook.
+    if (( ! ${+widgets[zle-line-pre-redraw]} )); then
+        zle -N zle-line-pre-redraw _gc_report_buffer
+    elif [[ "${widgets[zle-line-pre-redraw]}" == user:* ]]; then
         local existing="${widgets[zle-line-pre-redraw]}"
         zle -N _gc_orig_zle_line_pre_redraw "${existing#user:}"
         _gc_zle_line_pre_redraw() {
@@ -91,9 +96,9 @@ _gc_install_zle_hook() {
             zle _gc_orig_zle_line_pre_redraw -- "$@"
         }
         zle -N zle-line-pre-redraw _gc_zle_line_pre_redraw
-    else
-        zle -N zle-line-pre-redraw _gc_report_buffer
     fi
+    # Non-user widget: intentionally no-op. Ghost Complete loses its buffer
+    # hook in this case; that's acceptable degradation.
 }
 
 _gc_install_zle_hook

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -66,5 +66,28 @@ _gc_report_buffer() {
     printf '\e]7770;%d;%s\a' "$CURSOR" "$BUFFER"
 }
 
-autoload -Uz add-zle-hook-widget
-add-zle-hook-widget line-pre-redraw _gc_report_buffer
+# Chain into the existing zle-line-pre-redraw widget without using
+# add-zle-hook-widget: its dispatcher renames $WIDGET to
+# `azhw:zle-line-pre-redraw`, breaking frameworks (z4h, p10k) that key
+# behavior off $WIDGET inside the hook (e.g., z4h's _zsh_highlight()
+# guard for the post-Enter prompt render).
+_gc_install_zle_hook() {
+    # Idempotent: skip if our wrapper is already installed.
+    if [[ "${widgets[zle-line-pre-redraw]:-}" == *_gc_zle_line_pre_redraw* ]]; then
+        return
+    fi
+    if (( ${+widgets[zle-line-pre-redraw]} )); then
+        local existing="${widgets[zle-line-pre-redraw]}"
+        zle -N _gc_orig_zle_line_pre_redraw "${existing#user:}"
+        _gc_zle_line_pre_redraw() {
+            _gc_report_buffer
+            zle _gc_orig_zle_line_pre_redraw -- "$@"
+        }
+        zle -N zle-line-pre-redraw _gc_zle_line_pre_redraw
+    else
+        zle -N zle-line-pre-redraw _gc_report_buffer
+    fi
+}
+
+_gc_install_zle_hook
+unset -f _gc_install_zle_hook

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -73,13 +73,17 @@ _gc_report_buffer() {
 # guard for the post-Enter prompt render).
 _gc_install_zle_hook() {
     # Idempotent: skip if our wrapper or the direct-install fallback is
-    # already in place. The two patterns correspond to the two branches
-    # below — both leave a recognizable signature in widgets[].
+    # already in place. The two exact strings correspond to the two
+    # branches below — anything else falls through to re-install.
     local current="${widgets[zle-line-pre-redraw]:-}"
-    if [[ "$current" == *_gc_zle_line_pre_redraw* || "$current" == *_gc_report_buffer* ]]; then
+    if [[ "$current" == "user:_gc_zle_line_pre_redraw" || "$current" == "user:_gc_report_buffer" ]]; then
         return
     fi
-    if (( ${+widgets[zle-line-pre-redraw]} )); then
+    # Only chain when the existing registration is a plain user widget.
+    # `completion:` / `builtin:` prefixes don't survive `${existing#user:}`
+    # cleanly, and `zle -N` with the prefix baked in produces a nonsense
+    # widget name — safer to direct-install and accept the lost hook.
+    if (( ${+widgets[zle-line-pre-redraw]} )) && [[ "${widgets[zle-line-pre-redraw]}" == user:* ]]; then
         local existing="${widgets[zle-line-pre-redraw]}"
         zle -N _gc_orig_zle_line_pre_redraw "${existing#user:}"
         _gc_zle_line_pre_redraw() {

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -72,8 +72,11 @@ _gc_report_buffer() {
 # behavior off $WIDGET inside the hook (e.g., z4h's _zsh_highlight()
 # guard for the post-Enter prompt render).
 _gc_install_zle_hook() {
-    # Idempotent: skip if our wrapper is already installed.
-    if [[ "${widgets[zle-line-pre-redraw]:-}" == *_gc_zle_line_pre_redraw* ]]; then
+    # Idempotent: skip if our wrapper or the direct-install fallback is
+    # already in place. The two patterns correspond to the two branches
+    # below — both leave a recognizable signature in widgets[].
+    local current="${widgets[zle-line-pre-redraw]:-}"
+    if [[ "$current" == *_gc_zle_line_pre_redraw* || "$current" == *_gc_report_buffer* ]]; then
         return
     fi
     if (( ${+widgets[zle-line-pre-redraw]} )); then

--- a/tests/shell/test_zle_chaining.zsh
+++ b/tests/shell/test_zle_chaining.zsh
@@ -1,0 +1,90 @@
+#!/usr/bin/env zsh
+# Verifies the manual zle-line-pre-redraw chaining in shell/ghost-complete.zsh
+# preserves $WIDGET when the wrapper executes — the property z4h relies on
+# in its _zsh_highlight() guard — and that the install function is
+# idempotent across re-sources.
+#
+# Run: zsh tests/shell/test_zle_chaining.zsh
+#
+# Uses `zsh --no-rcs` for the assertion subshell to isolate the test from
+# any user rc files that may already register widgets via
+# add-zle-hook-widget (which would mask the no-prior-widget branch).
+
+set -euo pipefail
+
+SCRIPT_DIR="${0:A:h}"
+REPO_ROOT="${SCRIPT_DIR:h:h}"
+INTEGRATION="$REPO_ROOT/shell/ghost-complete.zsh"
+
+if [[ ! -f "$INTEGRATION" ]]; then
+    print -u2 "FAIL: $INTEGRATION not found"
+    exit 1
+fi
+
+# --- Test A: chaining branch (a prior widget exists) ---
+zsh --no-rcs -i -c "
+    set -e
+    zmodload zsh/zle
+    _baseline_pre_redraw() { :; }
+    zle -N zle-line-pre-redraw _baseline_pre_redraw
+
+    source '$INTEGRATION'
+
+    # Wrapper is registered under the canonical name.
+    if [[ \"\${widgets[zle-line-pre-redraw]}\" != *_gc_zle_line_pre_redraw* ]]; then
+        print -u2 'FAIL [chain]: zle-line-pre-redraw not bound to _gc_zle_line_pre_redraw'
+        print -u2 \"  actual: \${widgets[zle-line-pre-redraw]}\"
+        exit 1
+    fi
+
+    # Original baseline widget is preserved as _gc_orig.
+    if [[ \"\${widgets[_gc_orig_zle_line_pre_redraw]}\" != *_baseline_pre_redraw* ]]; then
+        print -u2 'FAIL [chain]: original widget not preserved as _gc_orig_zle_line_pre_redraw'
+        print -u2 \"  actual: \${widgets[_gc_orig_zle_line_pre_redraw]:-<unset>}\"
+        exit 1
+    fi
+
+    # Re-sourcing is idempotent: chain stays a single layer deep.
+    source '$INTEGRATION'
+    local count=\$(print -- \"\${widgets[zle-line-pre-redraw]}\" | grep -c _gc_zle_line_pre_redraw || true)
+    if (( count != 1 )); then
+        print -u2 \"FAIL [chain]: re-source produced \${count} chain entries (want 1)\"
+        exit 1
+    fi
+"
+
+# --- Test B: direct-install branch (no prior widget) ---
+zsh --no-rcs -i -c "
+    set -e
+    zmodload zsh/zle
+
+    source '$INTEGRATION'
+
+    # No prior widget existed → _gc_report_buffer registered directly.
+    if [[ \"\${widgets[zle-line-pre-redraw]}\" != *_gc_report_buffer* ]]; then
+        print -u2 'FAIL [direct]: zle-line-pre-redraw not bound to _gc_report_buffer'
+        print -u2 \"  actual: \${widgets[zle-line-pre-redraw]}\"
+        exit 1
+    fi
+
+    # _gc_orig should NOT be created when there was no prior widget.
+    if (( \${+widgets[_gc_orig_zle_line_pre_redraw]} )); then
+        print -u2 'FAIL [direct]: _gc_orig_zle_line_pre_redraw was created unnecessarily'
+        print -u2 \"  actual: \${widgets[_gc_orig_zle_line_pre_redraw]}\"
+        exit 1
+    fi
+
+    # Re-sourcing is idempotent for the direct-install branch too.
+    source '$INTEGRATION'
+    if [[ \"\${widgets[zle-line-pre-redraw]}\" != *_gc_report_buffer* ]]; then
+        print -u2 'FAIL [direct]: re-source mutated the registration'
+        print -u2 \"  actual: \${widgets[zle-line-pre-redraw]}\"
+        exit 1
+    fi
+    if (( \${+widgets[_gc_orig_zle_line_pre_redraw]} )); then
+        print -u2 'FAIL [direct]: re-source created _gc_orig spuriously'
+        exit 1
+    fi
+"
+
+print 'PASS: zle chaining preserves widget identity, idempotent in both branches'

--- a/tests/shell/test_zle_chaining.zsh
+++ b/tests/shell/test_zle_chaining.zsh
@@ -140,4 +140,52 @@ EEOF
     fi
 fi
 
-print 'PASS: zle chaining preserves widget identity, idempotent in both branches'
+# --- Test D: non-user widget is preserved (not silently clobbered) ---
+# When something has already registered a non-user widget at
+# zle-line-pre-redraw (completion:/builtin:/etc.), Ghost Complete must not
+# overwrite that registration. It's safer to lose our buffer hook than to
+# clobber a hook the user or their framework deliberately installed.
+zsh --no-rcs -c "
+    set -e
+    zmodload zsh/zle
+    # zle -C produces a 'completion:<builtin>:<fn>' registration.
+    _baseline_complete() { :; }
+    zle -C zle-line-pre-redraw list-choices _baseline_complete
+
+    orig=\"\${widgets[zle-line-pre-redraw]}\"
+    if [[ \"\$orig\" != completion:* ]]; then
+        print -u2 \"FAIL [preserve]: baseline non-user widget missing; got '\$orig'\"
+        exit 1
+    fi
+
+    source '$INTEGRATION'
+
+    # The original non-user registration must be intact, byte-for-byte.
+    if [[ \"\${widgets[zle-line-pre-redraw]}\" != \"\$orig\" ]]; then
+        print -u2 'FAIL [preserve]: non-user widget was clobbered'
+        print -u2 \"  expected: \$orig\"
+        print -u2 \"  actual: \${widgets[zle-line-pre-redraw]}\"
+        exit 1
+    fi
+
+    # Neither the wrapper nor the direct-install fallback may be bound at
+    # the canonical name — that would mean we clobbered the baseline.
+    if [[ \"\${widgets[zle-line-pre-redraw]}\" == *_gc_zle_line_pre_redraw* ]]; then
+        print -u2 'FAIL [preserve]: _gc_zle_line_pre_redraw was bound at zle-line-pre-redraw'
+        exit 1
+    fi
+    if [[ \"\${widgets[zle-line-pre-redraw]}\" == *_gc_report_buffer* ]]; then
+        print -u2 'FAIL [preserve]: _gc_report_buffer was bound at zle-line-pre-redraw'
+        exit 1
+    fi
+
+    # Re-sourcing must remain a no-op for the non-user case.
+    source '$INTEGRATION'
+    if [[ \"\${widgets[zle-line-pre-redraw]}\" != \"\$orig\" ]]; then
+        print -u2 'FAIL [preserve]: re-source mutated the non-user registration'
+        print -u2 \"  actual: \${widgets[zle-line-pre-redraw]}\"
+        exit 1
+    fi
+"
+
+print 'PASS: zle chaining preserves widget identity, idempotent, and non-user widgets survive'

--- a/tests/shell/test_zle_chaining.zsh
+++ b/tests/shell/test_zle_chaining.zsh
@@ -87,4 +87,57 @@ zsh --no-rcs -c "
     fi
 "
 
+# --- Test C: functional $WIDGET preservation (regression guard for core fix) ---
+# The whole point of manual chaining (vs add-zle-hook-widget) is that when
+# the line editor fires zle-line-pre-redraw, `$WIDGET` inside the chained
+# baseline widget must still read `zle-line-pre-redraw` — not
+# `azhw:zle-line-pre-redraw` and not `_gc_orig_zle_line_pre_redraw`. Drive
+# a real zle session via expect so the line editor itself fires the hook.
+if ! (( ${+commands[expect]} )); then
+    print -u2 'SKIP [functional]: expect(1) not installed; cannot drive zle'
+else
+    DRIVER="$(mktemp -t gc_zle_driver.XXXXXX)"
+    DRIVER_EXP="$(mktemp -t gc_zle_driver_exp.XXXXXX)"
+    WIDGET_OUT="$(mktemp -t gc_zle_widget.XXXXXX)"
+    trap "rm -f '$DRIVER' '$DRIVER_EXP' '$WIDGET_OUT'" EXIT
+
+    cat >"$DRIVER" <<ZEOF
+#!/usr/bin/env zsh
+set -e
+zmodload zsh/zle
+typeset -g CAPTURED_WIDGET="<unset>"
+_baseline_pre_redraw() { CAPTURED_WIDGET="\$WIDGET" }
+zle -N zle-line-pre-redraw _baseline_pre_redraw
+source '$INTEGRATION'
+_exit_line() { zle .accept-line }
+zle -N _exit_line
+bindkey ' ' _exit_line
+typeset -g FOO=""
+vared -p "" FOO
+print -- "\$CAPTURED_WIDGET" > '$WIDGET_OUT'
+ZEOF
+
+    cat >"$DRIVER_EXP" <<'EEOF'
+#!/usr/bin/expect -f
+log_user 0
+set timeout 5
+spawn zsh --no-rcs [lindex $argv 0]
+sleep 0.3
+send " "
+expect eof
+EEOF
+    chmod +x "$DRIVER_EXP"
+
+    if ! "$DRIVER_EXP" "$DRIVER" >/dev/null 2>&1; then
+        print -u2 'FAIL [functional]: expect driver exited non-zero'
+        exit 1
+    fi
+
+    captured="$(<"$WIDGET_OUT")"
+    if [[ "$captured" != "zle-line-pre-redraw" ]]; then
+        print -u2 "FAIL [functional]: \$WIDGET inside baseline was '$captured', expected 'zle-line-pre-redraw'"
+        exit 1
+    fi
+fi
+
 print 'PASS: zle chaining preserves widget identity, idempotent in both branches'

--- a/tests/shell/test_zle_chaining.zsh
+++ b/tests/shell/test_zle_chaining.zsh
@@ -22,7 +22,7 @@ if [[ ! -f "$INTEGRATION" ]]; then
 fi
 
 # --- Test A: chaining branch (a prior widget exists) ---
-zsh --no-rcs -i -c "
+zsh --no-rcs -c "
     set -e
     zmodload zsh/zle
     _baseline_pre_redraw() { :; }
@@ -46,15 +46,15 @@ zsh --no-rcs -i -c "
 
     # Re-sourcing is idempotent: chain stays a single layer deep.
     source '$INTEGRATION'
-    local count=\$(print -- \"\${widgets[zle-line-pre-redraw]}\" | grep -c _gc_zle_line_pre_redraw || true)
-    if (( count != 1 )); then
-        print -u2 \"FAIL [chain]: re-source produced \${count} chain entries (want 1)\"
+    if [[ \"\${widgets[zle-line-pre-redraw]}\" != *_gc_zle_line_pre_redraw* ]]; then
+        print -u2 'FAIL [chain]: re-source mutated the registration'
+        print -u2 \"  actual: \${widgets[zle-line-pre-redraw]}\"
         exit 1
     fi
 "
 
 # --- Test B: direct-install branch (no prior widget) ---
-zsh --no-rcs -i -c "
+zsh --no-rcs -c "
     set -e
     zmodload zsh/zle
 


### PR DESCRIPTION
## Summary

Fixes #64 and supersedes #65.

- **Ctrl+L 5s hang** under z4h: replaced the `cpr_pending: u8` counter with a FIFO request queue tagged by origin (`Ours` / `Shell`). Terminals respond to `CSI 6n` in request order, so popping the head dispatches the response to the correct owner without timing logic. Removes the entire class of bugs (overlapping CPRs collapsing into one flag, the our-pending-then-shell race, the 500ms-vs-5s expiry mismatch) raised in the #65 review.
- **RPROMPT misalignment** under p10k+z4h: replaced `add-zle-hook-widget line-pre-redraw _gc_report_buffer` with manual widget chaining. The dispatcher installed by `add-zle-hook-widget` renames `$WIDGET` to `azhw:zle-line-pre-redraw`, which breaks z4h's `_zsh_highlight()` guard for the post-Enter prompt render — that ran highlighting during prompt rendering and inflated the width measurement p10k uses for RPROMPT alignment.

## Changes

- `gc-parser`: `CprOwner` enum, `CprToken` opaque handle, `cpr_queue: VecDeque<CprEntry>`, `enqueue_cpr` / `claim_next_cpr` / `rollback_cpr` / `prune_stale_cpr` / `cpr_queue_len`. Removed `cpr_pending`, `increment_cpr_pending`, `claim_cpr_response`. Auto-enqueue `Shell` on `CSI 6n` in the `vte::Perform` impl.
- `gc-pty/proxy.rs`: Task A pops the queue head and matches on owner via the extracted `dispatch_cpr_response` helper; Task B enqueues `Ours` with a token, rolls back on write failure, and prunes anything older than 30s once per iteration (leak guard against terminals that drop requests).
- `shell/ghost-complete.zsh`: `_gc_install_zle_hook` installs the chain directly, idempotently, and only wraps when an existing widget is registered. Both branches (chain and direct-install) are guarded by the same idempotency check.
- `tests/shell/test_zle_chaining.zsh`: shell integration test asserting the wrapper preserves widget identity and is idempotent on re-source for both install branches.

Diagnosis credit: @amryadam — the root-cause analysis in #64 (CPR theft mechanism) and the follow-up identification of `add-zle-hook-widget`'s `$WIDGET` interaction made this fix possible.

## Differences from #65

- FIFO queue instead of `Option<Instant>` flag — no expiry race, handles overlapping CPRs and the our-pending-then-shell case correctly without special-case branches.
- RPROMPT fix at the source (widget chaining) rather than stripping OSC 7770/7771 from the terminal stream.
- `strip_internal_osc` omitted entirely — the cross-chunk corruption hazard you flagged in review never lands.
- Token-based rollback for write-failure recovery (vs decrementing a counter), correct under arbitrary interleaving with Task A's claims.

## Test plan

- [x] All workspace tests pass (810 tests across the workspace; gc-parser grew by 14, gc-pty grew by 5).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `zsh tests/shell/test_zle_chaining.zsh` passes — `$WIDGET` preserved, idempotent re-source in both install branches.
- [ ] manual verification on z4h+p10k:
  - [ ] Ctrl+L instant (was 5s)
  - [x] `gh auth status` returns in <1s (was 5s)
  - [ ] p10k RPROMPT aligned to right edge
  - [ ] ghost-complete suggestions still appear and work

Closes #64.