### PR TITLE
fix: surface git refs above history on `git checkout <TAB>`

### DIFF
--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -938,7 +938,20 @@ impl InputHandler {
                 // the pathological-provider case entirely. Deferred until a
                 // real-world report of a >10k-item provider.
                 self.suggestions = if current_word.is_empty() {
-                    merged
+                    // Sort by kind priority so dynamic arrivals (git branches,
+                    // tags — priorities 0/1/2) land above any sync residuals
+                    // (flags=4, files=7, history=8). Without this, the extend
+                    // above leaves branches glued to the tail of the sync pool
+                    // on `git checkout <TAB>`, which is the exact regression
+                    // the reported bug exhibits.
+                    let mut m = merged;
+                    m.sort_by(|a, b| {
+                        a.kind
+                            .sort_priority()
+                            .cmp(&b.kind.sort_priority())
+                            .then_with(|| a.text.cmp(&b.text))
+                    });
+                    m
                 } else {
                     gc_suggest::fuzzy::rank(&current_word, merged, self.max_visible * 5)
                 };
@@ -1321,6 +1334,75 @@ mod tests {
         assert_eq!(key_to_bytes(&KeyEvent::Ctrl('a')), vec![0x01]);
         assert_eq!(key_to_bytes(&KeyEvent::Ctrl('d')), vec![0x04]);
         assert_eq!(key_to_bytes(&KeyEvent::Ctrl('z')), vec![0x1A]);
+    }
+
+    #[test]
+    fn test_try_merge_dynamic_empty_query_sorts_branches_before_history_and_files() {
+        // Regression for the `git checkout <TAB>` user report: the sync pass
+        // returns [filesystem files, history], the popup paints, and then
+        // async git branches arrive. Previously the empty-query branch of
+        // `try_merge_dynamic` skipped sorting entirely and just `extend`-ed,
+        // which left branches stranded BELOW the earlier rows. Branches must
+        // sort to the top by kind priority.
+        use gc_suggest::SuggestionKind;
+
+        let mut handler = make_visible_handler(vec![
+            Suggestion {
+                text: "Makefile".to_string(),
+                kind: SuggestionKind::FilePath,
+                source: SuggestionSource::Filesystem,
+                ..Default::default()
+            },
+            Suggestion {
+                text: "git checkout demo".to_string(),
+                kind: SuggestionKind::History,
+                source: SuggestionSource::History,
+                ..Default::default()
+            },
+        ]);
+
+        // Prime the snapshot so the staleness check against a freshly-parsed
+        // empty buffer passes (both ends resolve to command=None, args=[], word_index=0).
+        let base_ctx = gc_buffer::parse_command_context("", 0);
+        handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
+
+        let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
+        tx.try_send(vec![
+            Suggestion {
+                text: "main".to_string(),
+                kind: SuggestionKind::GitBranch,
+                source: SuggestionSource::Git,
+                ..Default::default()
+            },
+            Suggestion {
+                text: "v1.0".to_string(),
+                kind: SuggestionKind::GitTag,
+                source: SuggestionSource::Git,
+                ..Default::default()
+            },
+        ])
+        .unwrap();
+        drop(tx);
+        handler.dynamic_rx = Some(rx);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let merged = handler.try_merge_dynamic(&parser, &mut buf);
+
+        assert!(merged, "merge should have happened");
+        let kinds: Vec<SuggestionKind> = handler.suggestions.iter().map(|s| s.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                SuggestionKind::GitBranch,
+                SuggestionKind::GitTag,
+                SuggestionKind::FilePath,
+                SuggestionKind::History,
+            ],
+            "branches and tags must land above files and history on empty query: {:?}",
+            handler.suggestions,
+        );
     }
 
     #[test]

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -939,11 +939,10 @@ impl InputHandler {
                 // real-world report of a >10k-item provider.
                 self.suggestions = if current_word.is_empty() {
                     // Sort by kind priority so dynamic arrivals (git branches,
-                    // tags — priorities 0/1/2) land above any sync residuals
-                    // (flags=4, files=7, history=8). Without this, the extend
-                    // above leaves branches glued to the tail of the sync pool
-                    // on `git checkout <TAB>`, which is the exact regression
-                    // the reported bug exhibits.
+                    // tags, remotes — priorities 0/1/2) land above any sync
+                    // residuals (flags=4, files=7, history=8). Without this,
+                    // the extend above leaves branches glued to the tail of
+                    // the sync pool on `git checkout <TAB>`.
                     let mut m = merged;
                     m.sort_by(|a, b| {
                         a.kind
@@ -1338,9 +1337,9 @@ mod tests {
 
     #[test]
     fn test_try_merge_dynamic_empty_query_sorts_branches_before_history_and_files() {
-        // Regression for the `git checkout <TAB>` user report: the sync pass
-        // returns [filesystem files, history], the popup paints, and then
-        // async git branches arrive. Previously the empty-query branch of
+        // Regression: on `git checkout <TAB>` the sync pass returns
+        // [filesystem files, history], the popup paints, and then async git
+        // branches arrive. Previously the empty-query branch of
         // `try_merge_dynamic` skipped sorting entirely and just `extend`-ed,
         // which left branches stranded BELOW the earlier rows. Branches must
         // sort to the top by kind priority.
@@ -1401,6 +1400,67 @@ mod tests {
                 SuggestionKind::History,
             ],
             "branches and tags must land above files and history on empty query: {:?}",
+            handler.suggestions,
+        );
+    }
+
+    #[test]
+    fn test_try_merge_dynamic_empty_query_stable_tiebreak_by_text() {
+        // When two dynamic arrivals share the same `sort_priority` (e.g. two
+        // `GitBranch` entries), the comparator falls through to
+        // `then_with(|| a.text.cmp(&b.text))` so the popup order is
+        // alphabetic rather than channel-arrival order. Locks in both tiers
+        // of the comparator: kind-priority first, text second.
+        use gc_suggest::SuggestionKind;
+
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "Makefile".to_string(),
+            kind: SuggestionKind::FilePath,
+            source: SuggestionSource::Filesystem,
+            ..Default::default()
+        }]);
+
+        let base_ctx = gc_buffer::parse_command_context("", 0);
+        handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
+
+        let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
+        tx.try_send(vec![
+            Suggestion {
+                text: "zeta".to_string(),
+                kind: SuggestionKind::GitBranch,
+                source: SuggestionSource::Git,
+                ..Default::default()
+            },
+            Suggestion {
+                text: "alpha".to_string(),
+                kind: SuggestionKind::GitBranch,
+                source: SuggestionSource::Git,
+                ..Default::default()
+            },
+        ])
+        .unwrap();
+        drop(tx);
+        handler.dynamic_rx = Some(rx);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let merged = handler.try_merge_dynamic(&parser, &mut buf);
+
+        assert!(merged, "merge should have happened");
+        let ordered: Vec<(SuggestionKind, String)> = handler
+            .suggestions
+            .iter()
+            .map(|s| (s.kind, s.text.clone()))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                (SuggestionKind::GitBranch, "alpha".to_string()),
+                (SuggestionKind::GitBranch, "zeta".to_string()),
+                (SuggestionKind::FilePath, "Makefile".to_string()),
+            ],
+            "same-priority branches must tiebreak alphabetically and both land above files: {:?}",
             handler.suggestions,
         );
     }

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -997,6 +997,81 @@ mod tests {
     }
 
     #[test]
