### PR TITLE
Converter: resolveLoadSpecs cycle guard + batched convert (Phase -1 followups)

### DIFF
--- a/docs/phase-minus-1-followups.md
+++ b/docs/phase-minus-1-followups.md
@@ -47,6 +47,12 @@ not been regenerated since v0.2.0.
 break the cycle with a console warning, and re-enable full regeneration of
 these two specs.
 
+**Resolved in 5afed5a (cycle guard) + d13c3a2 (spec regen).** `resolveLoadSpecs`
+now threads a `visited: Set<string>`, initialised with the top-level spec name,
+and emits a single `console.warn` when a cycle is detected. `simctl.json` grew
+from 59 B to 30.6 KB (37 subcommands); `xcrun.json` grew from 65 B to 58.1 KB
+(3 subcommands). Full-corpus regen surfaced no latent cycles beyond these two.
+
 ## 3. Single-process `npm run convert` OOMs at 705 specs
 
 **Status:** pre-existing, worked around in this branch.
@@ -60,6 +66,14 @@ is a fresh Node process.
 **Proposed fix:** either (a) add a batching mode to `src/index.js` with
 explicit flush points, or (b) switch `convert` to spawn workers and parallelise.
 Option (a) is smaller; option (b) is faster.
+
+**Resolved in 4ac85c8 (batching) + 4f4aab4 (failure-count + stdout-buffer fixes)
++ a273961 (integration test).** `npm run convert` now spawns a fresh Node worker
+per batch of 30 specs (configurable via `--batch-size`); each child exits after
+its batch, freeing its module cache. One command still does the whole run. Worker
+body is factored as `runConversionBatch` so the in-process fast path and the
+subprocess workers share logic. Measured on a 716-spec run: 2.83 s wall-clock,
+peak RSS ~772 MB (well under the 2 GB target).
 
 ## 4. specs/__snapshots__ baseline (Phase 0 prerequisite)
 

