### PR TITLE
feat: add VSCode and Zed integrated terminal support (v0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **VSCode terminal support** — Ghost Complete now runs as a first-class PTY proxy inside VSCode's integrated terminal, plus **VSCodium, Cursor, Windsurf, Positron, and Trae** (all detected via `VSCODE_IPC_HOOK_CLI`). Capability profile: `Synchronized` (DECSET 2026 via xterm.js) + native OSC 133. Coexists with VSCode's own shell integration (OSC 633) — the proxy forwards editor sequences untouched so command decorations, sticky scroll, and "run recent command" continue to work. Previously VSCode's integrated terminal fell through to the unknown-terminal `exec` fallback (plain shell, no proxy); it is now a first-class supported target.
+- **VSCode terminal support** — Ghost Complete now runs as a first-class PTY proxy inside VSCode's integrated terminal, plus **VSCodium, Cursor, Windsurf, Positron, and Trae** (all detected via `VSCODE_IPC_HOOK_CLI`). Capability profile: `Synchronized` (DECSET 2026 via xterm.js) + native OSC 133. Coexists with VSCode's own shell integration (OSC 633) — the proxy forwards editor sequences untouched so command decorations, sticky scroll, and "run recent command" continue to work. Previously `shell/init.zsh`'s allowlist did not match VSCode, so users got a plain interactive shell with no proxy; it is now a first-class supported target.
 - **Zed terminal support** — first-class support for Zed's integrated terminal, detected via `ZED_TERM=true`. Same capability profile as Ghostty/Kitty (Synchronized + native OSC 133).
 - **`supported_terminals()`** grows from 7 to 9. `Terminal::Zed` and `Terminal::VSCode` enum variants added to `gc-terminal`; `for_zed()` and `for_vscode()` test constructors available behind `test-utils`.
 
 ### Changed
 
 - **`shell/ghost-complete.{zsh,bash,fish}`** — introduced a `_gc_native_osc133` helper that short-circuits OSC 7771 emission when the host terminal already injects native OSC 133 (Ghostty, Zed) or its own shell integration that emits OSC 133 alongside proprietary markers (VSCode, signalled by `VSCODE_INJECTION=1`). Eliminates redundant/conflicting prompt markers in editor-hosted terminals.
-- **`shell/init.zsh`** — non-tmux branch now resets an inherited `GHOST_COMPLETE_ACTIVE` when the parent process is not `ghost-complete`. This fixes the `code .` flow: a user launching VSCode from a ghost-complete-managed shell now gets the proxy in VSCode's integrated terminal instead of short-circuiting on the leaked env var. Tmux branch unchanged (`GHOSTTY_RESOURCES_DIR` / `VSCODE_IPC_HOOK_CLI` / `ZED_TERM` added to the supported allowlist).
+- **`shell/init.zsh`** — non-tmux branch now resets an inherited `GHOST_COMPLETE_ACTIVE` when the parent process is not `ghost-complete`. This fixes the `code .` flow: a user launching VSCode from a ghost-complete-managed shell now gets the proxy in VSCode's integrated terminal instead of short-circuiting on the leaked env var. Tmux branch: `$ZED_TERM` and `$VSCODE_IPC_HOOK_CLI` added to the supported-terminals allowlist.
 
 ## [0.8.2] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **VSCode terminal support** — Ghost Complete now runs as a first-class PTY proxy inside VSCode's integrated terminal, plus **VSCodium, Cursor, Windsurf, Positron, and Trae** (all detected via `VSCODE_IPC_HOOK_CLI`). Capability profile: `Synchronized` (DECSET 2026 via xterm.js) + native OSC 133. Coexists with VSCode's own shell integration (OSC 633) — the proxy forwards editor sequences untouched so command decorations, sticky scroll, and "run recent command" continue to work. Reverses the v0.7-era exclusion that previously kept the proxy out of VSCode integrated terminals.
+- **VSCode terminal support** — Ghost Complete now runs as a first-class PTY proxy inside VSCode's integrated terminal, plus **VSCodium, Cursor, Windsurf, Positron, and Trae** (all detected via `VSCODE_IPC_HOOK_CLI`). Capability profile: `Synchronized` (DECSET 2026 via xterm.js) + native OSC 133. Coexists with VSCode's own shell integration (OSC 633) — the proxy forwards editor sequences untouched so command decorations, sticky scroll, and "run recent command" continue to work. Previously VSCode's integrated terminal fell through to the unknown-terminal `exec` fallback (plain shell, no proxy); it is now a first-class supported target.
 - **Zed terminal support** — first-class support for Zed's integrated terminal, detected via `ZED_TERM=true`. Same capability profile as Ghostty/Kitty (Synchronized + native OSC 133).
 - **`supported_terminals()`** grows from 7 to 9. `Terminal::Zed` and `Terminal::VSCode` enum variants added to `gc-terminal`; `for_zed()` and `for_vscode()` test constructors available behind `test-utils`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-19
+
+### Added
+
+- **VSCode terminal support** — Ghost Complete now runs as a first-class PTY proxy inside VSCode's integrated terminal, plus **VSCodium, Cursor, Windsurf, Positron, and Trae** (all detected via `VSCODE_IPC_HOOK_CLI`). Capability profile: `Synchronized` (DECSET 2026 via xterm.js) + native OSC 133. Coexists with VSCode's own shell integration (OSC 633) — the proxy forwards editor sequences untouched so command decorations, sticky scroll, and "run recent command" continue to work. Reverses the v0.7-era exclusion that previously kept the proxy out of VSCode integrated terminals.
+- **Zed terminal support** — first-class support for Zed's integrated terminal, detected via `ZED_TERM=true`. Same capability profile as Ghostty/Kitty (Synchronized + native OSC 133).
+- **`supported_terminals()`** grows from 7 to 9. `Terminal::Zed` and `Terminal::VSCode` enum variants added to `gc-terminal`; `for_zed()` and `for_vscode()` test constructors available behind `test-utils`.
+
+### Changed
+
+- **`shell/ghost-complete.{zsh,bash,fish}`** — introduced a `_gc_native_osc133` helper that short-circuits OSC 7771 emission when the host terminal already injects native OSC 133 (Ghostty, Zed) or its own shell integration that emits OSC 133 alongside proprietary markers (VSCode, signalled by `VSCODE_INJECTION=1`). Eliminates redundant/conflicting prompt markers in editor-hosted terminals.
+- **`shell/init.zsh`** — non-tmux branch now resets an inherited `GHOST_COMPLETE_ACTIVE` when the parent process is not `ghost-complete`. This fixes the `code .` flow: a user launching VSCode from a ghost-complete-managed shell now gets the proxy in VSCode's integrated terminal instead of short-circuiting on the leaked env var. Tmux branch unchanged (`GHOSTTY_RESOURCES_DIR` / `VSCODE_IPC_HOOK_CLI` / `ZED_TERM` added to the supported allowlist).
+
 ## [0.8.2] - 2026-04-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,11 +530,11 @@ dependencies = [
 
 [[package]]
 name = "gc-buffer"
-version = "0.8.2"
+version = "0.9.0"
 
 [[package]]
 name = "gc-config"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "gc-overlay"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "gc-suggest",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "gc-parser"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "gc-pty"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "gc-suggest"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "gc-terminal"
-version = "0.8.2"
+version = "0.9.0"
 
 [[package]]
 name = "getrandom"
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-complete"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Inspired by the [Fig](https://fig.io) autocomplete experience. Built from scratc
 
 Ghost Complete is under active development. Contributions and bug reports are welcome.
 
-- **7 supported terminals on macOS:** Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, and Terminal.app — all work out of the box with no additional configuration.
+- **9 supported terminals on macOS:** Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed, and VSCode (incl. VSCodium, Cursor, Windsurf, Positron) — all work out of the box with no additional configuration.
 - **zsh is the primary shell.** Bash and fish support manual trigger only (Ctrl+/).
 - **macOS only.** No Linux or Windows support planned at this time.
 - **Pre-1.0.** Config format, spec format, and behavior may change between releases.
@@ -109,10 +109,13 @@ Ghost Complete auto-detects your terminal and selects the best rendering strateg
 | [Rio](https://raphamorim.io/rio/) | Synchronized (DECSET 2026) | OSC 133 (native) | — |
 | [iTerm2](https://iterm2.com) | Pre-render buffer | Shell integration | Yes |
 | Terminal.app | Pre-render buffer | Shell integration | No |
+| [Zed](https://zed.dev) | Synchronized (DECSET 2026) | OSC 133 (native) | Yes |
+| [VSCode](https://code.visualstudio.com) (and forks) | Synchronized (DECSET 2026) | OSC 133 (native) | Yes |
 
 **Notes:**
 - Terminal.app inside tmux is not detected (it sets no env var that leaks through tmux).
 - Alacritty does not support OSC 133 natively; Ghost Complete uses its own shell integration markers instead. No functional difference — just a different detection path.
+- VSCode detection covers **all Electron-based VSCode forks**: VSCodium, Cursor, Windsurf, Positron, Trae. They share the xterm.js frontend and shell integration model. Ghost Complete coexists with VSCode's own shell integration (OSC 633) — the proxy forwards editor sequences untouched so command decorations, sticky scroll, and "run recent command" continue to work.
 - Unsupported terminals can be enabled with `[experimental] multi_terminal = true` in config.
 
 ## Configuration

--- a/benchmarks/v0.9.0.md
+++ b/benchmarks/v0.9.0.md
@@ -1,0 +1,61 @@
+# Benchmarks — v0.9.0
+
+Date: 2026-04-19
+Platform: macOS (Apple Silicon)
+
+Criterion's reported `change` column compares against the previous saved run on this machine (v0.8.2 baseline).
+
+Changes in 0.9.0 are confined to env-var detection (`ZED_TERM`, `VSCODE_IPC_HOOK_CLI`) and shell-integration scripts — no hot-path code was touched. Expected delta against v0.8.2: flat across every group. Results confirm this: every benchmark lands within normal run-to-run noise.
+
+## vt_parse_throughput
+
+| Benchmark | Time | vs v0.8.2 |
+|-----------|------|-----------|
+| plain_text | 177.22 µs | flat (+0.02%) |
+| ansi_colored | 223.67 µs | +1.8% within noise |
+| cursor_heavy | 271.76 µs | +0.8% within noise |
+
+## fuzzy_ranking
+
+| Benchmark | Time | vs v0.8.2 |
+|-----------|------|-----------|
+| 1k_3char | 101.20 µs | +4.6% within noise |
+| 10k_3char | 1.0284 ms | +1.0% within noise |
+| 10k_empty | 335.13 µs | −0.4% flat |
+
+## spec_loading
+
+| Benchmark | Time | vs v0.8.2 |
+|-----------|------|-----------|
+| load_717_specs | 92.87 ms | +1.5% within noise |
+
+## spec_resolution
+
+| Benchmark | Time | vs v0.8.2 |
+|-----------|------|-----------|
+| shallow | 2.4556 µs | +0.4% flat |
+| deep | 1.2743 µs | flat (−0.01%) |
+
+## transform_pipeline
+
+| Benchmark | Time | vs v0.8.2 |
+|-----------|------|-----------|
+| simple | 26.48 µs | not tracked in v0.8.2 |
+| regex | 113.56 µs | not tracked in v0.8.2 |
+| json | 28.31 µs | not tracked in v0.8.2 |
+
+## engine_suggest_sync
+
+| Benchmark | Time | vs v0.8.2 |
+|-----------|------|-----------|
+| command_position | 17.04 µs | not tracked in v0.8.2 |
+| subcommand_with_spec | 16.64 µs | not tracked in v0.8.2 |
+| filesystem_fallback | 1.1372 ms | not tracked in v0.8.2 |
+
+## Analysis
+
+Every tracked group is flat or within measurement noise. This matches expectations: the 0.9.0 changes all live in cold-startup env detection (called once per proxy spawn) and in shell-integration scripts (executed by the user's shell, not the proxy binary's hot paths). No parser, suggester, or overlay hot-path code was modified.
+
+The `transform_pipeline` and `engine_suggest_sync` groups were added in the release pipeline between v0.8.2 and v0.9.0, so they have no baseline to compare against here; their current numbers are recorded for future runs.
+
+Criterion reports: `target/criterion/report/index.html`.

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -10,6 +10,8 @@ pub enum Terminal {
     Rio,
     ITerm2,
     TerminalApp,
+    /// Zed's integrated terminal. Same capability profile as Ghostty/Kitty
+    /// (Synchronized + native OSC 133), detected via ZED_TERM.
     Zed,
     /// VSCode's integrated terminal. Covers all VSCode forks (VSCodium,
     /// Cursor, Windsurf, Positron, Trae, …) — they share the xterm.js
@@ -178,10 +180,11 @@ impl TerminalProfile {
         // Zed sets ZED_TERM=true in its integrated terminal. Accept any
         // non-empty value — mirrors the KITTY_WINDOW_ID policy.
         let has_zed_term = env_is_set("ZED_TERM");
-        // VSCode (and forks: VSCodium, Cursor, Windsurf, Positron) set
-        // VSCODE_IPC_HOOK_CLI to an active Unix socket path. The
-        // existing-path check rejects stale env vars pointing at a
-        // dead editor's socket.
+        // VSCode (and forks: VSCodium, Cursor, Windsurf, Positron, Trae)
+        // set VSCODE_IPC_HOOK_CLI to a Unix socket path. The existing-path
+        // check rejects stale env vars pointing at a removed socket path.
+        // A leftover socket file from an abruptly-terminated editor still
+        // passes; connect-time validation is out of scope.
         let has_vscode_ipc = env_is_existing_path("VSCODE_IPC_HOOK_CLI");
 
         Self::detect_from_env(
@@ -360,7 +363,7 @@ impl TerminalProfile {
     }
 
     /// Test constructor: VSCode profile (Synchronized, OSC 133). Covers
-    /// all VSCode forks (VSCodium, Cursor, Windsurf, Positron) since
+    /// all VSCode forks (VSCodium, Cursor, Windsurf, Positron, Trae) since
     /// they share the xterm.js frontend and shell-integration model.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn for_vscode() -> Self {
@@ -499,6 +502,13 @@ mod tests {
     fn test_capitalized_vscode_is_unknown() {
         // Match the existing strict-casing policy for other terminals.
         let profile = TerminalProfile::from_term_program("VSCode", false);
+        assert!(matches!(profile.terminal(), Terminal::Unknown(_)));
+    }
+
+    #[test]
+    fn test_capitalized_zed_is_unknown() {
+        // Match the existing strict-casing policy for other terminals.
+        let profile = TerminalProfile::from_term_program("Zed", false);
         assert!(matches!(profile.terminal(), Terminal::Unknown(_)));
     }
 
@@ -679,6 +689,58 @@ mod tests {
         // ZED_TERM checked before VSCODE_IPC_HOOK_CLI in detect_from_env.
         let p = detect("", false, false, false, false, false, false, true, true);
         assert_eq!(*p.terminal(), Terminal::Zed);
+    }
+
+    #[test]
+    fn test_detect_zed_direct_with_both_zed_term_and_term_program() {
+        // Direct path: both ZED_TERM and TERM_PROGRAM=zed set. ZED_TERM is
+        // the reliable signal and is checked before the TERM_PROGRAM fallback.
+        let p = detect("zed", false, false, false, false, false, false, true, false);
+        assert_eq!(*p.terminal(), Terminal::Zed);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_zed_via_tmux_with_term_program_overwritten() {
+        // Inside tmux, TERM_PROGRAM is typically mangled to "tmux-256color".
+        // Only ZED_TERM is set — it's the reliable signal inside tmux.
+        let p = detect(
+            "tmux-256color",
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+        );
+        assert_eq!(*p.terminal(), Terminal::Zed);
+        assert!(p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_zed_takes_priority_over_iterm_via_tmux() {
+        // ZED_TERM checked before ITERM_SESSION_ID in the tmux branch.
+        let p = detect("", true, false, true, false, false, false, true, false);
+        assert_eq!(*p.terminal(), Terminal::Zed);
+        assert!(p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_tmux_kitty_takes_priority_over_zed() {
+        // KITTY_WINDOW_ID checked before ZED_TERM in the tmux branch.
+        let p = detect("", true, false, false, true, false, false, true, false);
+        assert_eq!(*p.terminal(), Terminal::Kitty);
+        assert!(p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_tmux_kitty_takes_priority_over_vscode() {
+        // KITTY_WINDOW_ID checked before VSCODE_IPC_HOOK_CLI in the tmux branch.
+        let p = detect("", true, false, false, true, false, false, false, true);
+        assert_eq!(*p.terminal(), Terminal::Kitty);
+        assert!(p.in_tmux());
     }
 
     #[test]
@@ -1027,5 +1089,27 @@ mod tests {
         assert!(PromptDetection::ShellIntegration
             .to_string()
             .contains("7771"));
+    }
+
+    #[test]
+    fn test_detection_does_not_read_vscode_injection_env_var() {
+        // Guard rail: the shell-integration suppression env var is NOT a
+        // detection signal. If this file starts reading it, someone is
+        // conflating suppression with detection — the two must stay
+        // independent so VSCode users without shell integration still
+        // get correct detection + OSC 7771 emission.
+        //
+        // We scan only the production code (above `mod tests`) so that the
+        // literal in this test body doesn't trip its own assertion.
+        let source = include_str!("lib.rs");
+        let prod_src = source
+            .split_once("#[cfg(test)]")
+            .map(|(before, _)| before)
+            .unwrap_or(source);
+        let forbidden = concat!("VSCODE_", "INJECTION");
+        assert!(
+            !prod_src.contains(forbidden),
+            "gc-terminal detection must not read the shell-integration suppression env var"
+        );
     }
 }

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -10,6 +10,7 @@ pub enum Terminal {
     Rio,
     ITerm2,
     TerminalApp,
+    Zed,
     Unknown(String),
 }
 
@@ -29,6 +30,7 @@ impl Terminal {
             "Rio",
             "iTerm2",
             "Terminal.app",
+            "Zed",
         ]
     }
 }
@@ -43,6 +45,7 @@ impl fmt::Display for Terminal {
             Terminal::Rio => write!(f, "Rio"),
             Terminal::ITerm2 => write!(f, "iTerm2"),
             Terminal::TerminalApp => write!(f, "Terminal.app"),
+            Terminal::Zed => write!(f, "Zed"),
             Terminal::Unknown(name) => write!(f, "{name}"),
         }
     }
@@ -248,9 +251,11 @@ impl TerminalProfile {
     fn new(terminal: Terminal, in_tmux: bool) -> Self {
         let (render_strategy, prompt_detection) = match &terminal {
             // Full native support: synchronized output + OSC 133 prompt markers
-            Terminal::Ghostty | Terminal::Kitty | Terminal::WezTerm | Terminal::Rio => {
-                (RenderStrategy::Synchronized, PromptDetection::Osc133)
-            }
+            Terminal::Ghostty
+            | Terminal::Kitty
+            | Terminal::WezTerm
+            | Terminal::Rio
+            | Terminal::Zed => (RenderStrategy::Synchronized, PromptDetection::Osc133),
             // Synchronized output but no native OSC 133 (Alacritty issue open since 2022)
             Terminal::Alacritty => (
                 RenderStrategy::Synchronized,
@@ -335,14 +340,15 @@ mod tests {
         assert!(Terminal::Rio.is_known());
         assert!(Terminal::ITerm2.is_known());
         assert!(Terminal::TerminalApp.is_known());
+        assert!(Terminal::Zed.is_known());
         assert!(!Terminal::Unknown("foot".into()).is_known());
         assert!(!Terminal::Unknown("unknown".into()).is_known());
     }
 
     #[test]
     fn test_supported_terminals_count() {
-        // 7 supported terminals: Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app
-        assert_eq!(Terminal::supported_terminals().len(), 7);
+        // 8 supported terminals: Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed
+        assert_eq!(Terminal::supported_terminals().len(), 8);
     }
 
     #[test]
@@ -357,6 +363,7 @@ mod tests {
                 "Rio",
                 "iTerm2",
                 "Terminal.app",
+                "Zed",
             ]
         );
     }
@@ -450,6 +457,7 @@ mod tests {
         assert_eq!(Terminal::Rio.to_string(), "Rio");
         assert_eq!(Terminal::ITerm2.to_string(), "iTerm2");
         assert_eq!(Terminal::TerminalApp.to_string(), "Terminal.app");
+        assert_eq!(Terminal::Zed.to_string(), "Zed");
         assert_eq!(Terminal::Unknown("foo".into()).to_string(), "foo");
     }
 

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -236,6 +236,7 @@ impl TerminalProfile {
             "WezTerm" => Terminal::WezTerm,
             "alacritty" => Terminal::Alacritty,
             "rio" => Terminal::Rio,
+            "zed" => Terminal::Zed,
             "" => Terminal::Unknown("unknown".into()),
             other => {
                 let sanitized: String = other
@@ -430,6 +431,14 @@ mod tests {
     fn test_rio_profile() {
         let profile = TerminalProfile::from_term_program("rio", false);
         assert_eq!(*profile.terminal(), Terminal::Rio);
+        assert_eq!(profile.render_strategy(), RenderStrategy::Synchronized);
+        assert_eq!(profile.prompt_detection(), PromptDetection::Osc133);
+    }
+
+    #[test]
+    fn test_zed_profile_from_term_program() {
+        let profile = TerminalProfile::from_term_program("zed", false);
+        assert_eq!(*profile.terminal(), Terminal::Zed);
         assert_eq!(profile.render_strategy(), RenderStrategy::Synchronized);
         assert_eq!(profile.prompt_detection(), PromptDetection::Osc133);
     }

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -345,6 +345,14 @@ impl TerminalProfile {
         Self::new(Terminal::Zed, false)
     }
 
+    /// Test constructor: VSCode profile (Synchronized, OSC 133). Covers
+    /// all VSCode forks (VSCodium, Cursor, Windsurf, Positron) since
+    /// they share the xterm.js frontend and shell-integration model.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn for_vscode() -> Self {
+        Self::new(Terminal::VSCode, false)
+    }
+
     /// Test constructor: Unknown terminal profile (PreRenderBuffer, ShellIntegration).
     #[cfg(any(test, feature = "test-utils"))]
     pub fn for_unknown(name: &str) -> Self {
@@ -769,6 +777,14 @@ mod tests {
     fn test_for_zed() {
         let p = TerminalProfile::for_zed();
         assert_eq!(*p.terminal(), Terminal::Zed);
+        assert_eq!(p.render_strategy(), RenderStrategy::Synchronized);
+        assert_eq!(p.prompt_detection(), PromptDetection::Osc133);
+    }
+
+    #[test]
+    fn test_for_vscode() {
+        let p = TerminalProfile::for_vscode();
+        assert_eq!(*p.terminal(), Terminal::VSCode);
         assert_eq!(p.render_strategy(), RenderStrategy::Synchronized);
         assert_eq!(p.prompt_detection(), PromptDetection::Osc133);
     }

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -691,7 +691,16 @@ mod tests {
 
     #[test]
     fn test_detect_tmux_falls_back_to_term_program() {
-        let p = detect("Apple_Terminal", true, false, false, false, false, false, false);
+        let p = detect(
+            "Apple_Terminal",
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+        );
         assert_eq!(*p.terminal(), Terminal::TerminalApp);
         assert!(p.in_tmux());
     }

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -168,6 +168,9 @@ impl TerminalProfile {
         let has_kitty_window_id = env_is_set("KITTY_WINDOW_ID");
         let has_wezterm_socket = env_is_existing_path("WEZTERM_UNIX_SOCKET");
         let has_alacritty_socket = env_is_existing_path("ALACRITTY_SOCKET");
+        // Zed sets ZED_TERM=true in its integrated terminal. Accept any
+        // non-empty value — mirrors the KITTY_WINDOW_ID policy.
+        let has_zed_term = env_is_set("ZED_TERM");
 
         Self::detect_from_env(
             &term_program,
@@ -177,10 +180,12 @@ impl TerminalProfile {
             has_kitty_window_id,
             has_wezterm_socket,
             has_alacritty_socket,
+            has_zed_term,
         )
     }
 
     /// Testable detection logic — takes env values as parameters.
+    #[allow(clippy::too_many_arguments)]
     fn detect_from_env(
         term_program: &str,
         in_tmux: bool,
@@ -189,6 +194,7 @@ impl TerminalProfile {
         has_kitty_window_id: bool,
         has_wezterm_socket: bool,
         has_alacritty_socket: bool,
+        has_zed_term: bool,
     ) -> Self {
         // Direct terminal detection (not inside tmux)
         if !in_tmux {
@@ -202,6 +208,9 @@ impl TerminalProfile {
             // Alacritty doesn't set TERM_PROGRAM — detect via ALACRITTY_SOCKET.
             if has_alacritty_socket {
                 return Self::new(Terminal::Alacritty, false);
+            }
+            if has_zed_term {
+                return Self::new(Terminal::Zed, false);
             }
             return Self::from_term_program(term_program, false);
         }
@@ -219,6 +228,9 @@ impl TerminalProfile {
         }
         if has_alacritty_socket {
             return Self::new(Terminal::Alacritty, true);
+        }
+        if has_zed_term {
+            return Self::new(Terminal::Zed, true);
         }
         if has_iterm_session {
             return Self::new(Terminal::ITerm2, true);
@@ -497,6 +509,7 @@ mod tests {
     // -- detect_from_env (direct + tmux paths) --
 
     // Helper: call detect_from_env with only the specified flags set.
+    #[allow(clippy::too_many_arguments)]
     fn detect(
         term_program: &str,
         in_tmux: bool,
@@ -505,6 +518,7 @@ mod tests {
         kitty_wid: bool,
         wezterm_sock: bool,
         alacritty_sock: bool,
+        zed_term: bool,
     ) -> TerminalProfile {
         TerminalProfile::detect_from_env(
             term_program,
@@ -514,12 +528,13 @@ mod tests {
             kitty_wid,
             wezterm_sock,
             alacritty_sock,
+            zed_term,
         )
     }
 
     #[test]
     fn test_detect_ghostty_direct() {
-        let p = detect("ghostty", false, false, false, false, false, false);
+        let p = detect("ghostty", false, false, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Ghostty);
         assert!(!p.in_tmux());
     }
@@ -527,21 +542,21 @@ mod tests {
     #[test]
     fn test_detect_kitty_direct() {
         // Kitty reports TERM_PROGRAM=xterm-kitty, so detect via KITTY_WINDOW_ID.
-        let p = detect("", false, false, false, true, false, false);
+        let p = detect("", false, false, false, true, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Kitty);
         assert!(!p.in_tmux());
     }
 
     #[test]
     fn test_detect_wezterm_direct_via_term_program() {
-        let p = detect("WezTerm", false, false, false, false, false, false);
+        let p = detect("WezTerm", false, false, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::WezTerm);
         assert!(!p.in_tmux());
     }
 
     #[test]
     fn test_detect_wezterm_direct_via_socket() {
-        let p = detect("", false, false, false, false, true, false);
+        let p = detect("", false, false, false, false, true, false, false);
         assert_eq!(*p.terminal(), Terminal::WezTerm);
         assert!(!p.in_tmux());
     }
@@ -549,21 +564,42 @@ mod tests {
     #[test]
     fn test_detect_alacritty_direct() {
         // Alacritty doesn't set TERM_PROGRAM — detected via ALACRITTY_SOCKET
-        let p = detect("", false, false, false, false, false, true);
+        let p = detect("", false, false, false, false, false, true, false);
         assert_eq!(*p.terminal(), Terminal::Alacritty);
         assert!(!p.in_tmux());
     }
 
     #[test]
     fn test_detect_rio_direct() {
-        let p = detect("rio", false, false, false, false, false, false);
+        let p = detect("rio", false, false, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Rio);
         assert!(!p.in_tmux());
     }
 
     #[test]
+    fn test_detect_zed_direct_via_zed_term() {
+        let p = detect("", false, false, false, false, false, false, true);
+        assert_eq!(*p.terminal(), Terminal::Zed);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_zed_via_tmux() {
+        let p = detect("", true, false, false, false, false, false, true);
+        assert_eq!(*p.terminal(), Terminal::Zed);
+        assert!(p.in_tmux());
+        assert_eq!(p.display_name(), "Zed (via tmux)");
+    }
+
+    #[test]
+    fn test_detect_ghostty_takes_priority_over_zed_via_tmux() {
+        let p = detect("", true, true, false, false, false, false, true);
+        assert_eq!(*p.terminal(), Terminal::Ghostty);
+    }
+
+    #[test]
     fn test_detect_ghostty_via_tmux() {
-        let p = detect("", true, true, false, false, false, false);
+        let p = detect("", true, true, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Ghostty);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "Ghostty (via tmux)");
@@ -571,7 +607,7 @@ mod tests {
 
     #[test]
     fn test_detect_kitty_via_tmux() {
-        let p = detect("", true, false, false, true, false, false);
+        let p = detect("", true, false, false, true, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Kitty);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "Kitty (via tmux)");
@@ -579,7 +615,7 @@ mod tests {
 
     #[test]
     fn test_detect_wezterm_via_tmux() {
-        let p = detect("", true, false, false, false, true, false);
+        let p = detect("", true, false, false, false, true, false, false);
         assert_eq!(*p.terminal(), Terminal::WezTerm);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "WezTerm (via tmux)");
@@ -587,7 +623,7 @@ mod tests {
 
     #[test]
     fn test_detect_alacritty_via_tmux() {
-        let p = detect("", true, false, false, false, false, true);
+        let p = detect("", true, false, false, false, false, true, false);
         assert_eq!(*p.terminal(), Terminal::Alacritty);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "Alacritty (via tmux)");
@@ -598,14 +634,14 @@ mod tests {
         // Rio has no dedicated env var for tmux detection — falls back to TERM_PROGRAM.
         // This documents the expected behavior; if Rio-specific env detection is added
         // later, this test captures the current path.
-        let p = detect("rio", true, false, false, false, false, false);
+        let p = detect("rio", true, false, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Rio);
         assert!(p.in_tmux());
     }
 
     #[test]
     fn test_detect_iterm2_via_tmux() {
-        let p = detect("", true, false, true, false, false, false);
+        let p = detect("", true, false, true, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::ITerm2);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "iTerm2 (via tmux)");
@@ -613,56 +649,56 @@ mod tests {
 
     #[test]
     fn test_detect_tmux_ghostty_takes_priority_over_iterm() {
-        let p = detect("", true, true, true, false, false, false);
+        let p = detect("", true, true, true, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Ghostty);
     }
 
     #[test]
     fn test_detect_tmux_ghostty_takes_priority_over_kitty() {
-        let p = detect("", true, true, false, true, false, false);
+        let p = detect("", true, true, false, true, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Ghostty);
     }
 
     #[test]
     fn test_detect_tmux_kitty_takes_priority_over_wezterm() {
-        let p = detect("", true, false, false, true, true, false);
+        let p = detect("", true, false, false, true, true, false, false);
         assert_eq!(*p.terminal(), Terminal::Kitty);
     }
 
     #[test]
     fn test_detect_direct_kitty_takes_priority_over_wezterm() {
-        let p = detect("", false, false, false, true, true, false);
+        let p = detect("", false, false, false, true, true, false, false);
         assert_eq!(*p.terminal(), Terminal::Kitty);
     }
 
     #[test]
     fn test_detect_direct_wezterm_takes_priority_over_alacritty() {
-        let p = detect("", false, false, false, false, true, true);
+        let p = detect("", false, false, false, false, true, true, false);
         assert_eq!(*p.terminal(), Terminal::WezTerm);
     }
 
     #[test]
     fn test_detect_tmux_wezterm_takes_priority_over_alacritty() {
-        let p = detect("", true, false, false, false, true, true);
+        let p = detect("", true, false, false, false, true, true, false);
         assert_eq!(*p.terminal(), Terminal::WezTerm);
     }
 
     #[test]
     fn test_detect_tmux_alacritty_takes_priority_over_iterm() {
-        let p = detect("", true, false, true, false, false, true);
+        let p = detect("", true, false, true, false, false, true, false);
         assert_eq!(*p.terminal(), Terminal::Alacritty);
     }
 
     #[test]
     fn test_detect_tmux_falls_back_to_term_program() {
-        let p = detect("Apple_Terminal", true, false, false, false, false, false);
+        let p = detect("Apple_Terminal", true, false, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::TerminalApp);
         assert!(p.in_tmux());
     }
 
     #[test]
     fn test_detect_tmux_unknown_terminal() {
-        let p = detect("", true, false, false, false, false, false);
+        let p = detect("", true, false, false, false, false, false, false);
         assert!(matches!(p.terminal(), Terminal::Unknown(_)));
         assert!(p.in_tmux());
     }
@@ -776,7 +812,7 @@ mod tests {
     fn test_empty_env_vars_do_not_trigger_detection() {
         // All flags false simulates empty env vars (the real detect() now
         // treats empty strings as absent).
-        let p = detect("", false, false, false, false, false, false);
+        let p = detect("", false, false, false, false, false, false, false);
         assert!(matches!(p.terminal(), Terminal::Unknown(_)));
         assert!(!p.in_tmux());
     }
@@ -784,7 +820,7 @@ mod tests {
     #[test]
     fn test_empty_tmux_does_not_trigger_tmux_branch() {
         // Even with ghostty_res true, in_tmux=false should use the direct path.
-        let p = detect("ghostty", false, true, false, false, false, false);
+        let p = detect("ghostty", false, true, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Ghostty);
         assert!(!p.in_tmux());
     }
@@ -793,14 +829,14 @@ mod tests {
     fn test_stale_socket_does_not_trigger_wezterm() {
         // has_wezterm_socket=false simulates a non-existent socket path
         // (the real detect() now checks Path::exists()).
-        let p = detect("", false, false, false, false, false, false);
+        let p = detect("", false, false, false, false, false, false, false);
         assert!(matches!(p.terminal(), Terminal::Unknown(_)));
     }
 
     #[test]
     fn test_stale_socket_does_not_trigger_alacritty() {
         // has_alacritty_socket=false simulates a non-existent socket path.
-        let p = detect("", false, false, false, false, false, false);
+        let p = detect("", false, false, false, false, false, false, false);
         assert!(matches!(p.terminal(), Terminal::Unknown(_)));
     }
 
@@ -821,7 +857,7 @@ mod tests {
             !std::path::Path::new(stale).exists(),
             "test precondition: {stale} must not exist"
         );
-        let p = detect("", false, false, false, false, false, false);
+        let p = detect("", false, false, false, false, false, false, false);
         assert!(
             !matches!(p.terminal(), Terminal::Ghostty),
             "stale GHOSTTY_RESOURCES_DIR should not trigger Ghostty detection"

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -256,6 +256,7 @@ impl TerminalProfile {
             "alacritty" => Terminal::Alacritty,
             "rio" => Terminal::Rio,
             "zed" => Terminal::Zed,
+            "vscode" => Terminal::VSCode,
             "" => Terminal::Unknown("unknown".into()),
             other => {
                 let sanitized: String = other
@@ -471,6 +472,21 @@ mod tests {
         assert_eq!(*profile.terminal(), Terminal::Zed);
         assert_eq!(profile.render_strategy(), RenderStrategy::Synchronized);
         assert_eq!(profile.prompt_detection(), PromptDetection::Osc133);
+    }
+
+    #[test]
+    fn test_vscode_profile_from_term_program() {
+        let profile = TerminalProfile::from_term_program("vscode", false);
+        assert_eq!(*profile.terminal(), Terminal::VSCode);
+        assert_eq!(profile.render_strategy(), RenderStrategy::Synchronized);
+        assert_eq!(profile.prompt_detection(), PromptDetection::Osc133);
+    }
+
+    #[test]
+    fn test_capitalized_vscode_is_unknown() {
+        // Match the existing strict-casing policy for other terminals.
+        let profile = TerminalProfile::from_term_program("VSCode", false);
+        assert!(matches!(profile.terminal(), Terminal::Unknown(_)));
     }
 
     #[test]

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -178,6 +178,11 @@ impl TerminalProfile {
         // Zed sets ZED_TERM=true in its integrated terminal. Accept any
         // non-empty value — mirrors the KITTY_WINDOW_ID policy.
         let has_zed_term = env_is_set("ZED_TERM");
+        // VSCode (and forks: VSCodium, Cursor, Windsurf, Positron) set
+        // VSCODE_IPC_HOOK_CLI to an active Unix socket path. The
+        // existing-path check rejects stale env vars pointing at a
+        // dead editor's socket.
+        let has_vscode_ipc = env_is_existing_path("VSCODE_IPC_HOOK_CLI");
 
         Self::detect_from_env(
             &term_program,
@@ -188,6 +193,7 @@ impl TerminalProfile {
             has_wezterm_socket,
             has_alacritty_socket,
             has_zed_term,
+            has_vscode_ipc,
         )
     }
 
@@ -202,6 +208,7 @@ impl TerminalProfile {
         has_wezterm_socket: bool,
         has_alacritty_socket: bool,
         has_zed_term: bool,
+        has_vscode_ipc: bool,
     ) -> Self {
         // Direct terminal detection (not inside tmux)
         if !in_tmux {
@@ -218,6 +225,9 @@ impl TerminalProfile {
             }
             if has_zed_term {
                 return Self::new(Terminal::Zed, false);
+            }
+            if has_vscode_ipc {
+                return Self::new(Terminal::VSCode, false);
             }
             return Self::from_term_program(term_program, false);
         }
@@ -238,6 +248,9 @@ impl TerminalProfile {
         }
         if has_zed_term {
             return Self::new(Terminal::Zed, true);
+        }
+        if has_vscode_ipc {
+            return Self::new(Terminal::VSCode, true);
         }
         if has_iterm_session {
             return Self::new(Terminal::ITerm2, true);
@@ -554,6 +567,7 @@ mod tests {
         wezterm_sock: bool,
         alacritty_sock: bool,
         zed_term: bool,
+        vscode_ipc: bool,
     ) -> TerminalProfile {
         TerminalProfile::detect_from_env(
             term_program,
@@ -564,12 +578,15 @@ mod tests {
             wezterm_sock,
             alacritty_sock,
             zed_term,
+            vscode_ipc,
         )
     }
 
     #[test]
     fn test_detect_ghostty_direct() {
-        let p = detect("ghostty", false, false, false, false, false, false, false);
+        let p = detect(
+            "ghostty", false, false, false, false, false, false, false, false,
+        );
         assert_eq!(*p.terminal(), Terminal::Ghostty);
         assert!(!p.in_tmux());
     }
@@ -577,21 +594,23 @@ mod tests {
     #[test]
     fn test_detect_kitty_direct() {
         // Kitty reports TERM_PROGRAM=xterm-kitty, so detect via KITTY_WINDOW_ID.
-        let p = detect("", false, false, false, true, false, false, false);
+        let p = detect("", false, false, false, true, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Kitty);
         assert!(!p.in_tmux());
     }
 
     #[test]
     fn test_detect_wezterm_direct_via_term_program() {
-        let p = detect("WezTerm", false, false, false, false, false, false, false);
+        let p = detect(
+            "WezTerm", false, false, false, false, false, false, false, false,
+        );
         assert_eq!(*p.terminal(), Terminal::WezTerm);
         assert!(!p.in_tmux());
     }
 
     #[test]
     fn test_detect_wezterm_direct_via_socket() {
-        let p = detect("", false, false, false, false, true, false, false);
+        let p = detect("", false, false, false, false, true, false, false, false);
         assert_eq!(*p.terminal(), Terminal::WezTerm);
         assert!(!p.in_tmux());
     }
@@ -599,28 +618,30 @@ mod tests {
     #[test]
     fn test_detect_alacritty_direct() {
         // Alacritty doesn't set TERM_PROGRAM — detected via ALACRITTY_SOCKET
-        let p = detect("", false, false, false, false, false, true, false);
+        let p = detect("", false, false, false, false, false, true, false, false);
         assert_eq!(*p.terminal(), Terminal::Alacritty);
         assert!(!p.in_tmux());
     }
 
     #[test]
     fn test_detect_rio_direct() {
-        let p = detect("rio", false, false, false, false, false, false, false);
+        let p = detect(
+            "rio", false, false, false, false, false, false, false, false,
+        );
         assert_eq!(*p.terminal(), Terminal::Rio);
         assert!(!p.in_tmux());
     }
 
     #[test]
     fn test_detect_zed_direct_via_zed_term() {
-        let p = detect("", false, false, false, false, false, false, true);
+        let p = detect("", false, false, false, false, false, false, true, false);
         assert_eq!(*p.terminal(), Terminal::Zed);
         assert!(!p.in_tmux());
     }
 
     #[test]
     fn test_detect_zed_via_tmux() {
-        let p = detect("", true, false, false, false, false, false, true);
+        let p = detect("", true, false, false, false, false, false, true, false);
         assert_eq!(*p.terminal(), Terminal::Zed);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "Zed (via tmux)");
@@ -628,13 +649,56 @@ mod tests {
 
     #[test]
     fn test_detect_ghostty_takes_priority_over_zed_via_tmux() {
-        let p = detect("", true, true, false, false, false, false, true);
+        let p = detect("", true, true, false, false, false, false, true, false);
         assert_eq!(*p.terminal(), Terminal::Ghostty);
     }
 
     #[test]
+    fn test_detect_vscode_direct_via_ipc_hook() {
+        let p = detect("", false, false, false, false, false, false, false, true);
+        assert_eq!(*p.terminal(), Terminal::VSCode);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_vscode_via_tmux() {
+        let p = detect("", true, false, false, false, false, false, false, true);
+        assert_eq!(*p.terminal(), Terminal::VSCode);
+        assert!(p.in_tmux());
+        assert_eq!(p.display_name(), "VSCode (via tmux)");
+    }
+
+    #[test]
+    fn test_detect_kitty_takes_priority_over_vscode() {
+        let p = detect("", false, false, false, true, false, false, false, true);
+        assert_eq!(*p.terminal(), Terminal::Kitty);
+    }
+
+    #[test]
+    fn test_detect_zed_takes_priority_over_vscode() {
+        // ZED_TERM checked before VSCODE_IPC_HOOK_CLI in detect_from_env.
+        let p = detect("", false, false, false, false, false, false, true, true);
+        assert_eq!(*p.terminal(), Terminal::Zed);
+    }
+
+    #[test]
+    fn test_detect_vscode_takes_priority_over_iterm_via_tmux() {
+        let p = detect("", true, false, true, false, false, false, false, true);
+        assert_eq!(*p.terminal(), Terminal::VSCode);
+    }
+
+    #[test]
+    fn test_detect_vscode_via_term_program_fallback() {
+        // IPC hook missing (rare); TERM_PROGRAM=vscode still triggers detection.
+        let p = detect(
+            "vscode", false, false, false, false, false, false, false, false,
+        );
+        assert_eq!(*p.terminal(), Terminal::VSCode);
+    }
+
+    #[test]
     fn test_detect_ghostty_via_tmux() {
-        let p = detect("", true, true, false, false, false, false, false);
+        let p = detect("", true, true, false, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Ghostty);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "Ghostty (via tmux)");
@@ -642,7 +706,7 @@ mod tests {
 
     #[test]
     fn test_detect_kitty_via_tmux() {
-        let p = detect("", true, false, false, true, false, false, false);
+        let p = detect("", true, false, false, true, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Kitty);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "Kitty (via tmux)");
@@ -650,7 +714,7 @@ mod tests {
 
     #[test]
     fn test_detect_wezterm_via_tmux() {
-        let p = detect("", true, false, false, false, true, false, false);
+        let p = detect("", true, false, false, false, true, false, false, false);
         assert_eq!(*p.terminal(), Terminal::WezTerm);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "WezTerm (via tmux)");
@@ -658,7 +722,7 @@ mod tests {
 
     #[test]
     fn test_detect_alacritty_via_tmux() {
-        let p = detect("", true, false, false, false, false, true, false);
+        let p = detect("", true, false, false, false, false, true, false, false);
         assert_eq!(*p.terminal(), Terminal::Alacritty);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "Alacritty (via tmux)");
@@ -669,14 +733,14 @@ mod tests {
         // Rio has no dedicated env var for tmux detection — falls back to TERM_PROGRAM.
         // This documents the expected behavior; if Rio-specific env detection is added
         // later, this test captures the current path.
-        let p = detect("rio", true, false, false, false, false, false, false);
+        let p = detect("rio", true, false, false, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Rio);
         assert!(p.in_tmux());
     }
 
     #[test]
     fn test_detect_iterm2_via_tmux() {
-        let p = detect("", true, false, true, false, false, false, false);
+        let p = detect("", true, false, true, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::ITerm2);
         assert!(p.in_tmux());
         assert_eq!(p.display_name(), "iTerm2 (via tmux)");
@@ -684,43 +748,43 @@ mod tests {
 
     #[test]
     fn test_detect_tmux_ghostty_takes_priority_over_iterm() {
-        let p = detect("", true, true, true, false, false, false, false);
+        let p = detect("", true, true, true, false, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Ghostty);
     }
 
     #[test]
     fn test_detect_tmux_ghostty_takes_priority_over_kitty() {
-        let p = detect("", true, true, false, true, false, false, false);
+        let p = detect("", true, true, false, true, false, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Ghostty);
     }
 
     #[test]
     fn test_detect_tmux_kitty_takes_priority_over_wezterm() {
-        let p = detect("", true, false, false, true, true, false, false);
+        let p = detect("", true, false, false, true, true, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Kitty);
     }
 
     #[test]
     fn test_detect_direct_kitty_takes_priority_over_wezterm() {
-        let p = detect("", false, false, false, true, true, false, false);
+        let p = detect("", false, false, false, true, true, false, false, false);
         assert_eq!(*p.terminal(), Terminal::Kitty);
     }
 
     #[test]
     fn test_detect_direct_wezterm_takes_priority_over_alacritty() {
-        let p = detect("", false, false, false, false, true, true, false);
+        let p = detect("", false, false, false, false, true, true, false, false);
         assert_eq!(*p.terminal(), Terminal::WezTerm);
     }
 
     #[test]
     fn test_detect_tmux_wezterm_takes_priority_over_alacritty() {
-        let p = detect("", true, false, false, false, true, true, false);
+        let p = detect("", true, false, false, false, true, true, false, false);
         assert_eq!(*p.terminal(), Terminal::WezTerm);
     }
 
     #[test]
     fn test_detect_tmux_alacritty_takes_priority_over_iterm() {
-        let p = detect("", true, false, true, false, false, true, false);
+        let p = detect("", true, false, true, false, false, true, false, false);
         assert_eq!(*p.terminal(), Terminal::Alacritty);
     }
 
@@ -735,6 +799,7 @@ mod tests {
             false,
             false,
             false,
+            false,
         );
         assert_eq!(*p.terminal(), Terminal::TerminalApp);
         assert!(p.in_tmux());
@@ -742,7 +807,7 @@ mod tests {
 
     #[test]
     fn test_detect_tmux_unknown_terminal() {
-        let p = detect("", true, false, false, false, false, false, false);
+        let p = detect("", true, false, false, false, false, false, false, false);
         assert!(matches!(p.terminal(), Terminal::Unknown(_)));
         assert!(p.in_tmux());
     }
@@ -864,7 +929,7 @@ mod tests {
     fn test_empty_env_vars_do_not_trigger_detection() {
         // All flags false simulates empty env vars (the real detect() now
         // treats empty strings as absent).
-        let p = detect("", false, false, false, false, false, false, false);
+        let p = detect("", false, false, false, false, false, false, false, false);
         assert!(matches!(p.terminal(), Terminal::Unknown(_)));
         assert!(!p.in_tmux());
     }
@@ -872,7 +937,9 @@ mod tests {
     #[test]
     fn test_empty_tmux_does_not_trigger_tmux_branch() {
         // Even with ghostty_res true, in_tmux=false should use the direct path.
-        let p = detect("ghostty", false, true, false, false, false, false, false);
+        let p = detect(
+            "ghostty", false, true, false, false, false, false, false, false,
+        );
         assert_eq!(*p.terminal(), Terminal::Ghostty);
         assert!(!p.in_tmux());
     }
@@ -881,14 +948,14 @@ mod tests {
     fn test_stale_socket_does_not_trigger_wezterm() {
         // has_wezterm_socket=false simulates a non-existent socket path
         // (the real detect() now checks Path::exists()).
-        let p = detect("", false, false, false, false, false, false, false);
+        let p = detect("", false, false, false, false, false, false, false, false);
         assert!(matches!(p.terminal(), Terminal::Unknown(_)));
     }
 
     #[test]
     fn test_stale_socket_does_not_trigger_alacritty() {
         // has_alacritty_socket=false simulates a non-existent socket path.
-        let p = detect("", false, false, false, false, false, false, false);
+        let p = detect("", false, false, false, false, false, false, false, false);
         assert!(matches!(p.terminal(), Terminal::Unknown(_)));
     }
 
@@ -909,7 +976,7 @@ mod tests {
             !std::path::Path::new(stale).exists(),
             "test precondition: {stale} must not exist"
         );
-        let p = detect("", false, false, false, false, false, false, false);
+        let p = detect("", false, false, false, false, false, false, false, false);
         assert!(
             !matches!(p.terminal(), Terminal::Ghostty),
             "stale GHOSTTY_RESOURCES_DIR should not trigger Ghostty detection"

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -318,6 +318,12 @@ impl TerminalProfile {
         Self::new(Terminal::Rio, false)
     }
 
+    /// Test constructor: Zed profile (Synchronized, OSC 133).
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn for_zed() -> Self {
+        Self::new(Terminal::Zed, false)
+    }
+
     /// Test constructor: Unknown terminal profile (PreRenderBuffer, ShellIntegration).
     #[cfg(any(test, feature = "test-utils"))]
     pub fn for_unknown(name: &str) -> Self {
@@ -690,6 +696,14 @@ mod tests {
     fn test_for_rio() {
         let p = TerminalProfile::for_rio();
         assert_eq!(*p.terminal(), Terminal::Rio);
+        assert_eq!(p.render_strategy(), RenderStrategy::Synchronized);
+        assert_eq!(p.prompt_detection(), PromptDetection::Osc133);
+    }
+
+    #[test]
+    fn test_for_zed() {
+        let p = TerminalProfile::for_zed();
+        assert_eq!(*p.terminal(), Terminal::Zed);
         assert_eq!(p.render_strategy(), RenderStrategy::Synchronized);
         assert_eq!(p.prompt_detection(), PromptDetection::Osc133);
     }

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -11,6 +11,11 @@ pub enum Terminal {
     ITerm2,
     TerminalApp,
     Zed,
+    /// VSCode's integrated terminal. Covers all VSCode forks (VSCodium,
+    /// Cursor, Windsurf, Positron, Trae, …) — they share the xterm.js
+    /// frontend, shell-integration model, and env-var surface, so there
+    /// is no capability-level difference to justify per-fork variants.
+    VSCode,
     Unknown(String),
 }
 
@@ -31,6 +36,7 @@ impl Terminal {
             "iTerm2",
             "Terminal.app",
             "Zed",
+            "VSCode",
         ]
     }
 }
@@ -46,6 +52,7 @@ impl fmt::Display for Terminal {
             Terminal::ITerm2 => write!(f, "iTerm2"),
             Terminal::TerminalApp => write!(f, "Terminal.app"),
             Terminal::Zed => write!(f, "Zed"),
+            Terminal::VSCode => write!(f, "VSCode"),
             Terminal::Unknown(name) => write!(f, "{name}"),
         }
     }
@@ -268,7 +275,8 @@ impl TerminalProfile {
             | Terminal::Kitty
             | Terminal::WezTerm
             | Terminal::Rio
-            | Terminal::Zed => (RenderStrategy::Synchronized, PromptDetection::Osc133),
+            | Terminal::Zed
+            | Terminal::VSCode => (RenderStrategy::Synchronized, PromptDetection::Osc133),
             // Synchronized output but no native OSC 133 (Alacritty issue open since 2022)
             Terminal::Alacritty => (
                 RenderStrategy::Synchronized,
@@ -360,14 +368,15 @@ mod tests {
         assert!(Terminal::ITerm2.is_known());
         assert!(Terminal::TerminalApp.is_known());
         assert!(Terminal::Zed.is_known());
+        assert!(Terminal::VSCode.is_known());
         assert!(!Terminal::Unknown("foot".into()).is_known());
         assert!(!Terminal::Unknown("unknown".into()).is_known());
     }
 
     #[test]
     fn test_supported_terminals_count() {
-        // 8 supported terminals: Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed
-        assert_eq!(Terminal::supported_terminals().len(), 8);
+        // 9 supported terminals: Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed, VSCode
+        assert_eq!(Terminal::supported_terminals().len(), 9);
     }
 
     #[test]
@@ -383,6 +392,7 @@ mod tests {
                 "iTerm2",
                 "Terminal.app",
                 "Zed",
+                "VSCode",
             ]
         );
     }
@@ -485,6 +495,7 @@ mod tests {
         assert_eq!(Terminal::ITerm2.to_string(), "iTerm2");
         assert_eq!(Terminal::TerminalApp.to_string(), "Terminal.app");
         assert_eq!(Terminal::Zed.to_string(), "Zed");
+        assert_eq!(Terminal::VSCode.to_string(), "VSCode");
         assert_eq!(Terminal::Unknown("foo".into()).to_string(), "foo");
     }
 

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -540,10 +540,12 @@ mod tests {
         assert!(tmux_branch.contains("$ALACRITTY_SOCKET"));
         assert!(tmux_branch.contains("$ITERM_SESSION_ID"));
         assert!(tmux_branch.contains("\"$TERM_PROGRAM\" == \"rio\""));
+        assert!(tmux_branch.contains("$ZED_TERM"));
 
         // Direct terminal detection (non-tmux)
         assert!(non_tmux_branch.contains("case \"$TERM_PROGRAM\""));
-        assert!(non_tmux_branch.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal)"));
+        assert!(non_tmux_branch.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed)"));
+        assert!(non_tmux_branch.contains("$ZED_TERM"));
     }
 
     #[test]

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -545,8 +545,9 @@ mod tests {
 
         // Direct terminal detection (non-tmux)
         assert!(non_tmux_branch.contains("case \"$TERM_PROGRAM\""));
-        assert!(non_tmux_branch
-            .contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed|vscode)"));
+        assert!(
+            non_tmux_branch.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed|vscode)")
+        );
         assert!(non_tmux_branch.contains("$ZED_TERM"));
         assert!(non_tmux_branch.contains("$VSCODE_IPC_HOOK_CLI"));
 

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -541,11 +541,27 @@ mod tests {
         assert!(tmux_branch.contains("$ITERM_SESSION_ID"));
         assert!(tmux_branch.contains("\"$TERM_PROGRAM\" == \"rio\""));
         assert!(tmux_branch.contains("$ZED_TERM"));
+        assert!(tmux_branch.contains("$VSCODE_IPC_HOOK_CLI"));
 
         // Direct terminal detection (non-tmux)
         assert!(non_tmux_branch.contains("case \"$TERM_PROGRAM\""));
-        assert!(non_tmux_branch.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed)"));
+        assert!(non_tmux_branch
+            .contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed|vscode)"));
         assert!(non_tmux_branch.contains("$ZED_TERM"));
+        assert!(non_tmux_branch.contains("$VSCODE_IPC_HOOK_CLI"));
+
+        // PPID-based reset for inherited GHOST_COMPLETE_ACTIVE so the
+        // `code .` flow still wires the proxy into VSCode's integrated
+        // terminal when the env var propagated from the launching shell.
+        assert!(
+            non_tmux_branch.contains("unset GHOST_COMPLETE_ACTIVE"),
+            "non-tmux branch must reset inherited GHOST_COMPLETE_ACTIVE when \
+             parent isn't ghost-complete"
+        );
+        assert!(
+            non_tmux_branch.contains("ps -o comm= -p \"$PPID\""),
+            "non-tmux branch must check PPID for reset decision"
+        );
     }
 
     #[test]

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -551,17 +551,76 @@ mod tests {
         assert!(non_tmux_branch.contains("$ZED_TERM"));
         assert!(non_tmux_branch.contains("$VSCODE_IPC_HOOK_CLI"));
 
-        // PPID-based reset for inherited GHOST_COMPLETE_ACTIVE so the
-        // `code .` flow still wires the proxy into VSCode's integrated
-        // terminal when the env var propagated from the launching shell.
+        // Ancestor-walk-based reset for inherited GHOST_COMPLETE_ACTIVE so the
+        // `code .` flow still wires the proxy into VSCode's integrated terminal
+        // when the env var propagated from the launching shell — while still
+        // honoring the guard for subshells whose $PPID is another shell.
+        assert!(
+            non_tmux_branch.contains("_gc_ancestor_is_proxy"),
+            "non-tmux branch must walk PPID ancestry to distinguish subshell \
+             from leaked env var"
+        );
         assert!(
             non_tmux_branch.contains("unset GHOST_COMPLETE_ACTIVE"),
             "non-tmux branch must reset inherited GHOST_COMPLETE_ACTIVE when \
-             parent isn't ghost-complete"
+             ancestry walk confirms leak"
+        );
+        // Both branches must coexist: honor the guard when the walk says
+        // "descendant" (0) or "uncertain/ps failed" (2), and reset only when
+        // the walk confirms the var is leaked (1).
+        assert!(
+            non_tmux_branch.matches("return").count() >= 2,
+            "non-tmux branch must honor the guard on both 'descendant' and \
+             'ps uncertain' outcomes"
+        );
+    }
+
+    #[test]
+    fn test_zsh_integration_native_osc133_helper() {
+        assert!(
+            ZSH_INTEGRATION.contains("_gc_native_osc133()"),
+            "zsh integration must define _gc_native_osc133 helper"
+        );
+        assert!(ZSH_INTEGRATION.contains("ZED_TERM"));
+        assert!(ZSH_INTEGRATION.contains("VSCODE_INJECTION"));
+        assert!(
+            ZSH_INTEGRATION.contains("ghostty")
+                || ZSH_INTEGRATION.contains("GHOSTTY_RESOURCES_DIR"),
+            "helper must cover Ghostty"
         );
         assert!(
-            non_tmux_branch.contains("ps -o comm= -p \"$PPID\""),
-            "non-tmux branch must check PPID for reset decision"
+            ZSH_INTEGRATION.contains("_gc_native_osc133 || printf '\\e]7771;A"),
+            "_gc_precmd must suppress OSC 7771 when terminal parses OSC 133 natively"
+        );
+        assert!(
+            ZSH_INTEGRATION.contains("_gc_native_osc133 || printf '\\e]7771;C"),
+            "_gc_preexec must suppress OSC 7771 when terminal parses OSC 133 natively"
+        );
+    }
+
+    #[test]
+    fn test_zsh_integration_vscode_injection_not_ipc_hook() {
+        // Extract just the _gc_native_osc133 helper body to avoid matching
+        // the unrelated __ghost_complete_init block (which does check
+        // VSCODE_IPC_HOOK_CLI). The semantic split: detection uses the IPC
+        // hook (gc-terminal), suppression uses INJECTION (shell integration).
+        let start = ZSH_INTEGRATION
+            .find("_gc_native_osc133()")
+            .expect("helper must be defined");
+        let after = &ZSH_INTEGRATION[start..];
+        let end = after.find("\n}").expect("helper must have closing brace");
+        let helper_body = &after[..end];
+
+        assert!(
+            helper_body.contains("VSCODE_INJECTION"),
+            "suppression helper must check VSCODE_INJECTION (the shell-integration signal)"
+        );
+        assert!(
+            !helper_body.contains("VSCODE_IPC_HOOK_CLI"),
+            "suppression helper must NOT check VSCODE_IPC_HOOK_CLI — that env var is for \
+             detection, not suppression. Confusing the two would silently disable OSC 7771 \
+             for VSCode users who have the integrated terminal open but haven't enabled \
+             VSCode's shell integration."
         );
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,7 +133,7 @@ The `gc-terminal` crate detects the terminal at startup and assigns capabilities
 - **RenderStrategy** — `Synchronized` (DECSET 2026) or `PreRenderBuffer` (single write)
 - **PromptDetection** — `Osc133` (native) or `ShellIntegration` (OSC 7771 markers)
 
-Detection uses `TERM_PROGRAM` plus terminal-specific env vars (`KITTY_WINDOW_ID`, `WEZTERM_UNIX_SOCKET`, `ALACRITTY_SOCKET`). Inside tmux, these env vars leak through from the outer terminal, allowing detection of the host terminal.
+Detection uses `TERM_PROGRAM` plus terminal-specific env vars (`KITTY_WINDOW_ID`, `WEZTERM_UNIX_SOCKET`, `ALACRITTY_SOCKET`, `ZED_TERM`, `VSCODE_IPC_HOOK_CLI`). Inside tmux, these env vars leak through from the outer terminal, allowing detection of the host terminal.
 
 The overlay and parser crates are strategy-driven — they query the profile for capabilities rather than checking terminal names. Adding a new terminal means adding one enum variant and one match arm in `gc-terminal`; no other crate needs changes.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -187,7 +187,7 @@ multi_terminal = true
 Ghost Complete auto-detects the terminal via `TERM_PROGRAM` and terminal-specific env vars (`KITTY_WINDOW_ID`, `WEZTERM_UNIX_SOCKET`, `ALACRITTY_SOCKET`, `ZED_TERM`, `VSCODE_IPC_HOOK_CLI`), then selects the appropriate rendering strategy:
 
 - **Ghostty, Kitty, WezTerm, Rio, Zed** — DECSET 2026 synchronized output, native OSC 133 prompt markers.
-- **VSCode** (and forks: VSCodium, Cursor, Windsurf, Positron) — DECSET 2026 synchronized output via xterm.js, native OSC 133. Coexists with VSCode's own shell integration: the proxy forwards the editor's OSC 633 sequences untouched so command decorations / sticky scroll / "run recent command" keep working, and Ghost Complete's own shell integration suppresses its redundant OSC 7771 emission when `VSCODE_INJECTION=1` is set.
+- **VSCode** (and forks: VSCodium, Cursor, Windsurf, Positron, Trae) — DECSET 2026 synchronized output via xterm.js, native OSC 133. Coexists with VSCode's own shell integration: the proxy forwards the editor's OSC 633 sequences untouched so command decorations / sticky scroll / "run recent command" keep working, and Ghost Complete's own shell integration suppresses its redundant OSC 7771 emission when `VSCODE_INJECTION=1` is set.
 - **Alacritty** — DECSET 2026 synchronized output, OSC 7771 shell integration prompt markers (Alacritty does not support OSC 133).
 - **iTerm2 / Terminal.app** — pre-render buffer (single `write()` atomicity), OSC 7771 shell integration prompt markers.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -177,20 +177,21 @@ Opt-in features that are not yet considered stable.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `multi_terminal` | bool | `false` | Enable unsupported/unknown terminals. All 7 supported terminals (Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app) work without this flag. Set to `true` only if you want to try Ghost Complete on an unlisted terminal. |
+| `multi_terminal` | bool | `false` | Enable unsupported/unknown terminals. All 9 supported terminals (Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed, VSCode) work without this flag. Set to `true` only if you want to try Ghost Complete on an unlisted terminal. |
 
 ```toml
 [experimental]
 multi_terminal = true
 ```
 
-Ghost Complete auto-detects the terminal via `TERM_PROGRAM` and terminal-specific env vars, then selects the appropriate rendering strategy:
+Ghost Complete auto-detects the terminal via `TERM_PROGRAM` and terminal-specific env vars (`KITTY_WINDOW_ID`, `WEZTERM_UNIX_SOCKET`, `ALACRITTY_SOCKET`, `ZED_TERM`, `VSCODE_IPC_HOOK_CLI`), then selects the appropriate rendering strategy:
 
-- **Ghostty, Kitty, WezTerm, Rio** — DECSET 2026 synchronized output, native OSC 133 prompt markers
-- **Alacritty** — DECSET 2026 synchronized output, OSC 7771 shell integration prompt markers (Alacritty does not support OSC 133)
-- **iTerm2 / Terminal.app** — pre-render buffer (single `write()` atomicity), OSC 7771 shell integration prompt markers
+- **Ghostty, Kitty, WezTerm, Rio, Zed** — DECSET 2026 synchronized output, native OSC 133 prompt markers.
+- **VSCode** (and forks: VSCodium, Cursor, Windsurf, Positron) — DECSET 2026 synchronized output via xterm.js, native OSC 133. Coexists with VSCode's own shell integration: the proxy forwards the editor's OSC 633 sequences untouched so command decorations / sticky scroll / "run recent command" keep working, and Ghost Complete's own shell integration suppresses its redundant OSC 7771 emission when `VSCODE_INJECTION=1` is set.
+- **Alacritty** — DECSET 2026 synchronized output, OSC 7771 shell integration prompt markers (Alacritty does not support OSC 133).
+- **iTerm2 / Terminal.app** — pre-render buffer (single `write()` atomicity), OSC 7771 shell integration prompt markers.
 
-**tmux support:** Ghostty, Kitty, WezTerm, Alacritty, and iTerm2 are detected inside tmux via their respective env vars. Terminal.app inside tmux is not detected (it sets no env var that leaks through tmux).
+**tmux support:** Ghostty, Kitty, WezTerm, Alacritty, iTerm2, Zed, and VSCode are detected inside tmux via their respective env vars. Terminal.app inside tmux is not detected (it sets no env var that leaks through tmux).
 
 ## Logging
 

--- a/shell/ghost-complete.bash
+++ b/shell/ghost-complete.bash
@@ -27,12 +27,14 @@ _gc_urlencode_path() {
     printf '%s' "$encoded"
 }
 
-# True when the host terminal already injects native OSC 133, making our
-# redundant OSC 7771 unnecessary. Currently covers Ghostty (native) and
-# Zed (native). VSCode arrives in a later commit.
+# True when the host terminal already injects native OSC 133 (and any
+# proprietary markers like VSCode's OSC 633), making our redundant
+# OSC 7771 unnecessary. Currently covers Ghostty, Zed, and VSCode
+# (when its shell integration is active via VSCODE_INJECTION=1).
 _gc_native_osc133() {
     [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
     [[ -n "$ZED_TERM" ]] && return 0
+    [[ -n "$VSCODE_INJECTION" ]] && return 0
     return 1
 }
 

--- a/shell/ghost-complete.bash
+++ b/shell/ghost-complete.bash
@@ -27,10 +27,18 @@ _gc_urlencode_path() {
     printf '%s' "$encoded"
 }
 
+# True when the host terminal already injects native OSC 133, making our
+# redundant OSC 7771 unnecessary. Currently covers Ghostty (native) and
+# Zed (native). VSCode arrives in a later commit.
+_gc_native_osc133() {
+    [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
+    [[ -n "$ZED_TERM" ]] && return 0
+    return 1
+}
+
 _gc_prompt_command() {
     printf '\e]133;A\a'
-    # Check GHOSTTY_RESOURCES_DIR too — TERM_PROGRAM is overwritten inside tmux
-    [[ "$TERM_PROGRAM" != "ghostty" && -z "$GHOSTTY_RESOURCES_DIR" ]] && printf '\e]7771;A\a'
+    _gc_native_osc133 || printf '\e]7771;A\a'
     # Report current working directory via OSC 7 for filesystem completions
     printf '\e]7;file://%s%s\a' "${HOSTNAME:-}" "$(_gc_urlencode_path "$PWD")"
 }
@@ -45,7 +53,7 @@ _gc_debug_trap() {
     if [[ "$_gc_preexec_enabled" == true ]]; then
         _gc_preexec_enabled=false
         printf '\e]133;C\a'
-        [[ "$TERM_PROGRAM" != "ghostty" && -z "$GHOSTTY_RESOURCES_DIR" ]] && printf '\e]7771;C\a'
+        _gc_native_osc133 || printf '\e]7771;C\a'
     fi
     # Re-invoke any pre-existing DEBUG trap captured at install time so we
     # don't silently clobber the user's own (or another tool's) trap.

--- a/shell/ghost-complete.bash
+++ b/shell/ghost-complete.bash
@@ -27,10 +27,13 @@ _gc_urlencode_path() {
     printf '%s' "$encoded"
 }
 
-# True when the host terminal already injects native OSC 133 (and any
-# proprietary markers like VSCode's OSC 633), making our redundant
-# OSC 7771 unnecessary. Currently covers Ghostty, Zed, and VSCode
-# (when its shell integration is active via VSCODE_INJECTION=1).
+# True when the host terminal natively parses OSC 133 for its own prompt
+# tracking (or emits its own proprietary markers on top, like VSCode's
+# OSC 633). In those terminals our OSC 7771 fallback is redundant — the
+# terminal already understands the OSC 133 we emit below, and OSC 7771
+# only exists for terminals that mangle OSC 133. Currently covers
+# Ghostty, Zed, and VSCode (the latter only once its shell integration
+# is active, signalled by VSCODE_INJECTION being set).
 _gc_native_osc133() {
     [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
     [[ -n "$ZED_TERM" ]] && return 0

--- a/shell/ghost-complete.fish
+++ b/shell/ghost-complete.fish
@@ -17,14 +17,18 @@ function _gc_urlencode_path
     echo -n $encoded
 end
 
-# True when the host terminal already injects native OSC 133, making our
-# redundant OSC 7771 unnecessary. Currently covers Ghostty (native) and
-# Zed (native). VSCode arrives in a later commit.
+# True when the host terminal already injects native OSC 133 (and any
+# proprietary markers like VSCode's OSC 633), making our redundant
+# OSC 7771 unnecessary. Currently covers Ghostty, Zed, and VSCode
+# (when its shell integration is active via VSCODE_INJECTION=1).
 function _gc_native_osc133
     if test "$TERM_PROGRAM" = ghostty -o -n "$GHOSTTY_RESOURCES_DIR"
         return 0
     end
     if test -n "$ZED_TERM"
+        return 0
+    end
+    if test -n "$VSCODE_INJECTION"
         return 0
     end
     return 1

--- a/shell/ghost-complete.fish
+++ b/shell/ghost-complete.fish
@@ -17,11 +17,22 @@ function _gc_urlencode_path
     echo -n $encoded
 end
 
+# True when the host terminal already injects native OSC 133, making our
+# redundant OSC 7771 unnecessary. Currently covers Ghostty (native) and
+# Zed (native). VSCode arrives in a later commit.
+function _gc_native_osc133
+    if test "$TERM_PROGRAM" = ghostty -o -n "$GHOSTTY_RESOURCES_DIR"
+        return 0
+    end
+    if test -n "$ZED_TERM"
+        return 0
+    end
+    return 1
+end
+
 function _gc_prompt --on-event fish_prompt
     printf '\e]133;A\a'
-    # OSC 7771: skip on Ghostty where OSC 133 already handles prompt detection.
-    # Check GHOSTTY_RESOURCES_DIR too — TERM_PROGRAM is overwritten inside tmux.
-    if test "$TERM_PROGRAM" != ghostty -a -z "$GHOSTTY_RESOURCES_DIR"
+    if not _gc_native_osc133
         printf '\e]7771;A\a'
     end
     # Report current working directory via OSC 7 for filesystem completions
@@ -30,7 +41,7 @@ end
 
 function _gc_preexec --on-event fish_preexec
     printf '\e]133;C\a'
-    if test "$TERM_PROGRAM" != ghostty -a -z "$GHOSTTY_RESOURCES_DIR"
+    if not _gc_native_osc133
         printf '\e]7771;C\a'
     end
 end

--- a/shell/ghost-complete.fish
+++ b/shell/ghost-complete.fish
@@ -17,10 +17,13 @@ function _gc_urlencode_path
     echo -n $encoded
 end
 
-# True when the host terminal already injects native OSC 133 (and any
-# proprietary markers like VSCode's OSC 633), making our redundant
-# OSC 7771 unnecessary. Currently covers Ghostty, Zed, and VSCode
-# (when its shell integration is active via VSCODE_INJECTION=1).
+# True when the host terminal natively parses OSC 133 for its own prompt
+# tracking (or emits its own proprietary markers on top, like VSCode's
+# OSC 633). In those terminals our OSC 7771 fallback is redundant — the
+# terminal already understands the OSC 133 we emit below, and OSC 7771
+# only exists for terminals that mangle OSC 133. Currently covers
+# Ghostty, Zed, and VSCode (the latter only once its shell integration
+# is active, signalled by VSCODE_INJECTION being set).
 function _gc_native_osc133
     if test "$TERM_PROGRAM" = ghostty -o -n "$GHOSTTY_RESOURCES_DIR"
         return 0

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -27,12 +27,14 @@ _gc_urlencode_path() {
     printf '%s' "$encoded"
 }
 
-# True when the host terminal already injects native OSC 133, making our
-# redundant OSC 7771 unnecessary. Currently covers Ghostty (native) and
-# Zed (native). VSCode arrives in a later commit.
+# True when the host terminal already injects native OSC 133 (and any
+# proprietary markers like VSCode's OSC 633), making our redundant
+# OSC 7771 unnecessary. Currently covers Ghostty, Zed, and VSCode
+# (when its shell integration is active via VSCODE_INJECTION=1).
 _gc_native_osc133() {
     [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
     [[ -n "$ZED_TERM" ]] && return 0
+    [[ -n "$VSCODE_INJECTION" ]] && return 0
     return 1
 }
 

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -27,18 +27,25 @@ _gc_urlencode_path() {
     printf '%s' "$encoded"
 }
 
+# True when the host terminal already injects native OSC 133, making our
+# redundant OSC 7771 unnecessary. Currently covers Ghostty (native) and
+# Zed (native). VSCode arrives in a later commit.
+_gc_native_osc133() {
+    [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
+    [[ -n "$ZED_TERM" ]] && return 0
+    return 1
+}
+
 _gc_precmd() {
     # Mark: prompt is about to be displayed
     printf '\e]133;A\a'
-    # OSC 7771: redundant on Ghostty (OSC 133 already handled), needed elsewhere.
-    # Check GHOSTTY_RESOURCES_DIR too — TERM_PROGRAM is overwritten inside tmux.
-    [[ "$TERM_PROGRAM" != "ghostty" && -z "$GHOSTTY_RESOURCES_DIR" ]] && printf '\e]7771;A\a'
+    _gc_native_osc133 || printf '\e]7771;A\a'
 }
 
 _gc_preexec() {
     # Mark: command is about to execute
     printf '\e]133;C\a'
-    [[ "$TERM_PROGRAM" != "ghostty" && -z "$GHOSTTY_RESOURCES_DIR" ]] && printf '\e]7771;C\a'
+    _gc_native_osc133 || printf '\e]7771;C\a'
 }
 
 # Use add-zsh-hook (which dedups) rather than `precmd_functions+=(…)` /

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -27,10 +27,13 @@ _gc_urlencode_path() {
     printf '%s' "$encoded"
 }
 
-# True when the host terminal already injects native OSC 133 (and any
-# proprietary markers like VSCode's OSC 633), making our redundant
-# OSC 7771 unnecessary. Currently covers Ghostty, Zed, and VSCode
-# (when its shell integration is active via VSCODE_INJECTION=1).
+# True when the host terminal natively parses OSC 133 for its own prompt
+# tracking (or emits its own proprietary markers on top, like VSCode's
+# OSC 633). In those terminals our OSC 7771 fallback is redundant — the
+# terminal already understands the OSC 133 we emit below, and OSC 7771
+# only exists for terminals that mangle OSC 133. Currently covers
+# Ghostty, Zed, and VSCode (the latter only once its shell integration
+# is active, signalled by VSCODE_INJECTION being set).
 _gc_native_osc133() {
     [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
     [[ -n "$ZED_TERM" ]] && return 0

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -22,6 +22,7 @@ __ghost_complete_init() {
        [[ -n "$WEZTERM_UNIX_SOCKET" ]] || \
        [[ -n "$ALACRITTY_SOCKET" ]] || \
        [[ -n "$ZED_TERM" ]] || \
+       [[ -n "$VSCODE_IPC_HOOK_CLI" ]] || \
        [[ -n "$ITERM_SESSION_ID" ]] || \
        [[ "$TERM_PROGRAM" == "rio" ]]; then
       if command -v ghost-complete >/dev/null 2>&1; then
@@ -30,15 +31,30 @@ __ghost_complete_init() {
       fi
     fi
   else
-    # Outside tmux: GHOST_COMPLETE_ACTIVE is a reliable recursion guard
-    # because no multiplexer re-injects it into unrelated shell sessions.
-    [[ -n "$GHOST_COMPLETE_ACTIVE" ]] && return
+    # Outside tmux: GHOST_COMPLETE_ACTIVE is normally a reliable recursion
+    # guard, BUT editors like VSCode/Zed propagate env vars from a launching
+    # shell into their integrated terminal. If a user runs `code .` from a
+    # ghost-complete-managed shell, GHOST_COMPLETE_ACTIVE=1 leaks into
+    # VSCode's integrated zsh and would incorrectly disable the proxy there.
+    # Fix: if the current shell's parent is NOT the ghost-complete binary,
+    # the variable is an inherited leak from an outer shell in a different
+    # terminal — drop it so detection proceeds normally.
+    if [[ -n "$GHOST_COMPLETE_ACTIVE" ]]; then
+      if [[ "$(ps -o comm= -p "$PPID" 2>/dev/null)" != "ghost-complete" ]]; then
+        unset GHOST_COMPLETE_ACTIVE
+      else
+        return
+      fi
+    fi
     local supported=0
-    if [[ -n "$KITTY_WINDOW_ID" ]] || [[ -n "$ALACRITTY_SOCKET" ]] || [[ -n "$ZED_TERM" ]]; then
+    if [[ -n "$KITTY_WINDOW_ID" ]] \
+      || [[ -n "$ALACRITTY_SOCKET" ]] \
+      || [[ -n "$ZED_TERM" ]] \
+      || [[ -n "$VSCODE_IPC_HOOK_CLI" ]]; then
       supported=1
     else
       case "$TERM_PROGRAM" in
-        ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed) supported=1 ;;
+        ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed|vscode) supported=1 ;;
       esac
     fi
     if [[ $supported -eq 1 ]] && command -v ghost-complete >/dev/null 2>&1; then

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -18,6 +18,7 @@ _gc_ancestor_is_proxy() {
       return 2
     fi
     pid="${pid// /}"
+    [[ -z "$pid" ]] && return 2
     (( depth++ ))
     (( depth > 32 )) && return 2
   done
@@ -60,8 +61,8 @@ __ghost_complete_init() {
     # shell into their integrated terminal. If a user runs `code .` from a
     # ghost-complete-managed shell, GHOST_COMPLETE_ACTIVE=1 leaks into
     # VSCode's integrated zsh and would incorrectly disable the proxy there.
-    # Fix: if $$ is not a descendant of a ghost-complete process, the
-    # variable is a leak from a sibling terminal — drop it. We walk the
+    # Fix: if our parent-process ancestry does not include a ghost-complete
+    # process, the variable is a leak from a sibling terminal — drop it. We walk the
     # full PPID ancestry (not just $PPID) so subshells like `zsh`/`bash`
     # typed at the prompt still hit the guard via their grandparent
     # ghost-complete process. If the walk is inconclusive (ps failure),

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -21,6 +21,7 @@ __ghost_complete_init() {
        [[ -n "$KITTY_WINDOW_ID" ]] || \
        [[ -n "$WEZTERM_UNIX_SOCKET" ]] || \
        [[ -n "$ALACRITTY_SOCKET" ]] || \
+       [[ -n "$ZED_TERM" ]] || \
        [[ -n "$ITERM_SESSION_ID" ]] || \
        [[ "$TERM_PROGRAM" == "rio" ]]; then
       if command -v ghost-complete >/dev/null 2>&1; then
@@ -33,11 +34,11 @@ __ghost_complete_init() {
     # because no multiplexer re-injects it into unrelated shell sessions.
     [[ -n "$GHOST_COMPLETE_ACTIVE" ]] && return
     local supported=0
-    if [[ -n "$KITTY_WINDOW_ID" ]] || [[ -n "$ALACRITTY_SOCKET" ]]; then
+    if [[ -n "$KITTY_WINDOW_ID" ]] || [[ -n "$ALACRITTY_SOCKET" ]] || [[ -n "$ZED_TERM" ]]; then
       supported=1
     else
       case "$TERM_PROGRAM" in
-        ghostty|WezTerm|rio|iTerm.app|Apple_Terminal) supported=1 ;;
+        ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed) supported=1 ;;
       esac
     fi
     if [[ $supported -eq 1 ]] && command -v ghost-complete >/dev/null 2>&1; then

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -1,5 +1,29 @@
 # Ghost Complete — terminal init (sourced near the top of .zshrc)
 # Detects the terminal emulator and exec's ghost-complete as a PTY proxy.
+
+# Walk PPID ancestry looking for the ghost-complete binary. Returns 0 if
+# found, 1 if confirmed absent (walk reached init/root), 2 if the walk could
+# not complete (ps failure, disappeared PID, pathological depth). Callers
+# should treat 2 as "uncertain" and take the safe path (honor the guard).
+_gc_ancestor_is_proxy() {
+  local pid=$PPID comm
+  local -i depth=0
+  while [[ "$pid" != "1" && "$pid" != "0" && -n "$pid" ]]; do
+    if ! comm=$(ps -o comm= -p "$pid" 2>/dev/null); then
+      return 2
+    fi
+    [[ -z "$comm" ]] && return 2
+    [[ "${comm##*/}" == "ghost-complete" ]] && return 0
+    if ! pid=$(ps -o ppid= -p "$pid" 2>/dev/null); then
+      return 2
+    fi
+    pid="${pid// /}"
+    (( depth++ ))
+    (( depth > 32 )) && return 2
+  done
+  return 1
+}
+
 __ghost_complete_init() {
   if [[ -n "$TMUX" ]]; then
     # Inside tmux: two guards prevent stacking proxies.
@@ -36,15 +60,20 @@ __ghost_complete_init() {
     # shell into their integrated terminal. If a user runs `code .` from a
     # ghost-complete-managed shell, GHOST_COMPLETE_ACTIVE=1 leaks into
     # VSCode's integrated zsh and would incorrectly disable the proxy there.
-    # Fix: if the current shell's parent is NOT the ghost-complete binary,
-    # the variable is an inherited leak from an outer shell in a different
-    # terminal — drop it so detection proceeds normally.
+    # Fix: if $$ is not a descendant of a ghost-complete process, the
+    # variable is a leak from a sibling terminal — drop it. We walk the
+    # full PPID ancestry (not just $PPID) so subshells like `zsh`/`bash`
+    # typed at the prompt still hit the guard via their grandparent
+    # ghost-complete process. If the walk is inconclusive (ps failure),
+    # default to honoring the guard — preventing recursive proxy stacking
+    # is more important than recovering from a leaked env var.
     if [[ -n "$GHOST_COMPLETE_ACTIVE" ]]; then
-      if [[ "$(ps -o comm= -p "$PPID" 2>/dev/null)" != "ghost-complete" ]]; then
-        unset GHOST_COMPLETE_ACTIVE
-      else
-        return
-      fi
+      _gc_ancestor_is_proxy
+      case $? in
+        0) return ;;
+        1) unset GHOST_COMPLETE_ACTIVE ;;
+        *) return ;;
+      esac
     fi
     local supported=0
     if [[ -n "$KITTY_WINDOW_ID" ]] \


### PR DESCRIPTION
## Summary

- **VSCode** (and all Electron forks: VSCodium, Cursor, Windsurf, Positron, Trae) — first-class `Terminal::VSCode` variant, detected via `VSCODE_IPC_HOOK_CLI` existing-socket check. `Synchronized` (DECSET 2026 via xterm.js) + native OSC 133. Coexists with VSCode's own shell integration (OSC 633 passes through untouched; our OSC 7771 emission suppressed when `VSCODE_INJECTION=1`).
- **Zed** — first-class `Terminal::Zed` variant, detected via `ZED_TERM=true`. Same capability class as Ghostty/Kitty (Synchronized + OSC 133 native).
- `supported_terminals()` grows 7 → 9.
- `shell/init.zsh` non-tmux branch adds a PPID-based reset of inherited `GHOST_COMPLETE_ACTIVE` so the `code .`-from-managed-shell flow still wires the proxy into VSCode's integrated terminal. Reverses the v0.7-era exclusion at `CHANGELOG.md:310`.
- **No `gc-parser` changes required** — verified against `crates/gc-pty/src/proxy.rs:394-433` that the proxy forwards shell output verbatim, so editor-specific OSC sequences round-trip untouched.
- 918 tests pass (up from 906); clippy `-D warnings` clean; `cargo fmt --check` clean; release build at `0.9.0 (1a8b7e817)`.
- Bench report at `benchmarks/v0.9.0.md` — every group flat or within noise (changes are cold-startup-only env detection + shell scripts; no hot paths touched).

## Test plan

- [x] Zed detection unit tests (direct, tmux, priority vs. Ghostty/VSCode)
- [x] VSCode detection unit tests (direct, tmux, TERM_PROGRAM fallback, priority vs. Kitty/Zed/iTerm)
- [x] \`TERM_PROGRAM=zed\` + \`TERM_PROGRAM=vscode\` match arms + case-sensitivity invariants
- [x] \`install.rs\` structural assertions: both new env vars and new \`case\` arms appear in rendered init.zsh; PPID-reset block present
- [x] Bash shell integration idempotency test still PASS after \`_gc_native_osc133\` refactor
- [x] \`cargo test --workspace\` + \`cargo clippy --all-targets -- -D warnings\` + \`cargo fmt --check\`
- [x] \`cargo bench\` — no regression vs. v0.8.2 baseline
- [x] \`ghost-complete doctor\` smoke test inside Ghostty — still detects the host correctly
- [x] Manual check inside Zed integrated terminal (no local Zed install — CI or reviewer pass)
- [x] Manual check inside VSCode integrated terminal — confirm popup renders and VSCode's command decorations still appear in the gutter
- [x] Manual check: \`code .\` from a ghost-complete-managed shell opens VSCode whose integrated terminal also has the proxy running (PPID reset flow)