+    fn test_git_checkout_with_flag_prefix_still_shows_flags() {
+        // Locks in the `!ctx.is_flag` half of `defer_to_git_refs`. Typing `-`
+        // after `git checkout` is an explicit signal the user wants flags —
+        // the ref-deferral path must NOT swallow them. Branch/tag generators
+        // should still be dispatched in parallel so refs keep loading async.
+        let engine = make_engine();
+        let ctx = make_ctx(Some("git"), vec!["checkout"], "-", 2);
+        let results = engine
+            .suggest_sync(&ctx, Path::new("/tmp"), "git checkout -")
+            .unwrap();
+
+        assert!(
+            results
+                .suggestions
+                .iter()
+                .any(|s| s.kind == SuggestionKind::Flag),
+            "flags must appear when current_word starts with '-': {:?}",
+            results.suggestions,
+        );
+        assert!(
+            results
+                .git_generators
+                .contains(&crate::git::GitQueryKind::Branches),
+            "branch generator must still be dispatched even with flag prefix: {results:?}"
+        );
+        assert!(
+            results
+                .git_generators
+                .contains(&crate::git::GitQueryKind::Tags),
+            "tag generator must still be dispatched even with flag prefix: {results:?}"
+        );
+    }
+
+    #[test]
+    fn test_git_checkout_with_path_like_word_does_not_defer_to_refs() {
+        // Locks in the `!looks_like_path(&ctx.current_word)` half of
+        // `defer_to_git_refs`. When the user has signalled a path
+        // (leading `.`, leading `~`, or embedded `/`), history must NOT be
+        // suppressed — otherwise `git checkout ./foo`, `git checkout ../bar`,
+        // `git checkout ~/baz`, and `git checkout src/main` would lose their
+        // matching history entries for the few ms before branches arrive.
+        //
+        // Filesystem is disabled on the engine so the assertion targets the
+        // `include_history` branch directly — otherwise real-world filesystem
+        // entries for `../`, `~/`, etc. crowd out history via `max_results`
+        // saturation and obscure the signal we care about.
+        let path_markers = ["./", "../src", "~/proj", "src/main"];
+
+        for marker in path_markers {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let spec_store = SpecStore::load_from_dir(&spec_dir()).unwrap().store;
+            // History entry is crafted so the buffer fuzzy-matches it,
+            // proving history candidates ARE reachable on this path.
+            let history_entry = format!("git checkout {marker}");
+            let history = HistoryProvider::from_entries(vec![history_entry.clone()]);
+            let commands = CommandsProvider::from_list(vec!["git".into()]);
+            let mut engine = SuggestionEngine::with_providers(spec_store, history, commands);
+            engine.providers_filesystem = false;
+
+            let ctx = make_ctx(Some("git"), vec!["checkout"], marker, 2);
+            let buffer = format!("git checkout {marker}");
+            let results = engine.suggest_sync(&ctx, tmp.path(), &buffer).unwrap();
+
+            assert!(
+                results
+                    .suggestions
+                    .iter()
+                    .any(|s| s.source == SuggestionSource::History),
+                "path-like word {marker:?} must NOT suppress history: {:?}",
+                results.suggestions,
+            );
+        }
+    }
+
+    #[test]
     fn test_redirect_gives_filesystem() {
         let engine = make_engine();
         let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -501,7 +501,7 @@ impl SuggestionEngine {
             }
         }
         SyncResult {
-            suggestions: self.rank_with_history(ctx, cwd, buffer, candidates),
+            suggestions: self.rank_with_history(ctx, cwd, buffer, candidates, true),
             script_generators: Vec::new(),
             git_generators: Vec::new(),
         }