--- a/specs/simctl.json
+++ b/specs/simctl.json
@@ -1,1 +1,1056 @@
-{"name":"simctl","description":"Control an iOS Simulator"}
+{
+  "name": "simctl",
+  "subcommands": [
+    {
+      "name": "addmedia",
+      "description": "Add photos, live photos, videos, or contacts to the library of a device",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "path",
+          "isVariadic": true
+        }
+      ]
+    },
+    {
+      "name": "boot",
+      "description": "Boot a device or device pair",
+      "options": [
+        {
+          "name": [
+            "--arch"
+          ],
+          "description": "Specify the architecture to use when booting the simulator (eg: 'arm64' or 'x86_64')"
+        },
+        {
+          "name": [
+            "--disabledJob"
+          ],
+          "description": "Disables the given launchd job. Multiple jobs can be disabled by passing multiple flags"
+        },
+        {
+          "name": [
+            "--enabledJob"
+          ],
+          "description": "Enables the given launchd job when it would normally be disabled. Multiple jobs can be enabled by passing multiple flags"
+        }
+      ],
+      "args": {
+        "name": "device"
+      }
+    },
+    {
+      "name": "clone",
+      "description": "Clone an existing device",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "new name"
+        },
+        {
+          "name": "destination device set",
+          "isVariadic": true
+        }
+      ]
+    },
+    {
+      "name": "create",
+      "description": "Create a new device",
+      "args": [
+        {
+          "name": "name"
+        },
+        {
+          "name": "device type id",
+          "description": "A valid available device type. Find these by running 'xcrun simctl list devicetypes'. Examples: ('iPhone X', 'com.apple.CoreSimulator.SimDeviceType.iPhone-X')"
+        },
+        {
+          "name": "runtime id",
+          "description": "A valid and available runtime. Find these by running 'xcrun simctl list runtimes'. If no runtime is specified the newest runtime compatible with the device type is chosen. Examples: ('watchOS3', 'watchOS3.2', 'watchOS 3.2', 'com.apple.CoreSimulator.SimRuntime.watchOS-3-2', '/Volumes/path/to/Runtimes/watchOS 3.2.simruntime')",
+          "isVariadic": true
+        }
+      ]
+    },
+    {
+      "name": "delete",
+      "description": "Delete specified devices, unavailable devices, or all devices",
+      "args": [
+        {
+          "name": "device",
+          "isVariadic": true
+        },
+        {
+          "name": "unavailable",
+          "description": "Specifying unavailable will delete devices that are not supported by the current Xcode SDK"
+        },
+        {
+          "name": "all"
+        }
+      ]
+    },
+    {
+      "name": "diagnose",
+      "description": "Collect diagnostic information and logs",
+      "options": [
+        {
+          "name": [
+            "-b"
+          ],
+          "description": "Do NOT show the resulting archive in a Finder window upon completion"
+        },
+        {
+          "name": [
+            "-X"
+          ],
+          "description": "Run all diagnostics with no timeout. It ignores the --timeout value if it is specified"
+        },
+        {
+          "name": [
+            "--timeout"
+          ],
+          "description": "Specify a duration (in seconds) to wait for the log collection before timeout"
+        },
+        {
+          "name": [
+            "--output"
+          ],
+          "description": "Specify the output directory. If not provided the temporary directory is used"
+        },
+        {
+          "name": [
+            "--no-archive"
+          ],
+          "description": "Do not create an archive, leave the collected files uncompressed"
+        },
+        {
+          "name": [
+            "--all-logs"
+          ],
+          "description": "Include all device logs, even for non-booted devices"
+        },
+        {
+          "name": [
+            "--data-containers"
+          ],
+          "description": "Include booted device(s) data directory. Warning: May include private information, app data containers, and increases the size of the archive! Default is NOT to collect the data container"
+        },
+        {
+          "name": [
+            "--udid"
+          ],
+          "description": "Collect diagnostics only from the specified device. This option may be specified more than once to consider multiple devices. The --all-logs option causes all --udid options to be ignored"
+        }
+      ]
+    },
+    {
+      "name": "erase",
+      "description": "Erase a device's contents and settings",
+      "args": [
+        {
+          "name": "device",
+          "isVariadic": true
+        },
+        {
+          "name": "all",
+          "description": "Specifying all will erase all existing devices"
+        }
+      ]
+    },
+    {
+      "name": "get_app_container",
+      "description": "Print the path of the installed app's container",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "app bundle identifier"
+        },
+        {
+          "name": "container",
+          "description": "Optionally specify the container. Defaults to app.\napp                 The .app bundle\ndata                The application's data container\ngroups              The App Group containers\n<group identifier>  A specific App Group container",
+          "isOptional": true,
+          "suggestions": [
+            {
+              "name": "app",
+              "description": "The .app bundle"
+            },
+            {
+              "name": "data",
+              "description": "The application's data container"
+            },
+            {
+              "name": "groups",
+              "description": "The App Group containers"
+            },
+            {
+              "name": "<group identifier>",
+              "description": "A specific App Group container"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "getenv",
+      "description": "Print an environment variable from a running device",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "variable name"
+        }
+      ]
+    },
+    {
+      "name": "help",
+      "description": "Prints the usage for a given subcommand"
+    },
+    {
+      "name": "icloud_sync",
+      "description": "Trigger iCloud sync on a device",
+      "args": {
+        "name": "device"
+      }
+    },
+    {
+      "name": "install",
+      "description": "Install an app on a device",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "path"
+        }
+      ]
+    },
+    {
+      "name": "install_app_data",
+      "description": "Install an xcappdata package to a device, replacing the current contents of the container",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "path to xcappdata package"
+        }
+      ]
+    },
+    {
+      "name": "io",
+      "description": "Set up a device IO operation",
+      "subcommands": [
+        {
+          "name": "enumerate",
+          "description": "Lists all available IO ports and descriptor states",
+          "options": [
+            {
+              "name": [
+                "--poll"
+              ],
+              "description": "Poll after enumeration"
+            }
+          ]
+        },
+        {
+          "name": "poll",
+          "description": "Polls all available IO ports for events"
+        },
+        {
+          "name": "recordVideo",
+          "description": "Records the display to a QuickTime movie at the specified file or url",
+          "options": [
+            {
+              "name": [
+                "--codec"
+              ],
+              "description": "Specifies the codec type: 'h264' or 'hevc'. Default is 'hevc'"
+            },
+            {
+              "name": [
+                "--display"
+              ],
+              "description": "iOS: supports 'internal' or 'external'. Default is 'internal'. tvOS: supports only 'external' watchOS: supports only 'internal'"
+            },
+            {
+              "name": [
+                "--mask"
+              ],
+              "description": "For non-rectangular displays, handle the mask by policy: ignored: The mask is ignored and the unmasked framebuffer is saved. alpha: Not supported, but retained for compatibility; the mask is rendered black. black: The mask is rendered black"
+            },
+            {
+              "name": [
+                "--force"
+              ],
+              "description": "Force the output file to be written to, even if the file already exists"
+            }
+          ],
+          "args": {
+            "name": "file or url"
+          }
+        },
+        {
+          "name": "screenshot",
+          "description": "Saves a screenshot as a PNG to the specified file or url(use '-' for stdout)",
+          "options": [
+            {
+              "name": [
+                "--type"
+              ],
+              "description": "Can be 'png', 'tiff', 'bmp', 'gif', 'jpeg'. Default is png"
+            },
+            {
+              "name": [
+                "--display"
+              ],
+              "description": "iOS: supports 'internal' or 'external'. Default is 'internal'. tvOS: supports only 'external' watchOS: supports only 'internal'. You may also specify a port by UUID"
+            },
+            {
+              "name": [
+                "--mask"
+              ],
+              "description": "For non-rectangular displays, handle the mask by policy: ignored: The mask is ignored and the unmasked framebuffer is saved. alpha: The mask is used as premultiplied alpha. black: The mask is rendered black"
+            }
+          ],
+          "args": {
+            "name": "file or url"
+          }
+        }
+      ],
+      "args": {
+        "name": "device"
+      }
+    },
+    {
+      "name": "keychain",
+      "description": "Manipulate a device's keychain",
+      "subcommands": [
+        {
+          "name": "add-root-cert",
+          "description": "Add a certificate to the trusted root store",
+          "args": {
+            "name": "path"
+          }
+        },
+        {
+          "name": "add-cert",
+          "description": "Add a certificate to the keychain",
+          "args": {
+            "name": "path"
+          }
+        },
+        {
+          "name": "reset",
+          "description": "Reset the keychain"
+        }
+      ]
+    },
+    {
+      "name": "launch",
+      "description": "Launch an application by identifier on a device",
+      "options": [
+        {
+          "name": [
+            "-w",
+            "--wait-for-debugger"
+          ]
+        },
+        {
+          "name": [
+            "--console"
+          ],
+          "description": "Block and print the application's stdout and stderr to the current terminal. Signals received by simctl are passed through to the application. (Cannot be combined with --stdout or --stderr)"
+        },
+        {
+          "name": [
+            "--console-pty"
+          ],
+          "description": "Block and print the application's stdout and stderr to the current terminal via a PTY. Signals received by simctl are passed through to the application. (Cannot be combined with --stdout or --stderr)"
+        },
+        {
+          "name": [
+            "--stdout"
+          ],
+          "description": "Redirect the application's standard output to a file",
+          "args": {
+            "name": "path"
+          }
+        },
+        {
+          "name": [
+            "--stderr"
+          ],
+          "description": "Redirect the application's standard error to a file",
+          "args": {
+            "name": "path"
+          }
+        },
+        {
+          "name": [
+            "--terminate-running-process"
+          ],
+          "description": "Terminate any running copy of the application. Note: Log output is often directed to stderr, not stdout"
+        }
+      ],
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "app bundle identifier"
+        },
+        {
+          "name": "argv",
+          "isVariadic": true
+        }
+      ]
+    },
+    {
+      "name": "list",
+      "description": "List available devices, device types, runtimes, or device pairs",
+      "options": [
+        {
+          "name": [
+            "-j",
+            "--json"
+          ],
+          "description": "Print as JSON"
+        },
+        {
+          "name": [
+            "-e",
+            "--no-escape-slashes"
+          ],
+          "description": "Encode slashes without escapes in JSON output"
+        },
+        {
+          "name": [
+            "-v"
+          ],
+          "description": "More verbose output"
+        }
+      ],
+      "args": [
+        {
+          "name": "type",
+          "suggestions": [
+            {
+              "name": "devices"
+            },
+            {
+              "name": "deviceTypes"
+            },
+            {
+              "name": "runtimes"
+            },
+            {
+              "name": "pairs"
+            }
+          ]
+        },
+        {
+          "name": "search term",
+          "suggestions": [
+            {
+              "name": "available"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "location",
+      "description": "Control a device's simulated location",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List available simulation scenarios"
+        },
+        {
+          "name": "clear",
+          "description": "Stop any running scenario and clear any simulated location"
+        },
+        {
+          "name": "set",
+          "description": "Set the location to a specific latitude and longitude",
+          "args": {
+            "name": "lat,lon"
+          }
+        },
+        {
+          "name": "run",
+          "description": "Run a simulated location scenario (use the list action to get a list of scenarios)",
+          "args": {
+            "name": "scenario"
+          }
+        },
+        {
+          "name": "start",
+          "description": "Set the location to a series of waypoints specified as 'lat,lon' pairs, interpolating between them over time.\nAt least two waypoints are required. Use '-' to read waypoints from stdin, one waypoint per li\nSpeed specifies how quickly to move between waypoints in meters per second. If not specified 20m/s is us\nThe system will issue location updates along the path between each pair of waypoints. Use distance or interval to \ncontrol how often those updates are issued. Distance will issue an update every <meters> travelled without regard\nfor the time between updates. Interval will issue updates at fixed times without regard for how much\nthe location moves between updates.\nIf neither are specified an interval of 1.0 seconds is used. If both are specified the system picks on\nExample simulating a direct line between San Francisco and New York City, with updates every km:\nset --distance=1000 --speed=260 37.629538,-122.395733 40.628083,-73.768254",
+          "options": [
+            {
+              "name": [
+                "speed"
+              ]
+            },
+            {
+              "name": [
+                "distance"
+              ]
+            },
+            {
+              "name": [
+                "interval"
+              ]
+            }
+          ],
+          "args": {
+            "name": "lat,lon",
+            "isVariadic": true
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "empty"
+        }
+      ]
+    },
+    {
+      "name": "logverbose",
+      "description": "Enable or disable verbose logging for a device.\nNOTE: You may need to reboot the affected device before logging changes will be effective",
+      "args": [
+        {
+          "name": "device",
+          "description": "The device. If not provided all booted devices are affected"
+        },
+        {
+          "name": "enable/disable",
+          "description": "Enable or Disable verbose logging",
+          "suggestions": [
+            {
+              "name": "enable"
+            },
+            {
+              "name": "disable"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "openurl",
+      "description": "Open a URL in a device",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "URL"
+        }
+      ]
+    },
+    {
+      "name": "pair",
+      "description": "Create a new watch and phone pair",
+      "args": [
+        {
+          "name": "watch device"
+        },
+        {
+          "name": "phone device"
+        }
+      ]
+    },
+    {
+      "name": "pair_activate",
+      "description": "Set a given pair as active",
+      "args": {
+        "name": "pair"
+      }
+    },
+    {
+      "name": "pbcopy",
+      "description": "Copy standard input onto the device pasteboard",
+      "options": [
+        {
+          "name": [
+            "-v"
+          ]
+        }
+      ],
+      "args": {
+        "name": "device of 'host'"
+      }
+    },
+    {
+      "name": "pbpaste",
+      "description": "Print the contents of the device's pasteboard to standard output",
+      "options": [
+        {
+          "name": [
+            "-v"
+          ]
+        }
+      ],
+      "args": {
+        "name": "device of 'host'"
+      }
+    },
+    {
+      "name": "pbsync",
+      "description": "Sync the pasteboard content from one pasteboard to another",
+      "options": [
+        {
+          "name": [
+            "-p"
+          ],
+          "description": "Causes simctl to use promise data for secondary types.  simctl will continue to run to provide that promise data until something else replaces it on the pasteboard"
+        },
+        {
+          "name": [
+            "-v"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "source device or 'host'"
+        },
+        {
+          "name": "destination device or 'host'"
+        }
+      ]
+    },
+    {
+      "name": "privacy",
+      "description": "Grant, revoke, or reset privacy and permissions",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "action",
+          "suggestions": [
+            {
+              "name": "grant"
+            },
+            {
+              "name": "revoke"
+            },
+            {
+              "name": "reset"
+            }
+          ]
+        },
+        {
+          "name": "service",
+          "suggestions": [
+            {
+              "name": "all"
+            },
+            {
+              "name": "calendar"
+            },
+            {
+              "name": "contacts-limited"
+            },
+            {
+              "name": "contacts"
+            },
+            {
+              "name": "location"
+            },
+            {
+              "name": "location-always"
+            },
+            {
+              "name": "photos-add"
+            },
+            {
+              "name": "photos"
+            },
+            {
+              "name": "media-library"
+            },
+            {
+              "name": "microphone"
+            },
+            {
+              "name": "motion"
+            },
+            {
+              "name": "reminders"
+            },
+            {
+              "name": "siri"
+            }
+          ]
+        },
+        {
+          "name": "bundle identifier",
+          "description": "The bundle identifier of the target application"
+        }
+      ]
+    },
+    {
+      "name": "push",
+      "description": "Send a simulated push notification",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "bundle identifier",
+          "description": "The bundle identifier of the target application If the payload file contains a 'Simulator Target Bundle' top-level key this parameter may be omitted. If both are provided this argument will override the value from the payload"
+        },
+        {
+          "name": "json file",
+          "description": "Path to a JSON payload or '-' to read from stdin. The payload must:\n- Contain an object at the top level.\n- Contain an 'aps' key with valid Apple Push Notification values.\n- Be 4096 bytes or less",
+          "suggestions": [
+            {
+              "name": "-"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "rename",
+      "description": "Rename a device",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "name": "runtime",
+      "description": "Perform operations on runtimes",
+      "subcommands": [
+        {
+          "name": "add",
+          "description": "Add a runtime disk image to the secure storage area. The image will be staged, verified, and mounted. When possible the image file will be cloned so no additional disk space will be used. If stdout is a terminal and a copy is required then progress will be reported",
+          "options": [
+            {
+              "name": [
+                "-m",
+                "--move"
+              ],
+              "description": "Remove the original file if the image is added successfully. If the image cannot be staged or the add fails the original is not removed"
+            },
+            {
+              "name": [
+                "-a",
+                "--async"
+              ],
+              "description": "Print the UUID of the new image then exit, do not wait on the results of the add operation"
+            }
+          ],
+          "args": {
+            "name": "path"
+          }
+        },
+        {
+          "name": "delete",
+          "description": "Delete a simulator runtime from the secure storage area. If runtime is a disk image any booted simulators are shutdown and the disk is unmounted first. Use the alias 'all' to delete all images",
+          "options": [
+            {
+              "name": [
+                "-d",
+                "--notUsedSinceDays"
+              ],
+              "description": "Delete images not used within the past <days> days"
+            },
+            {
+              "name": [
+                "-n",
+                "--dry-run"
+              ],
+              "description": "Print what images would be deleted without actually deleting anything"
+            }
+          ],
+          "args": {
+            "name": "identifier"
+          }
+        },
+        {
+          "name": "verify",
+          "description": "Re-verify the signature of a given runtime",
+          "args": {
+            "name": "identifier"
+          }
+        },
+        {
+          "name": "list",
+          "options": [
+            {
+              "name": [
+                "-v"
+              ],
+              "description": "Print more verbose output"
+            },
+            {
+              "name": [
+                "-j",
+                "--json"
+              ],
+              "description": "Print as JSON"
+            }
+          ]
+        },
+        {
+          "name": "match list",
+          "description": "List the SDK build to runtime build mapping rules for the selected Xcode. Preferred means the runtime was either bundled with Xcode, exactly matched your SDK version, or the downloadable index indicated a better match for your SDK Manual overrides using 'match set' have the highest priority",
+          "options": [
+            {
+              "name": [
+                "-v"
+              ],
+              "description": "Verbose mode. Includes the full preferred build map, user override map, and known SDK names"
+            },
+            {
+              "name": [
+                "-j",
+                "--json"
+              ],
+              "description": "Print as JSON"
+            }
+          ]
+        },
+        {
+          "name": "match set",
+          "description": "Override the SDK to runtime build mapping. This controls which build of a given runtime Xcode will prefer for building and running when using that SDK. This matters most often during Beta releases when there are multiple builds for a given OS version. If --sdkBuild is not specified it is assumed you mean the SDK build for the currently selected Xcode.\n\nNote: Remember this is about build numbers, not semantic versions. When using the iOS 16.0 SDK Xcwill always prefer an iOS 16.0 runtime. Matching policy controls what to do when there are multiiOS 16.0 runtimes availabeg if the iOS 16.0 SDK is 20A245 and the available runtimes are (20A248, 20A252, 20A254) which should Xcode use for building, SwiftUI Previews, and when launching iOS 16.0 Simulators? They are all iOS 16.0 runtimes so a policy must decide which one is selected",
+          "options": [
+            {
+              "name": [
+                "--default"
+              ],
+              "description": "Clear the override for the given SDK and revert to default behavior"
+            },
+            {
+              "name": [
+                "--sdkBuild"
+              ],
+              "description": "Explicitly specify the SDK build, eg for an Xcode other than the selected Xcode"
+            }
+          ],
+          "args": [
+            {
+              "name": "sdk canonical name"
+            },
+            {
+              "name": "runtime build"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "shutdown",
+      "description": "Shutdown a device",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "all",
+          "suggestions": [
+            {
+              "name": "all"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "spawn",
+      "description": "Spawn a process by executing a given executable on a device",
+      "options": [
+        {
+          "name": [
+            "-w",
+            "--wait-for-debugger"
+          ]
+        },
+        {
+          "name": [
+            "-s",
+            "--standalone"
+          ]
+        },
+        {
+          "name": [
+            "-a",
+            "--arch"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "path to executable"
+        },
+        {
+          "name": "argv",
+          "isVariadic": true
+        }
+      ]
+    },
+    {
+      "name": "status_bar",
+      "description": "Set or clear status bar overrides",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List existing overrides"
+        },
+        {
+          "name": "clear",
+          "description": "Clear all existing status bar overrides"
+        },
+        {
+          "name": "override",
+          "description": "Set status bar override values, according to these flags. You may specify any combination of these flags (at least one is required)",
+          "options": [
+            {
+              "name": [
+                "--time"
+              ],
+              "description": "Set the date or time to a fixed value. If the string is a valid ISO date string it will also set the date on relevant devices"
+            },
+            {
+              "name": [
+                "--dataNetwork"
+              ],
+              "description": "If specified must be one of 'hide', 'wifi', '3g', '4g', 'lte', 'lte-a', 'lte+', '5g', '5g+', '5g-uwb', or '5g-uc'"
+            },
+            {
+              "name": [
+                "--wifiMode"
+              ],
+              "description": "If specified must be one of 'searching', 'failed', or 'active'"
+            },
+            {
+              "name": [
+                "--wifiBars"
+              ],
+              "description": "If specified must be 0-3"
+            },
+            {
+              "name": [
+                "--cellularMode"
+              ],
+              "description": "If specified must be one of 'notSupported', 'searching', 'failed', or 'active'"
+            },
+            {
+              "name": [
+                "--cellularBars"
+              ],
+              "description": "If specified must be 0-4"
+            },
+            {
+              "name": [
+                "--operatorName"
+              ],
+              "description": "Set the cellular operator/carrier name. Use '' for the empty string"
+            },
+            {
+              "name": [
+                "--batteryState"
+              ],
+              "description": "If specified must be one of 'charging', 'charged', or 'discharging'"
+            },
+            {
+              "name": [
+                "--batteryLevel"
+              ],
+              "description": "If specified must be 0-100"
+            }
+          ]
+        }
+      ],
+      "args": {
+        "name": "device"
+      }
+    },
+    {
+      "name": "terminate",
+      "description": "Terminate an application by identifier on a device",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "app bundle identifier"
+        }
+      ]
+    },
+    {
+      "name": "ui",
+      "description": "Get or Set UI options",
+      "subcommands": [
+        {
+          "name": "appearance",
+          "description": "When invoked without arguments prints the current user interface appearance style:\nlight\nThe Light appearance style.\ndark\nThe Dark appearance style.\nunsupported\nThe platform or runtime version do not support appearance styles.\nunknown\nThe current style is unknown or there was an error detecting it"
+        },
+        {
+          "name": "increase_contrast",
+          "description": "When invoked without arguments prints whether the Increase Contrast mode is currently enabled:\nenabled\nIncrease Contrast is enabled.\ndisabled\nIncrease Contrast is disabled.\nunsupported\nThe platform or runtime version do not support the Increase Contrast setting.\nunknown\nThe current setting is unknown or there was an error detecting it"
+        },
+        {
+          "name": "content_size",
+          "description": "When invoked without arguments prints the current preferred content size category, from the following possible values:"
+        }
+      ],
+      "args": {
+        "name": "device"
+      }
+    },
+    {
+      "name": "uninstall",
+      "description": "Uninstall an app from a device",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "app bundle identifier"
+        }
+      ]
+    },
+    {
+      "name": "unpair",
+      "description": "Unpair a watch and phone pair",
+      "args": {
+        "name": "pair UUID"
+      }
+    },
+    {
+      "name": "upgrade",
+      "description": "Upgrade a device to a newer runtime",
+      "args": [
+        {
+          "name": "device"
+        },
+        {
+          "name": "runtime id"
+        }
+      ]
+    }
+  ]
+}

--- a/specs/xcrun.json
+++ b/specs/xcrun.json
@@ -1,1 +1,1941 @@
-{"name":"xcrun","description":"Run or locate development tools"}
+{
+  "name": "xcrun",
+  "description": "Find and execute the named command line tool from the active xCode developer directory",
+  "subcommands": [
+    {
+      "name": "scntool",
+      "description": "SceneKit CLI utilities",
+      "options": [
+        {
+          "name": [
+            "--convert"
+          ],
+          "description": "File to convert",
+          "args": {
+            "name": "file",
+            "template": "filepaths"
+          }
+        },
+        {
+          "name": [
+            "--format"
+          ],
+          "description": "Format to convert to",
+          "args": {
+            "name": "format",
+            "suggestions": [
+              {
+                "name": "scn"
+              },
+              {
+                "name": "dae"
+              },
+              {
+                "name": "c3d"
+              }
+            ]
+          }
+        },
+        {
+          "name": [
+            "--output"
+          ],
+          "description": "Path to the output file",
+          "args": {
+            "name": "file",
+            "template": "filepaths"
+          }
+        },
+        {
+          "name": [
+            "--force-y-up"
+          ],
+          "description": "Convert objects to use y axis up"
+        },
+        {
+          "name": [
+            "--force-interleaved"
+          ],
+          "description": "Interleave the vertex data for multiple semantics in the same array to achieve better rendering performance"
+        },
+        {
+          "name": [
+            "--prefer-compressed-textures"
+          ],
+          "description": "Use .ktx, .astc and .pvrtc files for textures if available in the asset catalog"
+        },
+        {
+          "name": [
+            "--verbose"
+          ],
+          "description": "Get pretty error message"
+        }
+      ]
+    },
+    {
+      "name": "xcodebuild",
+      "options": [
+        {
+          "name": [
+            "-usage"
+          ],
+          "description": "Print brief usage"
+        },
+        {
+          "name": [
+            "-help"
+          ],
+          "description": "Print complete usage"
+        },
+        {
+          "name": [
+            "-verbose"
+          ],
+          "description": "Provide additional status output"
+        },
+        {
+          "name": [
+            "-license"
+          ],
+          "description": "Show the Xcode and SDK license agreements"
+        },
+        {
+          "name": [
+            "-checkFirstLaunchStatus"
+          ],
+          "description": "Check if any First Launch tasks need to be performed"
+        },
+        {
+          "name": [
+            "-runFirstLaunch"
+          ],
+          "description": "Install packages and agree to the license"
+        },
+        {
+          "name": [
+            "-project"
+          ],
+          "description": "Build the project NAME",
+          "args": {
+            "name": "NAME"
+          }
+        },
+        {
+          "name": [
+            "-target"
+          ],
+          "description": "Build the target NAME",
+          "args": {
+            "name": "NAME"
+          }
+        },
+        {
+          "name": [
+            "-alltargets"
+          ],
+          "description": "Build all targets"
+        },
+        {
+          "name": [
+            "-workspace"
+          ],
+          "description": "Build the workspace NAME",
+          "args": {
+            "name": "NAME",
+            "template": "filepaths"
+          }
+        },
+        {
+          "name": [
+            "-scheme"
+          ],
+          "description": "Build the scheme NAME",
+          "args": {
+            "name": "NAME"
+          }
+        },
+        {
+          "name": [
+            "-configuration"
+          ],
+          "description": "Use the build configuration NAME for building each target",
+          "args": {
+            "name": "NAME"
+          }
+        },
+        {
+          "name": [
+            "-xcconfig"
+          ],
+          "description": "Apply the build settings defined in the file at PATH as overrides",
+          "args": {
+            "name": "NAME",
+            "template": "filepaths"
+          }
+        },
+        {
+          "name": [
+            "-arch"
+          ],
+          "description": "Build each target for the architecture ARCH; this will override architectures defined in the project",
+          "args": {
+            "name": "ARCH",
+            "suggestions": [
+              {
+                "name": "x86_64"
+              },
+              {
+                "name": "arm64"
+              },
+              {
+                "name": "armv7"
+              }
+            ]
+          }
+        },
+        {
+          "name": [
+            "-sdk"
+          ],
+          "description": "Use SDK as the name or path of the base SDK when building the project",
+          "args": {
+            "name": "SDK",
+            "template": "folders"
+          }
+        },
+        {
+          "name": [
+            "-toolchain"
+          ],
+          "description": "Use the toolchain with identifier or name NAME",
+          "args": {
+            "name": "NAME"
+          }
+        },
+        {
+          "name": [
+            "-destination"
+          ],
+          "description": "Use the destination described by DESTINATIONSPECIFIER (a comma-separated set of key=value pairs describing the destination to use)",
+          "args": {
+            "name": "DESTINATION SPECIFIER",
+            "template": "folders"
+          }
+        },
+        {
+          "name": [
+            "-destination-timeout"
+          ],
+          "description": "Wait for TIMEOUT seconds while searching for the destination device",
+          "args": {
+            "name": "TIMEOUT"
+          }
+        },
+        {
+          "name": [
+            "-parallelizeTargets"
+          ],
+          "description": "Build independent targets in parallel"
+        },
+        {
+          "name": [
+            "-jobs"
+          ],
+          "description": "Specify the maximum number of concurrent build operations",
+          "args": {
+            "name": "NUMBER"
+          }
+        },
+        {
+          "name": [
+            "-maximum-concurrent-test-device-destinations"
+          ],
+          "description": "The maximum number of device destinations to test on concurrently",
+          "args": {
+            "name": "NUMBER"
+          }
+        },
+        {
+          "name": [
+            "-maximum-concurrent-test-simulator-destinations"
+          ],
+          "description": "The maximum number of simulator destinations to test on concurrently",
+          "args": {
+            "name": "NUMBER"
+          }
+        },
+        {
+          "name": [
+            "-parallel-testing-enabled"
+          ],
+          "description": "Overrides the per-target setting in the scheme",
+          "args": {
+            "name": "mode",
+            "suggestions": [
+              {
+                "name": "YES"
+              },
+              {
+                "name": "NO"
+              }
+            ]
+          }
+        },
+        {
+          "name": [
+            "-parallel-testing-worker-count"
+          ],
+          "description": "The exact number of test runners that will be spawned during parallel testing",
+          "args": {
+            "name": "NUMBER"
+          }
+        },
+        {
+          "name": [
+            "-maximum-parallel-testing-workers"
+          ],
+          "description": "The maximum number of test runners that will be spawned during parallel testing",
+          "args": {
+            "name": "NUMBER"
+          }
+        },
+        {
+          "name": [
+            "-dry-run"
+          ],
+          "description": "Do everything except actually running the commands"
+        },
+        {
+          "name": [
+            "-quiet"
+          ],
+          "description": "Do not print any output except for warnings and errors"
+        },
+        {
+          "name": [
+            "-hideShellScriptEnvironment"
+          ],
+          "description": "Don't show shell script environment variables in build log"
+        },
+        {
+          "name": [
+            "-showsdks"
+          ],
+          "description": "Display a compact list of the installed SDKs"
+        },
+        {
+          "name": [
+            "-showdestinations"
+          ],
+          "description": "Display a list of destinations"
+        },
+        {
+          "name": [
+            "-showTestPlans"
+          ],
+          "description": "Display a list of test plans"
+        },
+        {
+          "name": [
+            "-showBuildSettings"
+          ],
+          "description": "Display a list of build settings and values"
+        },
+        {
+          "name": [
+            "-showBuildSettingsForIndex"
+          ],
+          "description": "Display build settings for the index service"
+        },
+        {
+          "name": [
+            "-list"
+          ],
+          "description": "Lists the targets and configurations in a project, or the schemes in a workspace"
+        },
+        {
+          "name": [
+            "-find-executable"
+          ],
+          "description": "Display the full path to executable NAME in the provided SDK and toolchain",
+          "args": {
+            "name": "NAME"
+          }
+        },
+        {
+          "name": [
+            "-find-library"
+          ],
+          "description": "Display the full path to library NAME in the provided SDK and toolchain",
+          "args": {
+            "name": "NAME"
+          }
+        },
+        {
+          "name": [
+            "-version"
+          ],
+          "description": "Display the version of Xcode; with -sdk will display info about one or all installed SDKs"
+        },
+        {
+          "name": [
+            "-enableAddressSanitizer"
+          ],
+          "description": "Turn the address sanitizer on or off",
+          "args": {
+            "name": "mode",
+            "suggestions": [
+              {
+                "name": "YES"
+              },
+              {
+                "name": "NO"
+              }
+            ]
+          }
+        },
+        {
+          "name": [
+            "-enableThreadSanitizer"
+          ],
+          "description": "Turn the thread sanitizer on or off",
+          "args": {
+            "name": "mode",
+            "suggestions": [
+              {
+                "name": "YES"
+              },
+              {
+                "name": "NO"
+              }
+            ]
+          }
+        },
+        {
+          "name": [
+            "-enableUndefinedBehaviorSanitizer"
+          ],
+          "description": "Turn the undefined behavior sanitizer on or off",
+          "args": {
+            "name": "mode",
+            "suggestions": [
+              {
+                "name": "YES"
+              },
+              {
+                "name": "NO"
+              }
+            ]
+          }
+        },
+        {
+          "name": [
+            "-resultBundlePath"
+          ],
+          "description": "Specifies the directory where a result bundle describing what occurred will be placed",
+          "args": {
+            "name": "PATH",
+            "template": "folders"
+          }
+        },
+        {
+          "name": [
+            "-resultStreamPath"
+          ],
+          "description": "Specifies the file where a result stream will be written to (the file must already exist)",
+          "args": {
+            "name": "PATH",
+            "template": "filepaths"
+          }
+        },
+        {
+          "name": [
+            "-resultBundleVersion"
+          ],
+          "description": "Specifies which result bundle version should be used",
+          "args": {
+            "name": "version"
+          }
+        },
+        {
+          "name": [
+            "-clonedSourcePackagesDirPath"
+          ],
+          "description": "Specifies the directory to which remote source packages are fetch or expected to be found",
+          "args": {
+            "name": "PATH",
+            "template": "folders"
+          }
+        },
+        {
+          "name": [
+            "-derivedDataPath"
+          ],
+          "description": "Specifies the directory where build products and other derived data will go",
+          "args": {
+            "name": "PATH",
+            "template": "folders"
+          }
+        },
+        {
+          "name": [
+            "-archivePath"
+          ],
+          "description": "Specifies the directory where any created archives will be placed, or the archive that should be exported",
+          "args": {
+            "name": "PATH",
+            "template": "folders"
+          }
+        },
+        {
+          "name": [
+            "-exportArchive"
+          ],
+          "description": "Specifies that an archive should be exported"
+        },
+        {
+          "name": [
+            "-exportNotarizedApp"
+          ],
+          "description": "Export an archive that has been notarized by Apple"
+        },
+        {
+          "name": [
+            "-exportOptionsPlist"
+          ],
+          "description": "Specifies a path to a plist file that configures archive exporting",
+          "args": {
+            "name": "PATH",
+            "template": "filepaths"
+          }
+        },
+        {
+          "name": [
+            "-enableCodeCoverage"
+          ],
+          "description": "Turn code coverage on or off when testing",
+          "args": {
+            "name": "mode",
+            "suggestions": [
+              {
+                "name": "YES"
+              },
+              {
+                "name": "NO"
+              }
+            ]
+          }
+        },
+        {
+          "name": [
+            "-exportPath"
+          ],
+          "description": "Specifies the destination for the product exported from an archive",
+          "args": {
+            "name": "PATH",
+            "template": "folders"
+          }
+        },
+        {
+          "name": [
+            "-skipUnavailableActions"
+          ],
+          "description": "Specifies that scheme actions that cannot be performed should be skipped instead of causing a failure"
+        },
+        {
+          "name": [
+            "-exportLocalizations"
+          ],
+          "description": "Exports completed and outstanding project localizations"
+        },
+        {
+          "name": [
+            "-importLocalizations"
+          ],
+          "description": "Imports localizations for a project, assuming any necessary localized resources have been created in Xcode"
+        },
+        {
+          "name": [
+            "-localizationPath"
+          ],
+          "description": "Specifies a path to XLIFF localization file",
+          "args": {
+            "name": "PATH",
+            "template": "filepaths"
+          }
+        },
+        {
+          "name": [
+            "-exportLanguage"
+          ],
+          "description": "Specifies multiple optional ISO 639-1 languages included in a localization export",
+          "args": {
+            "name": "languages",
+            "isVariadic": true
+          }
+        },
+        {
+          "name": [
+            "-xcroot"
+          ],
+          "description": "Specifies a path to a .xcroot to use for building and/or testing",
+          "args": {
+            "name": "path",
+            "template": "folders"
+          }
+        },
+        {
+          "name": [
+            "-xctestrun"
+          ],
+          "description": "Specifies a path to a test run specification",
+          "args": {
+            "name": "path",
+            "template": "folders"
+          }
+        },
+        {
+          "name": [
+            "-testPlan"
+          ],
+          "description": "Specifies the name of the test plan associated with the scheme to use for testing",
+          "args": {
+            "name": "test plan"
+          }
+        },
+        {
+          "name": [
+            "-only-testing"
+          ],
+          "description": "Constrains testing by specifying tests to include, and excluding other tests"
+        },
+        {
+          "name": [
+            "-only-testing:"
+          ],
+          "description": "Constrains testing by specifying tests to include, and excluding other tests",
+          "args": {
+            "name": "Test Identifier"
+          }
+        },
+        {
+          "name": [
+            "-skip-testing"
+          ],
+          "description": "Constrains testing by specifying tests to exclude, but including other tests"
+        },
+        {
+          "name": [
+            "-skip-testing:"
+          ],
+          "description": "Constrains testing by specifying tests to exclude, but including other tests",
+          "args": {
+            "name": "Test Identifier"
+          }
+        },
+        {
+          "name": [
+            "-test-timeouts-enabled"
+          ],
+          "description": "Enable or disable test timeout behavior",
+          "args": {
+            "name": "mode",
+            "suggestions": [
+              {
+                "name": "YES"
+              },
+              {
+                "name": "NO"
+              }
+            ]
+          }
+        },
+        {
+          "name": [
+            "-default-test-execution-time-allowance"
+          ],
+          "description": "The default execution time an individual test is given to execute, if test timeouts are enabled",
+          "args": {
+            "name": "SECONDS"
+          }
+        },
+        {
+          "name": [
+            "-maximum-test-execution-time-allowance"
+          ],
+          "description": "The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance",
+          "args": {
+            "name": "SECONDS"
+          }
+        },
+        {
+          "name": [
+            "-only-test-configuration"
+          ],
+          "description": "Constrains testing by specifying test configurations to include, and excluding other test configurations"
+        },
+        {
+          "name": [
+            "-skip-test-configuration"
+          ],
+          "description": "Constrains testing by specifying test configurations to exclude, but including other test configurations"
+        },
+        {
+          "name": [
+            "-testLanguage"
+          ],
+          "description": "Constrains testing by specifying ISO 639-1 language in which to run the tests"
+        },
+        {
+          "name": [
+            "-testRegion"
+          ],
+          "description": "Constrains testing by specifying ISO 3166-1 region in which to run the tests"
+        },
+        {
+          "name": [
+            "-resolvePackageDependencies"
+          ],
+          "description": "Resolves any Swift package dependencies referenced by the project or workspace"
+        },
+        {
+          "name": [
+            "-disableAutomaticPackageResolution"
+          ],
+          "description": "Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file"
+        },
+        {
+          "name": [
+            "-json"
+          ],
+          "description": "Output as JSON"
+        },
+        {
+          "name": [
+            "-allowProvisioningUpdates"
+          ],
+          "description": "Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode's Accounts preference pane"
+        },
+        {
+          "name": [
+            "-allowProvisioningDeviceRegistration"
+          ],
+          "description": "Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if -allowProvisioningUpdates is also passed"
+        },
+        {
+          "name": [
+            "-scmProvider"
+          ],
+          "description": "Which implementation to use for Git operations (system/xcode)",
+          "args": {
+            "name": "Implementation",
+            "suggestions": [
+              {
+                "name": "system"
+              },
+              {
+                "name": "xcode"
+              }
+            ]
+          }
+        },
+        {
+          "name": [
+            "-showBuildTimingSummary"
+          ],
+          "description": "Display a report of the timings of all the commands invoked during the build"
+        },
+        {
+          "name": [
+            "-create-xcframework"
+          ],
+          "description": "Create an xcframework from prebuilt libraries; -help for more information"
+        },
+        {
+          "name": [
+            "build"
+          ],
+          "description": "Build the target in the build root (SYMROOT).  This is the default build action"
+        },
+        {
+          "name": [
+            "installsrc"
+          ],
+          "description": "Copy the source of the project to the source root (SRCROOT)"
+        },
+        {
+          "name": [
+            "install"
+          ],
+          "description": "Build the target and install it into the target's installation directory in the distribution root (DSTROOT)"
+        },
+        {
+          "name": [
+            "clean"
+          ],
+          "description": "Remove build products and intermediate files from the build root (SYMROOT)"
+        }
+      ]
+    },
+    {
+      "name": "simctl",
+      "subcommands": [
+        {
+          "name": "addmedia",
+          "description": "Add photos, live photos, videos, or contacts to the library of a device",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "path",
+              "isVariadic": true
+            }
+          ]
+        },
+        {
+          "name": "boot",
+          "description": "Boot a device or device pair",
+          "options": [
+            {
+              "name": [
+                "--arch"
+              ],
+              "description": "Specify the architecture to use when booting the simulator (eg: 'arm64' or 'x86_64')"
+            },
+            {
+              "name": [
+                "--disabledJob"
+              ],
+              "description": "Disables the given launchd job. Multiple jobs can be disabled by passing multiple flags"
+            },
+            {
+              "name": [
+                "--enabledJob"
+              ],
+              "description": "Enables the given launchd job when it would normally be disabled. Multiple jobs can be enabled by passing multiple flags"
+            }
+          ],
+          "args": {
+            "name": "device"
+          }
+        },
+        {
+          "name": "clone",
+          "description": "Clone an existing device",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "new name"
+            },
+            {
+              "name": "destination device set",
+              "isVariadic": true
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "description": "Create a new device",
+          "args": [
+            {
+              "name": "name"
+            },
+            {
+              "name": "device type id",
+              "description": "A valid available device type. Find these by running 'xcrun simctl list devicetypes'. Examples: ('iPhone X', 'com.apple.CoreSimulator.SimDeviceType.iPhone-X')"
+            },
+            {
+              "name": "runtime id",
+              "description": "A valid and available runtime. Find these by running 'xcrun simctl list runtimes'. If no runtime is specified the newest runtime compatible with the device type is chosen. Examples: ('watchOS3', 'watchOS3.2', 'watchOS 3.2', 'com.apple.CoreSimulator.SimRuntime.watchOS-3-2', '/Volumes/path/to/Runtimes/watchOS 3.2.simruntime')",
+              "isVariadic": true
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "description": "Delete specified devices, unavailable devices, or all devices",
+          "args": [
+            {
+              "name": "device",
+              "isVariadic": true
+            },
+            {
+              "name": "unavailable",
+              "description": "Specifying unavailable will delete devices that are not supported by the current Xcode SDK"
+            },
+            {
+              "name": "all"
+            }
+          ]
+        },
+        {
+          "name": "diagnose",
+          "description": "Collect diagnostic information and logs",
+          "options": [
+            {
+              "name": [
+                "-b"
+              ],
+              "description": "Do NOT show the resulting archive in a Finder window upon completion"
+            },
+            {
+              "name": [
+                "-X"
+              ],
+              "description": "Run all diagnostics with no timeout. It ignores the --timeout value if it is specified"
+            },
+            {
+              "name": [
+                "--timeout"
+              ],
+              "description": "Specify a duration (in seconds) to wait for the log collection before timeout"
+            },
+            {
+              "name": [
+                "--output"
+              ],
+              "description": "Specify the output directory. If not provided the temporary directory is used"
+            },
+            {
+              "name": [
+                "--no-archive"
+              ],
+              "description": "Do not create an archive, leave the collected files uncompressed"
+            },
+            {
+              "name": [
+                "--all-logs"
+              ],
+              "description": "Include all device logs, even for non-booted devices"
+            },
+            {
+              "name": [
+                "--data-containers"
+              ],
+              "description": "Include booted device(s) data directory. Warning: May include private information, app data containers, and increases the size of the archive! Default is NOT to collect the data container"
+            },
+            {
+              "name": [
+                "--udid"
+              ],
+              "description": "Collect diagnostics only from the specified device. This option may be specified more than once to consider multiple devices. The --all-logs option causes all --udid options to be ignored"
+            }
+          ]
+        },
+        {
+          "name": "erase",
+          "description": "Erase a device's contents and settings",
+          "args": [
+            {
+              "name": "device",
+              "isVariadic": true
+            },
+            {
+              "name": "all",
+              "description": "Specifying all will erase all existing devices"
+            }
+          ]
+        },
+        {
+          "name": "get_app_container",
+          "description": "Print the path of the installed app's container",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "app bundle identifier"
+            },
+            {
+              "name": "container",
+              "description": "Optionally specify the container. Defaults to app.\napp                 The .app bundle\ndata                The application's data container\ngroups              The App Group containers\n<group identifier>  A specific App Group container",
+              "isOptional": true,
+              "suggestions": [
+                {
+                  "name": "app",
+                  "description": "The .app bundle"
+                },
+                {
+                  "name": "data",
+                  "description": "The application's data container"
+                },
+                {
+                  "name": "groups",
+                  "description": "The App Group containers"
+                },
+                {
+                  "name": "<group identifier>",
+                  "description": "A specific App Group container"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "getenv",
+          "description": "Print an environment variable from a running device",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "variable name"
+            }
+          ]
+        },
+        {
+          "name": "help",
+          "description": "Prints the usage for a given subcommand"
+        },
+        {
+          "name": "icloud_sync",
+          "description": "Trigger iCloud sync on a device",
+          "args": {
+            "name": "device"
+          }
+        },
+        {
+          "name": "install",
+          "description": "Install an app on a device",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "path"
+            }
+          ]
+        },
+        {
+          "name": "install_app_data",
+          "description": "Install an xcappdata package to a device, replacing the current contents of the container",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "path to xcappdata package"
+            }
+          ]
+        },
+        {
+          "name": "io",
+          "description": "Set up a device IO operation",
+          "subcommands": [
+            {
+              "name": "enumerate",
+              "description": "Lists all available IO ports and descriptor states",
+              "options": [
+                {
+                  "name": [
+                    "--poll"
+                  ],
+                  "description": "Poll after enumeration"
+                }
+              ]
+            },
+            {
+              "name": "poll",
+              "description": "Polls all available IO ports for events"
+            },
+            {
+              "name": "recordVideo",
+              "description": "Records the display to a QuickTime movie at the specified file or url",
+              "options": [
+                {
+                  "name": [
+                    "--codec"
+                  ],
+                  "description": "Specifies the codec type: 'h264' or 'hevc'. Default is 'hevc'"
+                },
+                {
+                  "name": [
+                    "--display"
+                  ],
+                  "description": "iOS: supports 'internal' or 'external'. Default is 'internal'. tvOS: supports only 'external' watchOS: supports only 'internal'"
+                },
+                {
+                  "name": [
+                    "--mask"
+                  ],
+                  "description": "For non-rectangular displays, handle the mask by policy: ignored: The mask is ignored and the unmasked framebuffer is saved. alpha: Not supported, but retained for compatibility; the mask is rendered black. black: The mask is rendered black"
+                },
+                {
+                  "name": [
+                    "--force"
+                  ],
+                  "description": "Force the output file to be written to, even if the file already exists"
+                }
+              ],
+              "args": {
+                "name": "file or url"
+              }
+            },
+            {
+              "name": "screenshot",
+              "description": "Saves a screenshot as a PNG to the specified file or url(use '-' for stdout)",
+              "options": [
+                {
+                  "name": [
+                    "--type"
+                  ],
+                  "description": "Can be 'png', 'tiff', 'bmp', 'gif', 'jpeg'. Default is png"
+                },
+                {
+                  "name": [
+                    "--display"
+                  ],
+                  "description": "iOS: supports 'internal' or 'external'. Default is 'internal'. tvOS: supports only 'external' watchOS: supports only 'internal'. You may also specify a port by UUID"
+                },
+                {
+                  "name": [
+                    "--mask"
+                  ],
+                  "description": "For non-rectangular displays, handle the mask by policy: ignored: The mask is ignored and the unmasked framebuffer is saved. alpha: The mask is used as premultiplied alpha. black: The mask is rendered black"
+                }
+              ],
+              "args": {
+                "name": "file or url"
+              }
+            }
+          ],
+          "args": {
+            "name": "device"
+          }
+        },
+        {
+          "name": "keychain",
+          "description": "Manipulate a device's keychain",
+          "subcommands": [
+            {
+              "name": "add-root-cert",
+              "description": "Add a certificate to the trusted root store",
+              "args": {
+                "name": "path"
+              }
+            },
+            {
+              "name": "add-cert",
+              "description": "Add a certificate to the keychain",
+              "args": {
+                "name": "path"
+              }
+            },
+            {
+              "name": "reset",
+              "description": "Reset the keychain"
+            }
+          ]
+        },
+        {
+          "name": "launch",
+          "description": "Launch an application by identifier on a device",
+          "options": [
+            {
+              "name": [
+                "-w",
+                "--wait-for-debugger"
+              ]
+            },
+            {
+              "name": [
+                "--console"
+              ],
+              "description": "Block and print the application's stdout and stderr to the current terminal. Signals received by simctl are passed through to the application. (Cannot be combined with --stdout or --stderr)"
+            },
+            {
+              "name": [
+                "--console-pty"
+              ],
+              "description": "Block and print the application's stdout and stderr to the current terminal via a PTY. Signals received by simctl are passed through to the application. (Cannot be combined with --stdout or --stderr)"
+            },
+            {
+              "name": [
+                "--stdout"
+              ],
+              "description": "Redirect the application's standard output to a file",
+              "args": {
+                "name": "path"
+              }
+            },
+            {
+              "name": [
+                "--stderr"
+              ],
+              "description": "Redirect the application's standard error to a file",
+              "args": {
+                "name": "path"
+              }
+            },
+            {
+              "name": [
+                "--terminate-running-process"
+              ],
+              "description": "Terminate any running copy of the application. Note: Log output is often directed to stderr, not stdout"
+            }
+          ],
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "app bundle identifier"
+            },
+            {
+              "name": "argv",
+              "isVariadic": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List available devices, device types, runtimes, or device pairs",
+          "options": [
+            {
+              "name": [
+                "-j",
+                "--json"
+              ],
+              "description": "Print as JSON"
+            },
+            {
+              "name": [
+                "-e",
+                "--no-escape-slashes"
+              ],
+              "description": "Encode slashes without escapes in JSON output"
+            },
+            {
+              "name": [
+                "-v"
+              ],
+              "description": "More verbose output"
+            }
+          ],
+          "args": [
+            {
+              "name": "type",
+              "suggestions": [
+                {
+                  "name": "devices"
+                },
+                {
+                  "name": "deviceTypes"
+                },
+                {
+                  "name": "runtimes"
+                },
+                {
+                  "name": "pairs"
+                }
+              ]
+            },
+            {
+              "name": "search term",
+              "suggestions": [
+                {
+                  "name": "available"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "location",
+          "description": "Control a device's simulated location",
+          "subcommands": [
+            {
+              "name": "list",
+              "description": "List available simulation scenarios"
+            },
+            {
+              "name": "clear",
+              "description": "Stop any running scenario and clear any simulated location"
+            },
+            {
+              "name": "set",
+              "description": "Set the location to a specific latitude and longitude",
+              "args": {
+                "name": "lat,lon"
+              }
+            },
+            {
+              "name": "run",
+              "description": "Run a simulated location scenario (use the list action to get a list of scenarios)",
+              "args": {
+                "name": "scenario"
+              }
+            },
+            {
+              "name": "start",
+              "description": "Set the location to a series of waypoints specified as 'lat,lon' pairs, interpolating between them over time.\nAt least two waypoints are required. Use '-' to read waypoints from stdin, one waypoint per li\nSpeed specifies how quickly to move between waypoints in meters per second. If not specified 20m/s is us\nThe system will issue location updates along the path between each pair of waypoints. Use distance or interval to \ncontrol how often those updates are issued. Distance will issue an update every <meters> travelled without regard\nfor the time between updates. Interval will issue updates at fixed times without regard for how much\nthe location moves between updates.\nIf neither are specified an interval of 1.0 seconds is used. If both are specified the system picks on\nExample simulating a direct line between San Francisco and New York City, with updates every km:\nset --distance=1000 --speed=260 37.629538,-122.395733 40.628083,-73.768254",
+              "options": [
+                {
+                  "name": [
+                    "speed"
+                  ]
+                },
+                {
+                  "name": [
+                    "distance"
+                  ]
+                },
+                {
+                  "name": [
+                    "interval"
+                  ]
+                }
+              ],
+              "args": {
+                "name": "lat,lon",
+                "isVariadic": true
+              }
+            }
+          ],
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "empty"
+            }
+          ]
+        },
+        {
+          "name": "logverbose",
+          "description": "Enable or disable verbose logging for a device.\nNOTE: You may need to reboot the affected device before logging changes will be effective",
+          "args": [
+            {
+              "name": "device",
+              "description": "The device. If not provided all booted devices are affected"
+            },
+            {
+              "name": "enable/disable",
+              "description": "Enable or Disable verbose logging",
+              "suggestions": [
+                {
+                  "name": "enable"
+                },
+                {
+                  "name": "disable"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "openurl",
+          "description": "Open a URL in a device",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "URL"
+            }
+          ]
+        },
+        {
+          "name": "pair",
+          "description": "Create a new watch and phone pair",
+          "args": [
+            {
+              "name": "watch device"
+            },
+            {
+              "name": "phone device"
+            }
+          ]
+        },
+        {
+          "name": "pair_activate",
+          "description": "Set a given pair as active",
+          "args": {
+            "name": "pair"
+          }
+        },
+        {
+          "name": "pbcopy",
+          "description": "Copy standard input onto the device pasteboard",
+          "options": [
+            {
+              "name": [
+                "-v"
+              ]
+            }
+          ],
+          "args": {
+            "name": "device of 'host'"
+          }
+        },
+        {
+          "name": "pbpaste",
+          "description": "Print the contents of the device's pasteboard to standard output",
+          "options": [
+            {
+              "name": [
+                "-v"
+              ]
+            }
+          ],
+          "args": {
+            "name": "device of 'host'"
+          }
+        },
+        {
+          "name": "pbsync",
+          "description": "Sync the pasteboard content from one pasteboard to another",
+          "options": [
+            {
+              "name": [
+                "-p"
+              ],
+              "description": "Causes simctl to use promise data for secondary types.  simctl will continue to run to provide that promise data until something else replaces it on the pasteboard"
+            },
+            {
+              "name": [
+                "-v"
+              ]
+            }
+          ],
+          "args": [
+            {
+              "name": "source device or 'host'"
+            },
+            {
+              "name": "destination device or 'host'"
+            }
+          ]
+        },
+        {
+          "name": "privacy",
+          "description": "Grant, revoke, or reset privacy and permissions",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "action",
+              "suggestions": [
+                {
+                  "name": "grant"
+                },
+                {
+                  "name": "revoke"
+                },
+                {
+                  "name": "reset"
+                }
+              ]
+            },
+            {
+              "name": "service",
+              "suggestions": [
+                {
+                  "name": "all"
+                },
+                {
+                  "name": "calendar"
+                },
+                {
+                  "name": "contacts-limited"
+                },
+                {
+                  "name": "contacts"
+                },
+                {
+                  "name": "location"
+                },
+                {
+                  "name": "location-always"
+                },
+                {
+                  "name": "photos-add"
+                },
+                {
+                  "name": "photos"
+                },
+                {
+                  "name": "media-library"
+                },
+                {
+                  "name": "microphone"
+                },
+                {
+                  "name": "motion"
+                },
+                {
+                  "name": "reminders"
+                },
+                {
+                  "name": "siri"
+                }
+              ]
+            },
+            {
+              "name": "bundle identifier",
+              "description": "The bundle identifier of the target application"
+            }
+          ]
+        },
+        {
+          "name": "push",
+          "description": "Send a simulated push notification",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "bundle identifier",
+              "description": "The bundle identifier of the target application If the payload file contains a 'Simulator Target Bundle' top-level key this parameter may be omitted. If both are provided this argument will override the value from the payload"
+            },
+            {
+              "name": "json file",
+              "description": "Path to a JSON payload or '-' to read from stdin. The payload must:\n- Contain an object at the top level.\n- Contain an 'aps' key with valid Apple Push Notification values.\n- Be 4096 bytes or less",
+              "suggestions": [
+                {
+                  "name": "-"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "rename",
+          "description": "Rename a device",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "name"
+            }
+          ]
+        },
+        {
+          "name": "runtime",
+          "description": "Perform operations on runtimes",
+          "subcommands": [
+            {
+              "name": "add",
+              "description": "Add a runtime disk image to the secure storage area. The image will be staged, verified, and mounted. When possible the image file will be cloned so no additional disk space will be used. If stdout is a terminal and a copy is required then progress will be reported",
+              "options": [
+                {
+                  "name": [
+                    "-m",
+                    "--move"
+                  ],
+                  "description": "Remove the original file if the image is added successfully. If the image cannot be staged or the add fails the original is not removed"
+                },
+                {
+                  "name": [
+                    "-a",
+                    "--async"
+                  ],
+                  "description": "Print the UUID of the new image then exit, do not wait on the results of the add operation"
+                }
+              ],
+              "args": {
+                "name": "path"
+              }
+            },
+            {
+              "name": "delete",
+              "description": "Delete a simulator runtime from the secure storage area. If runtime is a disk image any booted simulators are shutdown and the disk is unmounted first. Use the alias 'all' to delete all images",
+              "options": [
+                {
+                  "name": [
+                    "-d",
+                    "--notUsedSinceDays"
+                  ],
+                  "description": "Delete images not used within the past <days> days"
+                },
+                {
+                  "name": [
+                    "-n",
+                    "--dry-run"
+                  ],
+                  "description": "Print what images would be deleted without actually deleting anything"
+                }
+              ],
+              "args": {
+                "name": "identifier"
+              }
+            },
+            {
+              "name": "verify",
+              "description": "Re-verify the signature of a given runtime",
+              "args": {
+                "name": "identifier"
+              }
+            },
+            {
+              "name": "list",
+              "options": [
+                {
+                  "name": [
+                    "-v"
+                  ],
+                  "description": "Print more verbose output"
+                },
+                {
+                  "name": [
+                    "-j",
+                    "--json"
+                  ],
+                  "description": "Print as JSON"
+                }
+              ]
+            },
+            {
+              "name": "match list",
+              "description": "List the SDK build to runtime build mapping rules for the selected Xcode. Preferred means the runtime was either bundled with Xcode, exactly matched your SDK version, or the downloadable index indicated a better match for your SDK Manual overrides using 'match set' have the highest priority",
+              "options": [
+                {
+                  "name": [
+                    "-v"
+                  ],
+                  "description": "Verbose mode. Includes the full preferred build map, user override map, and known SDK names"
+                },
+                {
+                  "name": [
+                    "-j",
+                    "--json"
+                  ],
+                  "description": "Print as JSON"
+                }
+              ]
+            },
+            {
+              "name": "match set",
+              "description": "Override the SDK to runtime build mapping. This controls which build of a given runtime Xcode will prefer for building and running when using that SDK. This matters most often during Beta releases when there are multiple builds for a given OS version. If --sdkBuild is not specified it is assumed you mean the SDK build for the currently selected Xcode.\n\nNote: Remember this is about build numbers, not semantic versions. When using the iOS 16.0 SDK Xcwill always prefer an iOS 16.0 runtime. Matching policy controls what to do when there are multiiOS 16.0 runtimes availabeg if the iOS 16.0 SDK is 20A245 and the available runtimes are (20A248, 20A252, 20A254) which should Xcode use for building, SwiftUI Previews, and when launching iOS 16.0 Simulators? They are all iOS 16.0 runtimes so a policy must decide which one is selected",
+              "options": [
+                {
+                  "name": [
+                    "--default"
+                  ],
+                  "description": "Clear the override for the given SDK and revert to default behavior"
+                },
+                {
+                  "name": [
+                    "--sdkBuild"
+                  ],
+                  "description": "Explicitly specify the SDK build, eg for an Xcode other than the selected Xcode"
+                }
+              ],
+              "args": [
+                {
+                  "name": "sdk canonical name"
+                },
+                {
+                  "name": "runtime build"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "shutdown",
+          "description": "Shutdown a device",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "all",
+              "suggestions": [
+                {
+                  "name": "all"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "spawn",
+          "description": "Spawn a process by executing a given executable on a device",
+          "options": [
+            {
+              "name": [
+                "-w",
+                "--wait-for-debugger"
+              ]
+            },
+            {
+              "name": [
+                "-s",
+                "--standalone"
+              ]
+            },
+            {
+              "name": [
+                "-a",
+                "--arch"
+              ]
+            }
+          ],
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "path to executable"
+            },
+            {
+              "name": "argv",
+              "isVariadic": true
+            }
+          ]
+        },
+        {
+          "name": "status_bar",
+          "description": "Set or clear status bar overrides",
+          "subcommands": [
+            {
+              "name": "list",
+              "description": "List existing overrides"
+            },
+            {
+              "name": "clear",
+              "description": "Clear all existing status bar overrides"
+            },
+            {
+              "name": "override",
+              "description": "Set status bar override values, according to these flags. You may specify any combination of these flags (at least one is required)",
+              "options": [
+                {
+                  "name": [
+                    "--time"
+                  ],
+                  "description": "Set the date or time to a fixed value. If the string is a valid ISO date string it will also set the date on relevant devices"
+                },
+                {
+                  "name": [
+                    "--dataNetwork"
+                  ],
+                  "description": "If specified must be one of 'hide', 'wifi', '3g', '4g', 'lte', 'lte-a', 'lte+', '5g', '5g+', '5g-uwb', or '5g-uc'"
+                },
+                {
+                  "name": [
+                    "--wifiMode"
+                  ],
+                  "description": "If specified must be one of 'searching', 'failed', or 'active'"
+                },
+                {
+                  "name": [
+                    "--wifiBars"
+                  ],
+                  "description": "If specified must be 0-3"
+                },
+                {
+                  "name": [
+                    "--cellularMode"
+                  ],
+                  "description": "If specified must be one of 'notSupported', 'searching', 'failed', or 'active'"
+                },
+                {
+                  "name": [
+                    "--cellularBars"
+                  ],
+                  "description": "If specified must be 0-4"
+                },
+                {
+                  "name": [
+                    "--operatorName"
+                  ],
+                  "description": "Set the cellular operator/carrier name. Use '' for the empty string"
+                },
+                {
+                  "name": [
+                    "--batteryState"
+                  ],
+                  "description": "If specified must be one of 'charging', 'charged', or 'discharging'"
+                },
+                {
+                  "name": [
+                    "--batteryLevel"
+                  ],
+                  "description": "If specified must be 0-100"
+                }
+              ]
+            }
+          ],
+          "args": {
+            "name": "device"
+          }
+        },
+        {
+          "name": "terminate",
+          "description": "Terminate an application by identifier on a device",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "app bundle identifier"
+            }
+          ]
+        },
+        {
+          "name": "ui",
+          "description": "Get or Set UI options",
+          "subcommands": [
+            {
+              "name": "appearance",
+              "description": "When invoked without arguments prints the current user interface appearance style:\nlight\nThe Light appearance style.\ndark\nThe Dark appearance style.\nunsupported\nThe platform or runtime version do not support appearance styles.\nunknown\nThe current style is unknown or there was an error detecting it"
+            },
+            {
+              "name": "increase_contrast",
+              "description": "When invoked without arguments prints whether the Increase Contrast mode is currently enabled:\nenabled\nIncrease Contrast is enabled.\ndisabled\nIncrease Contrast is disabled.\nunsupported\nThe platform or runtime version do not support the Increase Contrast setting.\nunknown\nThe current setting is unknown or there was an error detecting it"
+            },
+            {
+              "name": "content_size",
+              "description": "When invoked without arguments prints the current preferred content size category, from the following possible values:"
+            }
+          ],
+          "args": {
+            "name": "device"
+          }
+        },
+        {
+          "name": "uninstall",
+          "description": "Uninstall an app from a device",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "app bundle identifier"
+            }
+          ]
+        },
+        {
+          "name": "unpair",
+          "description": "Unpair a watch and phone pair",
+          "args": {
+            "name": "pair UUID"
+          }
+        },
+        {
+          "name": "upgrade",
+          "description": "Upgrade a device to a newer runtime",
+          "args": [
+            {
+              "name": "device"
+            },
+            {
+              "name": "runtime id"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "options": [
+    {
+      "name": [
+        "-h",
+        "--help"
+      ],
+      "description": "Help message"
+    },
+    {
+      "name": [
+        "--version"
+      ],
+      "description": "Show the xcrun version"
+    },
+    {
+      "name": [
+        "-v",
+        "--verbose"
+      ],
+      "description": "Show verbose logging output"
+    },
+    {
+      "name": [
+        "--sdk"
+      ],
+      "description": "Find the tool for the given SDK name",
+      "args": {
+        "name": "sdk name"
+      }
+    },
+    {
+      "name": [
+        "--toolchain"
+      ],
+      "description": "Find the tool for the given toolchain",
+      "args": {
+        "name": "name"
+      }
+    },
+    {
+      "name": [
+        "-l",
+        "--log"
+      ],
+      "description": "Show command path to be executed (and --run)"
+    },
+    {
+      "name": [
+        "-f",
+        "--find"
+      ],
+      "description": "Find and print the tool path"
+    },
+    {
+      "name": [
+        "--run"
+      ],
+      "description": "(Default) find and execute the tool"
+    },
+    {
+      "name": [
+        "-n",
+        "--no-cache"
+      ],
+      "description": "Do not use the lookup cache"
+    },
+    {
+      "name": [
+        "-k",
+        "--kill-cache"
+      ],
+      "description": "Invalidate all existing cache entries"
+    },
+    {
+      "name": [
+        "--show-sdk-path"
+      ],
+      "description": "Show selected SDK install path"
+    },
+    {
+      "name": [
+        "--show-sdk-version"
+      ],
+      "description": "Show selected SDK version"
+    },
+    {
+      "name": [
+        "--show-sdk-build-version"
+      ],
+      "description": "Show selected SDK build version"
+    },
+    {
+      "name": [
+        "--show-sdk-platform-path"
+      ],
+      "description": "Show selected SDK platform path"
+    },
+    {
+      "name": [
+        "--show-sdk-platform-version"
+      ],
+      "description": "Show selected SDK platform version"
+    }
+  ]
+}

--- a/tools/fig-converter/src/index.js
+++ b/tools/fig-converter/src/index.js
@@ -591,12 +591,13 @@ function runWorkerBatch({ batch, outputDir, dryRun, heapMb }) {
       },
     });
 
+    const STDOUT_BUF_CAP = 4096;
     let stdoutBuf = '';
     let stderrTail = '';
     const STDERR_TAIL_CAP = 500;
 
     child.stdout.on('data', (buf) => {
-      stdoutBuf += buf.toString('utf8');
+      stdoutBuf = (stdoutBuf + buf.toString('utf8')).slice(-STDOUT_BUF_CAP);
     });
 
     // Mirror stderr live so the user sees progress in real time, but also
@@ -613,13 +614,14 @@ function runWorkerBatch({ batch, outputDir, dryRun, heapMb }) {
       process.stderr.write(
         `[converter] failed to spawn worker: ${err.message}\n`
       );
+      const totals = makeEmptyTotals();
+      totals.failed = batch.length;
       resolvePromise({
-        totals: makeEmptyTotals(),
+        totals,
         errors: batch.map((spec) => ({
           spec,
           error: `worker spawn failed: ${err.message}`,
         })),
-        totals_failed_override: batch.length,
       });
     });
 

--- a/tools/fig-converter/src/index.js
+++ b/tools/fig-converter/src/index.js
@@ -16,11 +16,26 @@
  *      d. script (function) → requires_js: true
  *      e. custom generators → requires_js: true
  *   5. Write JSON to output directory
+ *
+ * Batched orchestration:
+ *   Single-process conversion of the full @withfig/autocomplete corpus (~705
+ *   specs) exceeds Node's heap even at --max-old-space-size=8192 because the
+ *   ESM dynamic import cache retains every spec module. The orchestrator
+ *   therefore splits the spec list into batches (default 30) and spawns a
+ *   fresh Node subprocess per batch; each child exits after its batch,
+ *   freeing its entire module cache. Small explicit --specs runs (≤ batch
+ *   size) stay in-process for snappy debugging.
+ *
+ *   Workers are invoked via the internal --batch-worker flag. Workers emit
+ *   exactly one line of JSON on stdout ({totals, errors}); progress goes to
+ *   stderr. See §3 of docs/phase-minus-1-followups.md.
  */
 
 import { readdir, mkdir, writeFile } from 'node:fs/promises';
 import { join, basename, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
+import { spawn } from 'node:child_process';
 import { convertSpec } from './static-converter.js';
 import { matchPostProcess } from './post-process-matcher.js';
 import { matchNativeGenerator } from './native-map.js';
@@ -420,41 +435,12 @@ export async function listSpecNames() {
     .map(f => f.replace(/\.js$/, ''));
 }
 
-// --- CLI entry point ---
-
-async function main() {
-  const { values } = parseArgs({
-    options: {
-      output: { type: 'string', short: 'o' },
-      specs: { type: 'string', short: 's' },
-      'dry-run': { type: 'boolean' },
-    },
-  });
-
-  const outputDir = values.output ? resolve(values.output) : null;
-  const isDryRun = values['dry-run'] || false;
-
-  if (!outputDir && !isDryRun) {
-    console.error('Usage: node src/index.js --output <dir> [--specs name1,name2] [--dry-run]');
-    process.exit(1);
-  }
-
-  // Create output directory
-  if (outputDir) {
-    await mkdir(outputDir, { recursive: true });
-  }
-
-  // Determine which specs to convert
-  let specNames;
-  if (values.specs) {
-    specNames = values.specs.split(',').map(s => s.trim());
-  } else {
-    specNames = await listSpecNames();
-  }
-
-  console.log(`Converting ${specNames.length} specs...`);
-
-  const totals = {
+/**
+ * Empty totals shape shared by worker and orchestrator. Kept as a function
+ * (not a constant) so each caller gets a fresh, independently-mutable object.
+ */
+function makeEmptyTotals() {
+  return {
     converted: 0,
     failed: 0,
     subcommands: 0,
@@ -464,7 +450,23 @@ async function main() {
     transformGenerators: 0,
     requiresJsGenerators: 0,
   };
+}
 
+/**
+ * Run the per-spec conversion loop over a list of spec names, writing each
+ * resulting JSON to `outputDir` (unless `dryRun`). Per-spec failures are
+ * recorded in `errors` and do not abort the batch. This is the shared worker
+ * body — used both in-process (small --specs runs) and inside each
+ * subprocess (--batch-worker mode).
+ *
+ * @param {object} opts
+ * @param {string[]} opts.specNames
+ * @param {string|null} opts.outputDir - Absolute path, or null for dry run.
+ * @param {boolean} [opts.dryRun=false]
+ * @returns {Promise<{totals: object, errors: Array<{spec: string, error: string}>}>}
+ */
+export async function runConversionBatch({ specNames, outputDir, dryRun = false }) {
+  const totals = makeEmptyTotals();
   const errors = [];
 
   for (const specName of specNames) {
@@ -478,8 +480,7 @@ async function main() {
 
       const { spec, stats } = result;
 
-      // Write to file
-      if (outputDir) {
+      if (outputDir && !dryRun) {
         const outputPath = join(outputDir, `${specName}.json`);
         // Ensure subdirectories exist (for specs like aws/s3)
         const dir = join(outputDir, ...specName.split('/').slice(0, -1));
@@ -502,7 +503,24 @@ async function main() {
     }
   }
 
-  // Print summary
+  return { totals, errors };
+}
+
+/**
+ * Merge a per-batch result into the running orchestrator aggregate. Mutates
+ * `agg` in place.
+ */
+function mergeTotals(agg, batchTotals) {
+  for (const key of Object.keys(agg)) {
+    agg[key] += batchTotals[key] || 0;
+  }
+}
+
+/**
+ * Print the final conversion summary to stdout. This is the human/CI-readable
+ * block and its format is considered stable — downstream docs reference it.
+ */
+function printSummary(totals, errors) {
   console.log(`\n--- Conversion Summary ---`);
   console.log(`Converted:          ${totals.converted}`);
   console.log(`Failed:             ${totals.failed}`);
@@ -522,6 +540,248 @@ async function main() {
       console.log(`  ... and ${errors.length - 20} more`);
     }
   }
+}
+
+/**
+ * Split an array into contiguous batches of up to `size` elements. Last
+ * batch may be smaller. `size` is assumed ≥ 1 (caller validates).
+ */
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+/**
+ * Spawn a worker subprocess for one batch and await its JSON-on-stdout
+ * result. Progress (and any console.warn/error from the child) is inherited
+ * to this process's stderr. Returns a best-effort result object even when
+ * the child exits non-zero: in that failure case, the batch's specs are all
+ * reported as failed, and up to 500 chars of stderr tail are forwarded to
+ * this process's stderr for operator context.
+ */
+function runWorkerBatch({ batch, outputDir, dryRun, heapMb }) {
+  return new Promise((resolvePromise) => {
+    // Use `--flag=value` form for string args so values that happen to start
+    // with `-` (e.g. the `-` spec from @withfig/autocomplete) or paths with
+    // unusual characters are not misparsed as flags by the worker's
+    // parseArgs. `--batch-worker` and `--dry-run` are booleans and pass
+    // plain.
+    const args = [
+      fileURLToPath(import.meta.url),
+      '--batch-worker',
+      `--specs=${batch.join(',')}`,
+    ];
+    if (outputDir) {
+      args.push(`--output=${outputDir}`);
+    }
+    if (dryRun) {
+      args.push('--dry-run');
+    }
+
+    const child = spawn(process.execPath, args, {
+      // stderr inherits so progress + warnings stream live. stdout is piped
+      // so we can capture the final JSON line. stdin is closed.
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --max-old-space-size=${heapMb}`.trim(),
+      },
+    });
+
+    let stdoutBuf = '';
+    let stderrTail = '';
+    const STDERR_TAIL_CAP = 500;
+
+    child.stdout.on('data', (buf) => {
+      stdoutBuf += buf.toString('utf8');
+    });
+
+    // Mirror stderr live so the user sees progress in real time, but also
+    // keep a rolling tail for failure diagnostics.
+    child.stderr.on('data', (buf) => {
+      const s = buf.toString('utf8');
+      process.stderr.write(s);
+      stderrTail = (stderrTail + s).slice(-STDERR_TAIL_CAP);
+    });
+
+    child.on('error', (err) => {
+      // Spawn failed outright (e.g., execPath missing). Treat the whole
+      // batch as failed and move on.
+      process.stderr.write(
+        `[converter] failed to spawn worker: ${err.message}\n`
+      );
+      resolvePromise({
+        totals: makeEmptyTotals(),
+        errors: batch.map((spec) => ({
+          spec,
+          error: `worker spawn failed: ${err.message}`,
+        })),
+        totals_failed_override: batch.length,
+      });
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        process.stderr.write(
+          `[converter] worker exited with code ${code}. Last stderr:\n${stderrTail}\n`
+        );
+        const totals = makeEmptyTotals();
+        totals.failed = batch.length;
+        resolvePromise({
+          totals,
+          errors: batch.map((spec) => ({
+            spec,
+            error: `worker exited ${code}`,
+          })),
+        });
+        return;
+      }
+
+      // Parse the last non-empty line of stdout as the result JSON. The
+      // worker emits exactly one line, but defensively take the last.
+      const lines = stdoutBuf.split('\n').filter((l) => l.trim().length > 0);
+      const last = lines[lines.length - 1];
+      if (!last) {
+        process.stderr.write(
+          `[converter] worker produced no stdout; marking batch failed\n`
+        );
+        const totals = makeEmptyTotals();
+        totals.failed = batch.length;
+        resolvePromise({
+          totals,
+          errors: batch.map((spec) => ({ spec, error: 'worker stdout empty' })),
+        });
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(last);
+        resolvePromise({
+          totals: { ...makeEmptyTotals(), ...(parsed.totals || {}) },
+          errors: Array.isArray(parsed.errors) ? parsed.errors : [],
+        });
+      } catch (err) {
+        process.stderr.write(
+          `[converter] could not parse worker stdout as JSON: ${err.message}\n`
+        );
+        const totals = makeEmptyTotals();
+        totals.failed = batch.length;
+        resolvePromise({
+          totals,
+          errors: batch.map((spec) => ({
+            spec,
+            error: `worker stdout not JSON: ${err.message}`,
+          })),
+        });
+      }
+    });
+  });
+}
+
+// --- CLI entry point ---
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      output: { type: 'string', short: 'o' },
+      specs: { type: 'string', short: 's' },
+      'dry-run': { type: 'boolean' },
+      'batch-size': { type: 'string' },
+      'batch-worker': { type: 'boolean' },
+    },
+  });
+
+  const outputDir = values.output ? resolve(values.output) : null;
+  const isDryRun = values['dry-run'] || false;
+  const isWorker = values['batch-worker'] || false;
+
+  if (!outputDir && !isDryRun) {
+    console.error('Usage: node src/index.js --output <dir> [--specs name1,name2] [--dry-run] [--batch-size N]');
+    process.exit(1);
+  }
+
+  if (outputDir) {
+    await mkdir(outputDir, { recursive: true });
+  }
+
+  // Determine which specs to process
+  let specNames;
+  if (values.specs) {
+    specNames = values.specs.split(',').map((s) => s.trim()).filter(Boolean);
+  } else {
+    specNames = await listSpecNames();
+  }
+
+  // --- Worker mode: do one batch in-process and emit JSON on stdout ---
+  if (isWorker) {
+    console.error(`[worker] converting ${specNames.length} specs`);
+    const { totals, errors } = await runConversionBatch({
+      specNames,
+      outputDir,
+      dryRun: isDryRun,
+    });
+    // EXACTLY one line of JSON on stdout; nothing else.
+    process.stdout.write(JSON.stringify({ totals, errors }) + '\n');
+    return;
+  }
+
+  // --- Orchestrator mode ---
+  const batchSizeRaw = values['batch-size'];
+  const batchSize = batchSizeRaw !== undefined ? Number.parseInt(batchSizeRaw, 10) : 30;
+  if (!Number.isFinite(batchSize) || batchSize < 1) {
+    console.error(`Invalid --batch-size ${batchSizeRaw}; must be a positive integer`);
+    process.exit(1);
+  }
+
+  const heapMb = Number.parseInt(process.env.CONVERT_WORKER_HEAP_MB ?? '2048', 10);
+  if (!Number.isFinite(heapMb) || heapMb < 128) {
+    console.error(`Invalid CONVERT_WORKER_HEAP_MB=${process.env.CONVERT_WORKER_HEAP_MB}; must be an integer ≥ 128`);
+    process.exit(1);
+  }
+
+  console.log(`Converting ${specNames.length} specs...`);
+
+  // Fast path: small explicit --specs runs stay in-process. Keeps
+  // iteration snappy and avoids subprocess startup tax when the user is
+  // actively debugging a handful of specs.
+  if (specNames.length <= batchSize) {
+    const { totals, errors } = await runConversionBatch({
+      specNames,
+      outputDir,
+      dryRun: isDryRun,
+    });
+    printSummary(totals, errors);
+    return;
+  }
+
+  // Batched path: spawn one Node subprocess per batch. Each child exits
+  // after its batch, freeing its ESM module cache. Sequential on purpose
+  // (parallelism is a separate plan — this fix is "don't OOM").
+  const batches = chunk(specNames, batchSize);
+  const aggregateTotals = makeEmptyTotals();
+  const aggregateErrors = [];
+
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+    const first = batch[0];
+    const last = batch[batch.length - 1];
+    process.stderr.write(
+      `[batch-${i + 1}/${batches.length}] converting ${batch.length} specs: ${first}..${last}\n`
+    );
+    const { totals, errors } = await runWorkerBatch({
+      batch,
+      outputDir,
+      dryRun: isDryRun,
+      heapMb,
+    });
+    mergeTotals(aggregateTotals, totals);
+    for (const e of errors) aggregateErrors.push(e);
+  }
+
+  printSummary(aggregateTotals, aggregateErrors);
 }
 
 // Run main only when executed directly (not imported)

--- a/tools/fig-converter/src/index.js
+++ b/tools/fig-converter/src/index.js
@@ -53,11 +53,23 @@ async function loadFigSpec(specName) {
  * Resolve loadSpec references by inlining the referenced sub-spec.
  * Walks the converted spec tree and replaces _loadSpec markers with actual content.
  *
+ * A cycle guard tracks the set of loadSpec targets already on the current
+ * resolution path (threaded via `visited`). When a target is already visited,
+ * a single `console.warn` is emitted with the would-be cycle chain and the
+ * load is skipped. The `_loadSpec` marker is still stripped so the subcommand
+ * remains in the cleaned output (carrying whatever static content it had).
+ *
  * @param {object} spec - The converted spec (from static-converter)
- * @param {string} specName - The parent spec name (for resolving relative paths)
+ * @param {string} specName - The parent spec name (used in the cycle warning)
+ * @param {Set<string>} visited - Targets already resolved on this path; callers
+ *   should pass `new Set([specName])` at the top level so direct self-refs are
+ *   caught. Must not be mutated by the caller across sibling invocations — a
+ *   fresh branch is forked for each loadSpec descent.
+ * @param {(name: string) => Promise<object|null>} loader - Injectable loader
+ *   for tests. Defaults to `loadFigSpec` (dynamic import from BUILD_DIR).
  * @returns {object} The spec with loadSpec references resolved
  */
-async function resolveLoadSpecs(spec, specName) {
+export async function resolveLoadSpecs(spec, specName, visited = new Set([specName]), loader = loadFigSpec) {
   if (!spec || typeof spec !== 'object') return spec;
 
   if (spec.subcommands && Array.isArray(spec.subcommands)) {
@@ -67,33 +79,49 @@ async function resolveLoadSpecs(spec, specName) {
         const loadSpec = sub._loadSpec;
         delete sub._loadSpec;
 
-        if (typeof loadSpec === 'string') {
-          // Simple string reference — load and inline
-          const loaded = await loadFigSpec(loadSpec);
-          if (loaded) {
-            const converted = convertSpec(loaded);
-            // Merge the loaded spec into this subcommand
-            if (converted.subcommands) sub.subcommands = converted.subcommands;
-            if (converted.options) sub.options = converted.options;
-            if (converted.args) sub.args = converted.args;
-          }
-        } else if (typeof loadSpec === 'object' && loadSpec.specName) {
-          // Object with specName property
-          const loaded = await loadFigSpec(loadSpec.specName);
-          if (loaded) {
-            const converted = convertSpec(loaded);
-            if (converted.subcommands) sub.subcommands = converted.subcommands;
-            if (converted.options) sub.options = converted.options;
-            if (converted.args) sub.args = converted.args;
-          }
-        } else if (typeof loadSpec === 'function') {
+        const targetName =
+          typeof loadSpec === 'string'
+            ? loadSpec
+            : typeof loadSpec === 'object' && loadSpec && typeof loadSpec.specName === 'string'
+              ? loadSpec.specName
+              : null;
+
+        if (typeof loadSpec === 'function') {
           // Dynamic function — can't resolve statically
           sub.requires_js = true;
+        } else if (targetName !== null) {
+          if (visited.has(targetName)) {
+            // Cycle detected — emit a single warning and skip the load.
+            // The subcommand keeps its existing content; we still recurse
+            // into it below so inner loadSpecs further down still resolve.
+            const cyclePath = [...visited, targetName].join(' → ');
+            console.warn(
+              `[converter] loadSpec cycle detected in "${specName}": "${cyclePath}" already resolved; skipping to avoid infinite recursion`
+            );
+          } else {
+            const loaded = await loader(targetName);
+            if (loaded) {
+              const converted = convertSpec(loaded);
+              // Merge the loaded spec into this subcommand
+              if (converted.subcommands) sub.subcommands = converted.subcommands;
+              if (converted.options) sub.options = converted.options;
+              if (converted.args) sub.args = converted.args;
+
+              // Descend into the freshly-inlined sub-spec with a forked
+              // visited set so sibling loadSpecs to the same target don't
+              // false-positive on each other.
+              const nextVisited = new Set(visited);
+              nextVisited.add(targetName);
+              await resolveLoadSpecs(sub, specName, nextVisited, loader);
+              continue;
+            }
+          }
         }
       }
 
-      // Recurse into subcommands
-      await resolveLoadSpecs(sub, specName);
+      // Recurse into subcommands with the current visited set (no new frame
+      // was pushed — this branch didn't cross a loadSpec boundary).
+      await resolveLoadSpecs(sub, specName, visited, loader);
     }
   }
 

--- a/tools/fig-converter/src/index.test.js
+++ b/tools/fig-converter/src/index.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { convertSingleSpec, listSpecNames, cleanGenerator } from './index.js';
+import { convertSingleSpec, listSpecNames, cleanGenerator, runConversionBatch } from './index.js';
 
 describe('listSpecNames', () => {
   it('returns an array of spec names', async () => {
@@ -233,5 +233,60 @@ describe('cleanGenerator', () => {
       _CORRECTED_IN: 'nope',
     });
     assert.deepStrictEqual(result, { script: ['cmd'] });
+  });
+});
+
+describe('runConversionBatch', () => {
+  it('aggregates totals from multiple small specs (in-process smoke test)', async () => {
+    // Sanity-check the shared worker body: converting three small specs via
+    // the batch function should yield totals equal to the sum of calling
+    // convertSingleSpec on each individually. This locks the in-process /
+    // subprocess-worker code paths to the same semantics without spawning
+    // a subprocess.
+    const specs = ['ls', 'cat', 'echo'];
+
+    // Reference totals: sum of per-spec stats.
+    const reference = {
+      converted: 0,
+      subcommands: 0,
+      options: 0,
+      generators: 0,
+    };
+    for (const name of specs) {
+      const r = await convertSingleSpec(name);
+      assert.ok(r, `${name} should convert`);
+      reference.converted++;
+      reference.subcommands += r.stats.subcommands;
+      reference.options += r.stats.options;
+      reference.generators += r.stats.generators;
+    }
+
+    const { totals, errors } = await runConversionBatch({
+      specNames: specs,
+      outputDir: null,
+      dryRun: true,
+    });
+
+    assert.deepStrictEqual(errors, []);
+    assert.equal(totals.converted, reference.converted);
+    assert.equal(totals.failed, 0);
+    assert.equal(totals.subcommands, reference.subcommands);
+    assert.equal(totals.options, reference.options);
+    assert.equal(totals.generators, reference.generators);
+  });
+
+  it('records per-spec failures in errors without aborting the batch', async () => {
+    // A nonexistent spec must surface as an error but must not prevent
+    // subsequent real specs in the same batch from being counted.
+    const { totals, errors } = await runConversionBatch({
+      specNames: ['cat', 'this_spec_does_not_exist_xyz', 'echo'],
+      outputDir: null,
+      dryRun: true,
+    });
+
+    assert.equal(totals.converted, 2);
+    assert.equal(totals.failed, 1);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].spec, 'this_spec_does_not_exist_xyz');
   });
 });

--- a/tools/fig-converter/src/index.test.js
+++ b/tools/fig-converter/src/index.test.js
@@ -1,5 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { convertSingleSpec, listSpecNames, cleanGenerator, runConversionBatch } from './index.js';
 
 describe('listSpecNames', () => {
@@ -288,5 +293,55 @@ describe('runConversionBatch', () => {
     assert.equal(totals.failed, 1);
     assert.equal(errors.length, 1);
     assert.equal(errors[0].spec, 'this_spec_does_not_exist_xyz');
+  });
+});
+
+describe('batched convert integration', () => {
+  it('batched subprocess output matches direct convertSingleSpec output', { timeout: 60000 }, async () => {
+    const specs = ['ls', 'cat', 'echo', 'brew', 'git', 'npm', 'docker', 'grep', 'tar', 'curl'];
+    const tempDir = await mkdtemp(join(tmpdir(), 'gc-convert-it-'));
+    try {
+      // Run the orchestrator as a real subprocess with --batch-size 3, which
+      // forces 10 specs to split into 4 batches (ceil(10/3) = 4), exercising
+      // the subprocess-per-batch code path rather than the in-process fast path.
+      const indexPath = fileURLToPath(new URL('./index.js', import.meta.url));
+      const child = spawn(
+        process.execPath,
+        [indexPath, '--output', tempDir, '--specs', specs.join(','), '--batch-size', '3'],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+
+      let stderr = '';
+      child.stderr.on('data', (b) => { stderr += b.toString(); });
+      let stdout = '';
+      child.stdout.on('data', (b) => { stdout += b.toString(); });
+
+      const exitCode = await new Promise((resolve) => child.on('close', resolve));
+      assert.equal(exitCode, 0, `orchestrator exited ${exitCode}.\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+
+      // Confirm the batched subprocess path was actually exercised: the
+      // orchestrator emits "[batch-N/M]" progress lines on stderr.
+      assert.match(stderr, /\[batch-\d+\/\d+\]/, `expected batching progress in stderr, got:\n${stderr}`);
+
+      // Compare each batched output file against an in-process convertSingleSpec
+      // call. They must be structurally identical post-parse.
+      for (const name of specs) {
+        const direct = await convertSingleSpec(name);
+        if (!direct) {
+          // Should not happen for the chosen specs, but skip gracefully rather
+          // than failing the entire test if the upstream dep is missing it.
+          console.log(`[integration] convertSingleSpec returned null for '${name}', skipping`);
+          continue;
+        }
+
+        const batchedPath = join(tempDir, `${name}.json`);
+        const batchedRaw = await readFile(batchedPath, 'utf8');
+        const batched = JSON.parse(batchedRaw);
+
+        assert.deepStrictEqual(batched, direct.spec, `output mismatch for spec '${name}'`);
+      }
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tools/fig-converter/src/resolve-load-specs.test.js
+++ b/tools/fig-converter/src/resolve-load-specs.test.js
@@ -1,0 +1,229 @@
+/**
+ * resolve-load-specs.test.js
+ *
+ * Focused cycle-guard tests for `resolveLoadSpecs`. The fixtures here are Fig
+ * raw specs fed through `convertSpec` to produce the intermediate shape that
+ * `resolveLoadSpecs` expects (`subcommands[].* _loadSpec` markers).
+ *
+ * Upstream reality that motivates these tests:
+ *   - `simctl.js` self-references via its `help` subcommand (`loadSpec: "simctl"`)
+ *   - `xcrun.js` transitively loads `simctl`, so the cycle cascades
+ * Without a guard, both blow up Node's heap. See docs/phase-minus-1-followups.md §2.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { convertSpec } from './static-converter.js';
+import { resolveLoadSpecs } from './index.js';
+
+/** Captures console.warn output for the duration of a test. */
+function captureWarn() {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => {
+    warnings.push(args.map((a) => String(a)).join(' '));
+  };
+  return {
+    warnings,
+    restore() {
+      console.warn = original;
+    },
+  };
+}
+
+/**
+ * Build a loader from a map of {name: rawFigSpec}. Unknown names return null,
+ * matching the real `loadFigSpec` contract.
+ */
+function makeLoader(specs) {
+  return async (name) => (specs[name] ? specs[name] : null);
+}
+
+describe('resolveLoadSpecs cycle guard', () => {
+  let warnCapture;
+
+  beforeEach(() => {
+    warnCapture = captureWarn();
+  });
+
+  afterEach(() => {
+    warnCapture.restore();
+  });
+
+  it('detects direct self-reference A → A (one warning, no infinite recursion)', async () => {
+    // A has a subcommand "help" whose loadSpec points back to A.
+    const rawA = {
+      name: 'A',
+      subcommands: [
+        { name: 'help', loadSpec: 'A' },
+        { name: 'other', description: 'leaf' },
+      ],
+    };
+    const intermediate = convertSpec(rawA);
+    const loader = makeLoader({ A: rawA });
+
+    const result = await resolveLoadSpecs(intermediate, 'A', new Set(['A']), loader);
+
+    assert.equal(warnCapture.warnings.length, 1, 'expected exactly one warning');
+    assert.match(warnCapture.warnings[0], /loadSpec cycle detected/);
+    assert.match(warnCapture.warnings[0], /A → A/);
+    // The help subcommand survives with no _loadSpec marker remaining.
+    const help = result.subcommands.find((s) => s.name === 'help');
+    assert.ok(help, 'help subcommand should still exist');
+    assert.equal(help._loadSpec, undefined, '_loadSpec marker should be stripped');
+    // Sibling subcommand untouched.
+    const other = result.subcommands.find((s) => s.name === 'other');
+    assert.ok(other, 'sibling subcommand should still exist');
+  });
+
+  it('detects two-hop cycle A → B → A (one warning)', async () => {
+    const rawA = {
+      name: 'A',
+      subcommands: [{ name: 'to-b', loadSpec: 'B' }],
+    };
+    const rawB = {
+      name: 'B',
+      subcommands: [{ name: 'back-to-a', loadSpec: 'A' }],
+    };
+    const intermediate = convertSpec(rawA);
+    const loader = makeLoader({ A: rawA, B: rawB });
+
+    const result = await resolveLoadSpecs(intermediate, 'A', new Set(['A']), loader);
+
+    assert.equal(warnCapture.warnings.length, 1, 'expected exactly one warning');
+    assert.match(warnCapture.warnings[0], /A → B → A/);
+    // A's subcommand "to-b" should have been inlined with B's subcommands.
+    const toB = result.subcommands.find((s) => s.name === 'to-b');
+    assert.ok(toB, 'to-b subcommand should exist');
+    assert.ok(Array.isArray(toB.subcommands), 'to-b should have inlined B.subcommands');
+    const backToA = toB.subcommands.find((s) => s.name === 'back-to-a');
+    assert.ok(backToA, 'back-to-a should still exist (inlined from B)');
+    assert.equal(backToA._loadSpec, undefined, '_loadSpec marker stripped on cycle skip');
+  });
+
+  it('detects three-hop cycle A → B → C → A (one warning)', async () => {
+    const rawA = {
+      name: 'A',
+      subcommands: [{ name: 'to-b', loadSpec: 'B' }],
+    };
+    const rawB = {
+      name: 'B',
+      subcommands: [{ name: 'to-c', loadSpec: 'C' }],
+    };
+    const rawC = {
+      name: 'C',
+      subcommands: [{ name: 'back-to-a', loadSpec: 'A' }],
+    };
+    const intermediate = convertSpec(rawA);
+    const loader = makeLoader({ A: rawA, B: rawB, C: rawC });
+
+    const result = await resolveLoadSpecs(intermediate, 'A', new Set(['A']), loader);
+
+    assert.equal(warnCapture.warnings.length, 1);
+    assert.match(warnCapture.warnings[0], /A → B → C → A/);
+    // Walk the inlined chain: A.to-b → B's content → to-c → C's content → back-to-a
+    const toB = result.subcommands.find((s) => s.name === 'to-b');
+    assert.ok(toB && Array.isArray(toB.subcommands), 'A.to-b should inline B');
+    const toC = toB.subcommands.find((s) => s.name === 'to-c');
+    assert.ok(toC && Array.isArray(toC.subcommands), 'B.to-c should inline C');
+    const backToA = toC.subcommands.find((s) => s.name === 'back-to-a');
+    assert.ok(backToA, 'C.back-to-a should exist (cycle-skipped, marker stripped)');
+    assert.equal(backToA._loadSpec, undefined);
+  });
+
+  it('resolves deep non-cyclic chain A → B → C → D without warnings', async () => {
+    const rawA = { name: 'A', subcommands: [{ name: 'to-b', loadSpec: 'B' }] };
+    const rawB = { name: 'B', subcommands: [{ name: 'to-c', loadSpec: 'C' }] };
+    const rawC = { name: 'C', subcommands: [{ name: 'to-d', loadSpec: 'D' }] };
+    const rawD = {
+      name: 'D',
+      subcommands: [{ name: 'leaf', description: 'terminal' }],
+    };
+    const intermediate = convertSpec(rawA);
+    const loader = makeLoader({ A: rawA, B: rawB, C: rawC, D: rawD });
+
+    const result = await resolveLoadSpecs(intermediate, 'A', new Set(['A']), loader);
+
+    assert.equal(warnCapture.warnings.length, 0, 'no cycle warnings expected');
+
+    // All four layers should be inlined end-to-end.
+    const toB = result.subcommands.find((s) => s.name === 'to-b');
+    assert.ok(toB && Array.isArray(toB.subcommands));
+    const toC = toB.subcommands.find((s) => s.name === 'to-c');
+    assert.ok(toC && Array.isArray(toC.subcommands));
+    const toD = toC.subcommands.find((s) => s.name === 'to-d');
+    assert.ok(toD && Array.isArray(toD.subcommands));
+    const leaf = toD.subcommands.find((s) => s.name === 'leaf');
+    assert.ok(leaf, 'deepest leaf should be inlined');
+    // No _loadSpec markers anywhere.
+    assert.ok(!JSON.stringify(result).includes('_loadSpec'));
+  });
+
+  it('allows sibling subcommands to load the same target without false positive', async () => {
+    // A has two subcommands, both loadSpec: "B". Neither B nor A form a cycle.
+    // If visited were shared globally across siblings, the second sibling would
+    // trip the guard. This test pins that visited is path-scoped.
+    const rawA = {
+      name: 'A',
+      subcommands: [
+        { name: 'first', loadSpec: 'B' },
+        { name: 'second', loadSpec: 'B' },
+      ],
+    };
+    const rawB = {
+      name: 'B',
+      subcommands: [{ name: 'leaf', description: 'terminal' }],
+    };
+    const intermediate = convertSpec(rawA);
+    const loader = makeLoader({ A: rawA, B: rawB });
+
+    const result = await resolveLoadSpecs(intermediate, 'A', new Set(['A']), loader);
+
+    assert.equal(warnCapture.warnings.length, 0, 'sibling same-target loads must not warn');
+    const first = result.subcommands.find((s) => s.name === 'first');
+    const second = result.subcommands.find((s) => s.name === 'second');
+    assert.ok(first && Array.isArray(first.subcommands) && first.subcommands.length === 1);
+    assert.ok(second && Array.isArray(second.subcommands) && second.subcommands.length === 1);
+    assert.equal(first.subcommands[0].name, 'leaf');
+    assert.equal(second.subcommands[0].name, 'leaf');
+  });
+
+  it('applies cycle guard to object-form loadSpec ({ specName: ... })', async () => {
+    const rawA = {
+      name: 'A',
+      subcommands: [{ name: 'help', loadSpec: { specName: 'A' } }],
+    };
+    const intermediate = convertSpec(rawA);
+    const loader = makeLoader({ A: rawA });
+
+    const result = await resolveLoadSpecs(intermediate, 'A', new Set(['A']), loader);
+
+    assert.equal(warnCapture.warnings.length, 1);
+    assert.match(warnCapture.warnings[0], /A → A/);
+    const help = result.subcommands.find((s) => s.name === 'help');
+    assert.ok(help);
+    assert.equal(help._loadSpec, undefined);
+  });
+
+  it('leaves function-form loadSpec untouched (sets requires_js, no cycle interaction)', async () => {
+    // The intermediate spec carries the function reference directly on _loadSpec.
+    // convertSpec preserves it as-is because typeof figSub.loadSpec !== 'undefined'.
+    const fn = () => ({ name: 'dynamic' });
+    const rawA = {
+      name: 'A',
+      subcommands: [{ name: 'dyn', loadSpec: fn }],
+    };
+    const intermediate = convertSpec(rawA);
+    // Sanity: the marker made it through the static pass.
+    assert.equal(typeof intermediate.subcommands[0]._loadSpec, 'function');
+
+    const loader = makeLoader({ A: rawA });
+    const result = await resolveLoadSpecs(intermediate, 'A', new Set(['A']), loader);
+
+    assert.equal(warnCapture.warnings.length, 0, 'function-form must not trigger cycle guard');
+    const dyn = result.subcommands.find((s) => s.name === 'dyn');
+    assert.ok(dyn);
+    assert.equal(dyn.requires_js, true);
+    assert.equal(dyn._loadSpec, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Closes Phase -1 followups §2 and §3 from [`docs/phase-minus-1-followups.md`](../blob/integration/requires-js-specs/docs/phase-minus-1-followups.md). §1 (cd.json / git.json reconciliation) is deliberately **out of scope** here — it's a user-visible behavior change that needs its own review cycle.

### §2 — `resolveLoadSpecs` cycle guard
Thread a `visited: Set<string>` through `resolveLoadSpecs` (seeded with the top-level spec name), emit a single `console.warn` when a cycle is detected, and skip the load. Upstream `simctl.js` self-references via its `help` subcommand, and `xcrun.js` transitively loads `simctl`, so both previously OOMed Node during conversion and had shipped as ~60-byte stubs since v0.2.0.

- `simctl.json`: 59 B → 30.6 KB (37 subcommands)
- `xcrun.json`: 65 B → 58.1 KB (3 subcommands)
- Full-corpus regen surfaced no other latent cycles.

### §3 — Batched `npm run convert`
Single-process conversion of 705+ specs OOMed Node even at `--max-old-space-size=8192` because ESM's dynamic-import cache retains each module. Workaround used to be an external 36-chunk shell script.

The orchestrator now spawns a fresh Node worker per batch of 30 specs (configurable via `--batch-size`); each child exits after its batch, freeing its module cache. The worker body is factored out as `runConversionBatch` so the in-process fast path (used when the requested spec count fits in one batch) and the subprocess workers share logic. One command (`npm run convert`) still does the whole run.

**Measured on a 716-spec full run:**
- Wall-clock: **2.83 s** (target <5 min)
- Peak RSS: **~772 MB** (target <2 GB)
- 0 failures, cycles caught for `simctl` and `xcrun` only.

## Commits

1. `5afed5a` — `fix(converter): add cycle guard to resolveLoadSpecs`
2. `d13c3a2` — `chore(specs): regenerate simctl and xcrun after cycle guard`
3. `4ac85c8` — `feat(converter): subprocess-per-batch convert to avoid OOM`
4. `4f4aab4` — `fix(converter): correct spawn-error failure count and cap stdout buffer`
5. `a273961` — `test(converter): integration test for batched convert parity`
6. `1103521` — `docs: mark phase -1 followups §2 and §3 as resolved`

## Explicitly out of scope

- **§1 (cd.json / git.json reconciliation).** Regenerating these files ships user-visible regressions (`cd <TAB>` loses the folders template; `git checkout <TAB>` loses instant-ref fast path). Needs a separate plan.
- **The 11 oversized/niche specs** (aws, gcloud, hub, fin, northflank, cl, commercelayer, sfdx, twilio, doppler, mongocli) deliberately excluded to keep the binary at ~25 MB. Full `npm run convert` still resurrects these files locally; they were deleted before committing. A follow-up may want to add an exclusion list to the converter so the orchestrator doesn't recreate them. Not this PR.
- **Phase 1 spike work.** Separate session.
- **Phase 0.5 CI gate work.** Separate session.
- **Matcher changes.** The Phase 1 matcher freeze still applies; this PR doesn't touch `post-process-matcher.js`.

## Test plan

- [x] `npm --prefix tools/fig-converter test` — 99 tests pass (was 96 before this PR; +3 = cycle-guard parity, `runConversionBatch` smoke, batched-convert integration).
- [x] `cargo test -p gc-suggest` — 282 passed, 0 failed. Confirms regenerated `simctl.json` + `xcrun.json` deserialize cleanly.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Full `npm run convert` in one invocation — succeeds without OOM. Peak RSS ~772 MB, 2.83 s wall-clock.
- [x] `git diff specs/` post-regen — only `simctl.json` and `xcrun.json` changed (plus `cd.json`/`git.json`/11 niche specs which were reverted as out-of-scope; all 694 other specs round-tripped byte-identical).

## References

- Phase -1 followups doc: `docs/phase-minus-1-followups.md`
- Umbrella PR: #75