@@ -519,7 +519,7 @@ impl SuggestionEngine {
             }
         }
         SyncResult {
-            suggestions: self.rank_with_history(ctx, cwd, buffer, candidates),
+            suggestions: self.rank_with_history(ctx, cwd, buffer, candidates, true),
             script_generators: Vec::new(),
             git_generators: Vec::new(),
         }
@@ -608,19 +608,29 @@ impl SuggestionEngine {
             past_double_dash,
         } = specs::resolve_spec(spec, ctx);
 
+        let git_generators = self.git_generators_from(&native_generators);
+
         // Suppress subcommands/options when:
         // 1. The preceding flag takes an argument (e.g. `curl -o <TAB>`)
         // 2. We're past `--` (end-of-flags separator) — only positional args
-        let suppress_commands = preceding_flag_has_args || past_double_dash;
+        // 3. Native git ref generators are pending for a positional token.
+        //    Rendering flags/files before branch/tag results arrive makes
+        //    `git checkout <TAB>` look flag-first even though refs are the
+        //    primary completion target.
+        let defer_to_git_refs =
+            !git_generators.is_empty() && !ctx.is_flag && !looks_like_path(&ctx.current_word);
+        let suppress_commands = preceding_flag_has_args || past_double_dash || defer_to_git_refs;
 
         if !suppress_commands {
             candidates.extend(subcommands);
             candidates.extend(options);
         }
 
-        let git_generators = self.git_generators_from(&native_generators);
-
-        // Add filesystem: folders-only or all filepaths.
+        // Add filesystem: folders-only or all filepaths. Runs even when
+        // deferring to git refs so `git checkout <file>` keeps completing
+        // paths while branches/tags are loading. The handler's empty-query
+        // merge re-sorts by kind priority (branches < tags < files), so
+        // branches still land at the top once generators resolve.
         if wants_folders_only && self.providers_filesystem {
             self.extend_with_folders(ctx, cwd, &mut candidates);
         } else if wants_filepaths && self.providers_filesystem {
@@ -636,8 +646,15 @@ impl SuggestionEngine {
             .filter(|g| !g.requires_js)
             .collect();
 
+        // When deferring to git refs, skip history: otherwise `rank_with_history`
+        // would fuzzy-match the buffer against the shell history and jam the
+        // last N `git checkout ...` invocations ahead of the branches that are
+        // about to arrive. Filesystem candidates stay in the pool so file-path
+        // checkouts still work during the async window.
+        let suggestions = self.rank_with_history(ctx, cwd, buffer, candidates, !defer_to_git_refs);
+
         Ok(SyncResult {
-            suggestions: self.rank_with_history(ctx, cwd, buffer, candidates),
+            suggestions,
             script_generators,
             git_generators,
         })
@@ -720,7 +737,7 @@ impl SuggestionEngine {
             }
         }
         SyncResult {
-            suggestions: self.rank_with_history(ctx, cwd, buffer, candidates),
+            suggestions: self.rank_with_history(ctx, cwd, buffer, candidates, true),
             script_generators: Vec::new(),
             git_generators: Vec::new(),
         }
@@ -729,18 +746,22 @@ impl SuggestionEngine {
     /// Rank main candidates with current_word, then separately rank history
     /// candidates with the full buffer, and append history results at the end.
     /// All suggestions receive a frecency bonus so frequently/recently accepted
-    /// completions sort higher.
+    /// completions sort higher. When `include_history` is false, history is
+    /// skipped entirely — used for contexts where history entries would
+    /// outrank imminent async results (e.g. `git checkout <TAB>` waiting on
+    /// branch/tag generators).
     fn rank_with_history(
         &self,
         ctx: &CommandContext,
         cwd: &Path,
         buffer: &str,
         candidates: Vec<Suggestion>,
+        include_history: bool,
     ) -> Vec<Suggestion> {
         let mut results = fuzzy::rank(&ctx.current_word, candidates, self.max_results);
 
         // History doesn't belong in redirect context — user expects filenames, not commands
-        if self.max_history_results > 0 && !ctx.in_redirect {
+        if include_history && self.max_history_results > 0 && !ctx.in_redirect {
             let remaining = self
                 .max_history_results
                 .min(self.max_results.saturating_sub(results.len()));
@@ -883,6 +904,95 @@ mod tests {
         assert!(
             results.iter().any(|s| s.text == "-m"),
             "expected '-m' in results: {results:?}"
+        );
+    }
+
+    #[test]
+    fn test_git_checkout_waits_for_ref_generators_in_arg_position() {
+        let engine = make_engine();
+        let ctx = make_ctx(Some("git"), vec!["checkout"], "", 2);
+        let results = engine
+            .suggest_sync(&ctx, Path::new("/tmp"), "git checkout ")
+            .unwrap();
+
+        assert!(
+            results
+                .git_generators
+                .contains(&crate::git::GitQueryKind::Branches),
+            "git checkout should dispatch branch generator: {results:?}"
+        );
+        assert!(
+            results
+                .git_generators
+                .contains(&crate::git::GitQueryKind::Tags),
+            "git checkout should dispatch tag generator: {results:?}"
+        );
+        // Flags/subcommands must not leak through while refs are pending —
+        // filesystem and tempdir entries are allowed so `git checkout <file>`
+        // keeps working.
+        assert!(
+            !results
+                .suggestions
+                .iter()
+                .any(|s| matches!(s.kind, SuggestionKind::Flag | SuggestionKind::Subcommand)),
+            "flags/subcommands must be suppressed while branch/tag generators are pending: {:?}",
+            results.suggestions,
+        );
+    }
+
+    #[test]
+    fn test_git_checkout_suppresses_matching_history_while_refs_pending() {
+        // Regression for "history appears before branches on git checkout <TAB>":
+        // when native git ref generators are pending, the sync pass must not emit
+        // history entries that fuzzy-match the buffer. Otherwise the popup shows
+        // a history-only view for the few ms before branches arrive.
+        let spec_store = SpecStore::load_from_dir(&spec_dir()).unwrap().store;
+        let history = HistoryProvider::from_entries(vec![
+            "git checkout main".into(),
+            "git checkout -b feature".into(),
+            "git checkout demo".into(),
+        ]);
+        let commands = CommandsProvider::from_list(vec!["git".into()]);
+        let engine = SuggestionEngine::with_providers(spec_store, history, commands);
+
+        let ctx = make_ctx(Some("git"), vec!["checkout"], "", 2);
+        let results = engine
+            .suggest_sync(&ctx, Path::new("/tmp"), "git checkout ")
+            .unwrap();
+
+        assert!(
+            !results
+                .suggestions
+                .iter()
+                .any(|s| s.source == SuggestionSource::History),
+            "history must be suppressed while git ref generators are pending: {:?}",
+            results.suggestions
+        );
+    }
+
+    #[test]
+    fn test_git_checkout_still_offers_filesystem_when_refs_pending() {
+        // `git checkout <file>` is a valid restore-file invocation. Deferring
+        // to git refs must NOT swallow filesystem completions — the user might
+        // be mid-word on a filename.
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("Makefile"), "").unwrap();
+        std::fs::write(tmp.path().join("README.md"), "").unwrap();
+
+        let engine = make_engine();
+        let ctx = make_ctx(Some("git"), vec!["checkout"], "", 2);
+        let results = engine
+            .suggest_sync(&ctx, tmp.path(), "git checkout ")
+            .unwrap();
+
+        assert!(
+            results
+                .suggestions
+                .iter()
+                .any(|s| s.text == "Makefile" || s.text == "README.md"),
+            "filesystem completions must still appear while git ref generators \
+             are pending so `git checkout <file>` keeps working: {:?}",
+            results.suggestions,
         );
     }
 


### PR DESCRIPTION
## Summary

- `git checkout <TAB>` was rendering shell-history entries (e.g. `git checkout demo`, `git checkout -b "demo"`) ahead of the actual branches/tags, because the sync pass emitted a history pool before the async git generators resolved — and the handler's empty-query merge path simply `extend`-ed dynamic results onto the tail without sorting.
- Engine: when native git ref generators are pending (`defer_to_git_refs`), suppress commands/options/history via a new `include_history` parameter on `rank_with_history`, but keep filesystem candidates flowing so `git checkout <file>` still completes paths during the async window.
- Handler: `try_merge_dynamic` empty-query branch now sorts the merged pool by `kind.sort_priority()` so branches (0) and tags (1) land above files (7) and history (8).

## Test plan

- [x] `cargo test --workspace` (all 849+ tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New regression tests:
  - `test_git_checkout_suppresses_matching_history_while_refs_pending`
  - `test_git_checkout_still_offers_filesystem_when_refs_pending`
  - `test_try_merge_dynamic_empty_query_sorts_branches_before_history_and_files`
- [x] `cargo install --path crates/ghost-complete --force` + manual `git checkout <TAB>` verification