### PR TITLE
Phase 0.5: CI gate scaffolding (binary-size, snapshot-diff, oracle, bench-regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,66 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --all-targets
+
+  binary-size-gate:
+    name: Binary size gate
+    needs: [check]
+    runs-on: macos-latest
+    env:
+      PHASE_BUDGET: 2MB
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build release binary
+        run: cargo build --release
+      - name: Absolute ceiling (30MB)
+        run: scripts/check-binary-size.sh --absolute-max 30MB
+      - name: Per-phase delta budget
+        run: scripts/check-binary-size.sh --delta-max "$PHASE_BUDGET"
+
+  snapshot-diff-gate:
+    name: Snapshot diff gate
+    needs: [check, binary-size-gate]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Diff specs/__snapshots__
+        run: scripts/check-snapshots.sh
+
+  oracle-gate:
+    name: Oracle gate (fig-converter)
+    needs: [check]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            fig_converter:
+              - 'tools/fig-converter/**'
+      - name: Set up Node
+        if: steps.filter.outputs.fig_converter == 'true'
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+      - name: Install fig-converter dependencies
+        if: steps.filter.outputs.fig_converter == 'true'
+        run: npm ci
+        working-directory: tools/fig-converter
+      - name: Run oracle stub
+        if: steps.filter.outputs.fig_converter == 'true'
+        run: npm run oracle:changed
+        working-directory: tools/fig-converter
+
+  bench-regression:
+    name: Bench regression gate
+    needs: [check]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Bench regression check (threshold 10%)
+        run: scripts/check-bench.sh --threshold 10

--- a/benchmarks/binary-size-baseline.txt
+++ b/benchmarks/binary-size-baseline.txt
@@ -1,0 +1,1 @@
+49385984	target/release/ghost-complete

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -109,10 +109,10 @@ These steps require repo admin access. Without them the gates run but **do not b
 2. Edit the branch protection rule for `master`, or create one if none exists.
 3. Enable **"Require status checks to pass before merging"**.
 4. In the status check search box, add the following checks by their **exact names** (these are the human-readable `name:` values from the CI YAML, not the YAML job keys):
-   - `Binary size gate`
    - `Snapshot diff gate`
    - `Oracle gate (fig-converter)`
    - `Bench regression gate`
+   - `Binary size gate` — **DELAY adding this one.** The absolute-ceiling check currently fails red (binary is ~47 MB, ceiling is 30 MB). Requiring this check today blocks every PR. Add it only after the requires-js-specs work shrinks the binary below 30 MB. In the meantime the gate still runs and reports red, keeping the goal visible.
 5. Save the rule.
 
 These four checks are added **alongside** any existing required checks (e.g. `Check`, `Test`, `Clippy`, `Format`, `MSRV (1.86)`, `Linux tripwire (compile-check only)`). They replace nothing.

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -1,0 +1,152 @@
+# CI Gates — Phase 0.5
+
+## Overview
+
+Phase 0.5 introduces four CI gates to prevent regressions during the requires-js-specs work. The gates enforce binary size budgets, spec snapshot consistency, fig-converter correctness, and benchmark performance. They are wired into `.github/workflows/ci.yml` via `needs:` dependencies, which controls **ordering within a workflow run** — i.e. a gate waits for its prerequisite jobs before it starts. That is a separate concern from **branch protection**, which is what blocks the GitHub merge button on a PR. A repo admin must explicitly configure the four status checks as required in GitHub's branch-protection settings (see [Branch-protection configuration](#branch-protection-configuration) below). Without that step, the gates run and report results but cannot block a merge.
+
+---
+
+## Gates
+
+### Binary size gate
+
+**Job name in CI:** `Binary size gate`
+**YAML key:** `binary-size-gate`
+**Trigger:** `needs: [check]` — runs after the `check` job succeeds.
+
+**Purpose:** enforces two independent size constraints on the release binary:
+
+1. **Absolute ceiling (30 MB)** — the binary must not exceed 30 MB. This limit is fixed. Raising it requires an explicit plan amendment.
+2. **Per-phase delta budget (default +2 MB)** — the binary must not have grown by more than `PHASE_BUDGET` (set to `2MB` in the job env) since the size recorded in [`benchmarks/binary-size-baseline.txt`](../benchmarks/binary-size-baseline.txt).
+
+**Failure modes:**
+
+- Absolute ceiling failure: binary size exceeds 30 MB. CI shows red. This is intentional — the gate is meant to stay red until the binary is actually shrunk to the target, so the goal is not quietly forgotten.
+- Delta budget failure: binary grew by more than `PHASE_BUDGET` since the baseline was recorded.
+
+**How to debug locally:**
+
+```bash
+cargo build --release
+scripts/check-binary-size.sh --absolute-max 30MB
+scripts/check-binary-size.sh --delta-max 2MB
+```
+
+**Baseline maintenance:** when a phase legitimately grows the binary, update the baseline file:
+
+```bash
+du -b target/release/ghost-complete > benchmarks/binary-size-baseline.txt
+```
+
+---
+
+### Snapshot diff gate
+
+**Job name in CI:** `Snapshot diff gate`
+**YAML key:** `snapshot-diff-gate`
+**Trigger:** `needs: [check, binary-size-gate]` — runs after both `check` and `Binary size gate` succeed. Size is cheaper to check first, and the plan chains them explicitly.
+
+**Purpose:** catches PRs that modify `specs/*.json` files without updating the corresponding `specs/__snapshots__/*.snap` entries.
+
+**Failure modes:** diff found between a spec file and its snapshot.
+
+**Status today:** `specs/__snapshots__/` does not exist yet — it lands in session D of Phase 0. Until then, `scripts/check-snapshots.sh` detects the missing directory, emits a warning, and exits 0. The gate does not block anything.
+
+**How to debug locally:**
+
+```bash
+scripts/check-snapshots.sh
+```
+
+---
+
+### Oracle gate (fig-converter)
+
+**Job name in CI:** `Oracle gate (fig-converter)`
+**YAML key:** `oracle-gate`
+**Trigger:** `needs: [check]`, additionally guarded by `if: github.event_name == 'pull_request'` and a path filter on `tools/fig-converter/**`. The gate only runs on PRs that touch the converter.
+
+**Purpose:** runs the fig-converter correctness oracle to detect semantic mismatches between the JS reference implementation and the Rust transform pipeline.
+
+**Failure modes:** oracle reports a mismatch between JS and Rust outputs for any changed converter path.
+
+**Status today:** the `oracle:changed` npm script in `tools/fig-converter/package.json` is a stub that exits 0 with "not yet implemented". Real oracle output lands in Phase 0 (Session A downstream).
+
+**How to debug locally:**
+
+```bash
+cd tools/fig-converter && npm run oracle:changed
+```
+
+---
+
+### Bench regression gate
+
+**Job name in CI:** `Bench regression gate`
+**YAML key:** `bench-regression`
+**Trigger:** `needs: [check]`
+
+**Purpose:** fails if any Criterion benchmark group regresses more than 10% relative to the saved baseline.
+
+**Failure modes:** a benchmark's mean is more than 10% slower than its recorded baseline value.
+
+**Status today:** `scripts/check-bench.sh` is a stub. The baseline file (`benchmarks/baseline-pre-js-port.md`) does not exist yet — it lands in Phase 0.4. Until then the script exits 0 with a warning. The gate does not block anything.
+
+**How to debug locally:**
+
+```bash
+cargo bench
+scripts/check-bench.sh --threshold 10
+```
+
+---
+
+## Branch-protection configuration
+
+These steps require repo admin access. Without them the gates run but **do not block merge**.
+
+1. Go to <https://github.com/StanMarek/ghost-complete/settings/branches>.
+2. Edit the branch protection rule for `master`, or create one if none exists.
+3. Enable **"Require status checks to pass before merging"**.
+4. In the status check search box, add the following checks by their **exact names** (these are the human-readable `name:` values from the CI YAML, not the YAML job keys):
+   - `Binary size gate`
+   - `Snapshot diff gate`
+   - `Oracle gate (fig-converter)`
+   - `Bench regression gate`
+5. Save the rule.
+
+These four checks are added **alongside** any existing required checks (e.g. `Check`, `Test`, `Clippy`, `Format`, `MSRV (1.86)`, `Linux tripwire (compile-check only)`). They replace nothing.
+
+> **Note on job names vs. YAML keys:** GitHub branch protection displays the `name:` field of each job, not the YAML key. `Binary size gate` (the name) corresponds to `binary-size-gate` (the key). Using the YAML key in the search box will not match.
+
+---
+
+## When gates turn into real enforcement
+
+Three of the four gates are currently stubs that exit 0 when their prerequisite artifacts are absent:
+
+| Gate | Activates when | Lands in |
+|------|---------------|----------|
+| `Snapshot diff gate` | `specs/__snapshots__/` directory is created | Phase 0, session D |
+| `Oracle gate (fig-converter)` | Real `oracle:changed` npm script replaces the stub | Phase 0, session A |
+| `Bench regression gate` | `benchmarks/baseline-pre-js-port.md` is committed | Phase 0.4 |
+
+Once all three artifacts exist, the gates enforce for real. The `Binary size gate` is already enforcing the delta budget now (as long as `benchmarks/binary-size-baseline.txt` exists).
+
+---
+
+## FAQ
+
+**"Why is the 30 MB ceiling lower than the current binary (~47 MB)?"**
+
+The 30 MB target is where the requires-js-specs work is expected to land after specs are removed from the embedded binary. The ceiling is set now to make the goal explicit: the gate intentionally fails red until the binary is shrunk. The delta budget (`PHASE_BUDGET=2MB`) handles the near-term constraint — "don't grow from the current baseline". These are two independent checks; both must pass.
+
+**"Can I skip a gate on a specific PR?"**
+
+No. Required status checks are all-or-nothing. For a legitimate one-off exception (e.g. an unavoidable binary size overrun covered by a plan amendment), the admin must:
+
+1. Temporarily remove the specific status check from branch protection.
+2. Merge the PR.
+3. Re-add the status check immediately after.
+
+This is an emergency procedure. Document the exception in the PR description and in the relevant plan file.

--- a/scripts/check-bench.sh
+++ b/scripts/check-bench.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# scripts/check-bench.sh — CI gate: benchmark regression check (STUB)
+#
+# Compares Criterion benchmark results against a recorded baseline.
+# Real implementation deferred until baseline-pre-js-port.md lands.
+#
+# EXIT CODES
+#   0 — pass (or missing baseline/data, or dry-run)
+#   1 — regression detected (gate violation) — NOT YET IMPLEMENTED
+#   2 — script/usage error
+#
+# DRY-RUN
+#   Pass --dry-run or set CI_DRY_RUN=1.  Argument validation still runs;
+#   the actual regression check is skipped and the script exits 0.
+#
+# TODO: real implementation should:
+#   - Parse target/criterion/**/estimates.json for each benchmark group
+#   - Extract mean.point_estimate (nanoseconds) per benchmark
+#   - Compare against the baseline table in benchmarks/baseline-pre-js-port.md
+#   - Fail if any benchmark regresses by more than --threshold percent
+#   - Report which benchmarks regressed and by how much
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+BASELINE_FILE="$REPO_ROOT/benchmarks/baseline-pre-js-port.md"
+CRITERION_DIR="$REPO_ROOT/target/criterion"
+DEFAULT_THRESHOLD=10
+
+usage() {
+    cat <<'EOF'
+Usage:
+  check-bench.sh [--threshold <percent>] [--dry-run] [--help]
+
+Checks for benchmark regressions against benchmarks/baseline-pre-js-port.md.
+If baseline or Criterion data are absent, exits 0 with a warning.
+
+Options:
+  --threshold <pct>   Regression threshold in percent (default: 10).
+  --dry-run           Skip regression check; print what would be checked; exit 0.
+  --help              Print this help and exit 0.
+
+Environment:
+  CI_DRY_RUN=1   Equivalent to --dry-run.
+EOF
+}
+
+# ---- parse args ---------------------------------------------------------------
+
+dry_run=0
+threshold="$DEFAULT_THRESHOLD"
+[[ "${CI_DRY_RUN:-0}" == "1" ]] && dry_run=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            usage; exit 0 ;;
+        --dry-run)
+            dry_run=1; shift ;;
+        --threshold)
+            [[ -z "${2:-}" ]] && die "--threshold requires an argument"
+            threshold="$2"
+            # Validate it's a non-negative integer
+            if ! [[ "$threshold" =~ ^[0-9]+$ ]]; then
+                die "--threshold must be a non-negative integer, got: $threshold"
+            fi
+            shift 2 ;;
+        *)
+            die "unknown flag: $1 (use --help for usage)" ;;
+    esac
+done
+
+# ---- dry-run early exit -------------------------------------------------------
+
+if [[ "$dry_run" -eq 1 ]]; then
+    log "[dry-run] would check benchmark regressions with --threshold ${threshold}%"
+    exit 0
+fi
+
+# ---- guard: baseline file must exist ------------------------------------------
+
+if [[ ! -f "$BASELINE_FILE" ]]; then
+    printf 'warning: baseline file not found (%s) — skipping benchmark regression check\n' \
+        "$BASELINE_FILE" >&2
+    exit 0
+fi
+
+# ---- guard: Criterion data must exist -----------------------------------------
+
+if [[ ! -d "$CRITERION_DIR" ]]; then
+    printf 'warning: no benchmark data found (%s) — run `cargo bench` first\n' \
+        "$CRITERION_DIR" >&2
+    exit 0
+fi
+
+# ---- STUB body ----------------------------------------------------------------
+# TODO: replace this placeholder with real regression detection.
+# Real logic should:
+#   1. Find all target/criterion/**/estimates.json
+#   2. Extract mean.point_estimate from each
+#   3. Parse the Markdown table in benchmarks/baseline-pre-js-port.md
+#      (expected format: | bench_name | mean_ns | ... |)
+#   4. For each bench present in both: compute pct_change = (current - base) / base * 100
+#   5. If pct_change > threshold, record as regression
+#   6. After all benches: if any regressions, print report and exit 1
+#      Otherwise print summary and exit 0
+
+log "benchmark regression check not yet implemented — placeholder pass"
+exit 0

--- a/scripts/check-bench.test.sh
+++ b/scripts/check-bench.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# scripts/check-bench.test.sh — tests for check-bench.sh
+# Self-contained; no bats dependency.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-bench.sh"
+
+# ---- tiny test harness -------------------------------------------------------
+
+_pass=0
+_fail=0
+
+assert_exit_code() {
+    local desc="$1" expected="$2"; shift 2
+    local actual=0
+    "$@" >/dev/null 2>&1 || actual=$?
+    if [[ "$actual" -eq "$expected" ]]; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s (exit %d)\n' "$desc" "$actual"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s — expected exit %d, got %d\n' "$desc" "$expected" "$actual"
+    fi
+}
+
+assert_stdout_contains() {
+    local desc="$1" needle="$2"; shift 2
+    local out
+    out="$("$@" 2>/dev/null || true)"
+    if printf '%s' "$out" | grep -qFe "$needle"; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s\n' "$desc"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s — stdout did not contain %q\n' "$desc" "$needle"
+        printf '      stdout was: %s\n' "$out"
+    fi
+}
+
+assert_stderr_contains() {
+    local desc="$1" needle="$2"; shift 2
+    local err
+    err="$("$@" 2>&1 >/dev/null || true)"
+    if printf '%s' "$err" | grep -qFe "$needle"; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s\n' "$desc"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s — stderr did not contain %q\n' "$desc" "$needle"
+        printf '      stderr was: %s\n' "$err"
+    fi
+}
+
+finish() {
+    printf '\n%d passed, %d failed\n' "$_pass" "$_fail"
+    [[ "$_fail" -eq 0 ]]
+}
+
+# ---- scratch setup -----------------------------------------------------------
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Build a patched copy pointing at our scratch tree.
+PATCHED="$SCRATCH/check-bench-patched.sh"
+sed \
+    -e "s|REPO_ROOT=\"\$(cd \"\$SCRIPT_DIR/..\" && pwd)\"|REPO_ROOT=\"$SCRATCH\"|" \
+    "$SCRIPT" > "$PATCHED"
+sed -i.bak "s|source \"\$SCRIPT_DIR/lib/common.sh\"|source \"$SCRIPT_DIR/lib/common.sh\"|" "$PATCHED"
+chmod +x "$PATCHED"
+
+run_patched() { bash "$PATCHED" "$@"; }
+
+# ---- tests -------------------------------------------------------------------
+
+assert_exit_code "--help exits 0"  0  bash "$SCRIPT" --help
+assert_stdout_contains "--help prints usage" "Usage:" bash "$SCRIPT" --help
+
+assert_exit_code "unknown flag → exit 2" 2  bash "$SCRIPT" --bogus
+
+assert_exit_code "--threshold bad value → exit 2" 2  bash "$SCRIPT" --threshold abc
+
+# Missing baseline file → exit 0 with warning
+# (no benchmarks dir / file in scratch)
+assert_exit_code "missing baseline → exit 0" 0 run_patched
+assert_stderr_contains "missing baseline → stderr warning" "warning" run_patched
+
+# Baseline present but no target/criterion → exit 0 with warning
+mkdir -p "$SCRATCH/benchmarks"
+printf '| bench | mean_ns |\n| foo | 100 |\n' > "$SCRATCH/benchmarks/baseline-pre-js-port.md"
+assert_exit_code "no criterion dir → exit 0" 0 run_patched
+assert_stderr_contains "no criterion dir → stderr warning" "warning" run_patched
+
+# Both baseline and criterion present → stub exits 0
+mkdir -p "$SCRATCH/target/criterion"
+assert_exit_code "baseline + criterion → stub exits 0" 0 run_patched
+
+# --dry-run → exit 0 regardless
+assert_exit_code "--dry-run exits 0" 0 run_patched --dry-run
+assert_exit_code "CI_DRY_RUN=1 exits 0" 0 env CI_DRY_RUN=1 bash "$PATCHED"
+
+# --threshold override → still exits 0 (stub)
+assert_exit_code "--threshold 20 exits 0" 0 run_patched --threshold 20
+
+# ---- done --------------------------------------------------------------------
+
+finish

--- a/scripts/check-binary-size.sh
+++ b/scripts/check-binary-size.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# scripts/check-binary-size.sh — CI gate: ghost-complete binary size check
+#
+# USAGE
+#   check-binary-size.sh --absolute-max <size>   fail if binary > size
+#   check-binary-size.sh --delta-max <size>       fail if (binary - baseline) > size
+#
+# EXIT CODES
+#   0 — gate passed (or dry-run)
+#   1 — gate violated (binary too large / delta too large)
+#   2 — script/usage error (bad flags, missing dependency, build failure)
+#
+# DRY-RUN
+#   Pass --dry-run or set CI_DRY_RUN=1.  Argument validation still runs; the
+#   actual size check is skipped and the script exits 0.  This lets cargo-test
+#   / npm-test call-sites invoke the script without triggering a real failure.
+#
+# SIZE UNITS (case-insensitive)
+#   Bare integer = bytes.  K/KB/KiB = 1024.  M/MB/MiB = 1024^2.
+#   G/GB/GiB = 1024^3.  MB and MiB are treated identically (no SI/IEC split).
+#
+# BASELINE FILE
+#   benchmarks/binary-size-baseline.txt — one of:
+#     49283072                              (bare integer, bytes)
+#     49283072\ttarget/release/ghost-complete   (du -b output)
+#   Leading whitespace is ignored.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+BINARY_PATH="$REPO_ROOT/target/release/ghost-complete"
+BASELINE_FILE="$REPO_ROOT/benchmarks/binary-size-baseline.txt"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  check-binary-size.sh --absolute-max <size>
+  check-binary-size.sh --delta-max <size>
+  check-binary-size.sh --help
+
+Options:
+  --absolute-max <size>   Fail if binary size exceeds <size>.
+  --delta-max <size>      Fail if binary size minus recorded baseline exceeds <size>.
+                          Requires benchmarks/binary-size-baseline.txt.
+  --dry-run               Skip size check; print what would be checked; exit 0.
+  --help                  Print this help and exit 0.
+
+Size units (case-insensitive): bare integer (bytes), K/KB/KiB, M/MB/MiB, G/GB/GiB.
+MB and MiB are treated identically as 1024*1024 bytes.
+
+Environment:
+  CI_DRY_RUN=1   Equivalent to --dry-run.
+EOF
+}
+
+# ---- parse args ---------------------------------------------------------------
+
+mode=""          # "absolute" | "delta"
+limit_raw=""     # raw size string from CLI
+dry_run=0
+
+[[ "${CI_DRY_RUN:-0}" == "1" ]] && dry_run=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            usage; exit 0 ;;
+        --dry-run)
+            dry_run=1; shift ;;
+        --absolute-max)
+            [[ -z "${2:-}" ]] && die "--absolute-max requires an argument"
+            mode="absolute"
+            limit_raw="$2"
+            shift 2 ;;
+        --delta-max)
+            [[ -z "${2:-}" ]] && die "--delta-max requires an argument"
+            mode="delta"
+            limit_raw="$2"
+            shift 2 ;;
+        *)
+            die "unknown flag: $1 (use --help for usage)" ;;
+    esac
+done
+
+[[ -z "$mode" ]] && die "one of --absolute-max or --delta-max is required (use --help for usage)"
+
+# Validate the size argument early (even in dry-run, so bad flags surface).
+limit_bytes="$(parse_size "$limit_raw")"
+
+# ---- dry-run early exit -------------------------------------------------------
+
+if [[ "$dry_run" -eq 1 ]]; then
+    limit_mb="$(bytes_to_mb "$limit_bytes")"
+    log "[dry-run] would check binary size with --${mode}-max ${limit_raw} (${limit_mb})"
+    exit 0
+fi
+
+# ---- build binary if missing --------------------------------------------------
+
+if [[ ! -f "$BINARY_PATH" ]]; then
+    log "Binary not found at $BINARY_PATH — building with cargo build --release"
+    if ! command -v cargo &>/dev/null; then
+        die "cargo not found; cannot build binary (install Rust: https://rustup.rs)"
+    fi
+    if ! (cd "$REPO_ROOT" && cargo build --release); then
+        die "cargo build --release failed"
+    fi
+fi
+
+# ---- measure actual binary size -----------------------------------------------
+
+if [[ ! -f "$BINARY_PATH" ]]; then
+    die "binary still missing after build: $BINARY_PATH"
+fi
+
+actual_bytes="$(wc -c < "$BINARY_PATH")"
+# wc -c can leave leading whitespace on some platforms; strip it
+actual_bytes="${actual_bytes// /}"
+actual_mb="$(bytes_to_mb "$actual_bytes")"
+
+# ---- run the gate -------------------------------------------------------------
+
+case "$mode" in
+    absolute)
+        limit_mb="$(bytes_to_mb "$limit_bytes")"
+        log "Binary size: ${actual_mb} (limit: ${limit_mb})"
+        if (( actual_bytes > limit_bytes )); then
+            printf 'FAIL: binary size %s exceeds absolute limit %s\n' "$actual_mb" "$limit_mb" >&2
+            exit 1
+        fi
+        log "PASS: binary size within limit."
+        ;;
+
+    delta)
+        # Read baseline
+        if [[ ! -f "$BASELINE_FILE" ]]; then
+            die "baseline file not found: $BASELINE_FILE (required for --delta-max)"
+        fi
+        # Support both "49283072" and "49283072\t<path>" (du -b output).
+        # Read the first non-empty line, strip leading whitespace, take first field.
+        baseline_bytes=""
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            # Strip leading whitespace
+            line="${line#"${line%%[! ]*}"}"
+            [[ -z "$line" ]] && continue
+            # Take first whitespace-delimited token (handles tab-separated du -b format)
+            baseline_bytes="${line%%[$'\t' ]*}"
+            break
+        done < "$BASELINE_FILE"
+
+        if [[ -z "$baseline_bytes" ]] || ! [[ "$baseline_bytes" =~ ^[0-9]+$ ]]; then
+            die "could not parse baseline bytes from $BASELINE_FILE (got: '$baseline_bytes')"
+        fi
+
+        delta=$(( actual_bytes - baseline_bytes ))
+        limit_mb="$(bytes_to_mb "$limit_bytes")"
+        baseline_mb="$(bytes_to_mb "$baseline_bytes")"
+        delta_mb="$(bytes_to_mb "$(( delta < 0 ? 0 : delta ))")"
+
+        log "Binary size: ${actual_mb}  Baseline: ${baseline_mb}  Delta: +${delta_mb}  Limit: ${limit_mb}"
+
+        if (( delta > limit_bytes )); then
+            printf 'FAIL: binary growth %s exceeds delta limit %s (baseline: %s, current: %s)\n' \
+                "$delta_mb" "$limit_mb" "$baseline_mb" "$actual_mb" >&2
+            exit 1
+        fi
+        log "PASS: binary delta within limit."
+        ;;
+esac
+
+exit 0

--- a/scripts/check-binary-size.sh
+++ b/scripts/check-binary-size.sh
@@ -159,9 +159,13 @@ case "$mode" in
         delta=$(( actual_bytes - baseline_bytes ))
         limit_mb="$(bytes_to_mb "$limit_bytes")"
         baseline_mb="$(bytes_to_mb "$baseline_bytes")"
-        delta_mb="$(bytes_to_mb "$(( delta < 0 ? 0 : delta ))")"
+        if (( delta < 0 )); then
+            delta_mb="-$(bytes_to_mb "$(( -delta ))")"
+        else
+            delta_mb="+$(bytes_to_mb "$delta")"
+        fi
 
-        log "Binary size: ${actual_mb}  Baseline: ${baseline_mb}  Delta: +${delta_mb}  Limit: ${limit_mb}"
+        log "Binary size: ${actual_mb}  Baseline: ${baseline_mb}  Delta: ${delta_mb}  Limit: ${limit_mb}"
 
         if (( delta > limit_bytes )); then
             printf 'FAIL: binary growth %s exceeds delta limit %s (baseline: %s, current: %s)\n' \

--- a/scripts/check-binary-size.test.sh
+++ b/scripts/check-binary-size.test.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# scripts/check-binary-size.test.sh — tests for check-binary-size.sh
+# Self-contained; no bats dependency.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-binary-size.sh"
+
+# ---- tiny test harness -------------------------------------------------------
+
+_pass=0
+_fail=0
+
+_check() {
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s\n' "$desc"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s\n' "$desc"
+    fi
+}
+
+assert_exit_code() {
+    local desc="$1" expected="$2"; shift 2
+    local actual=0
+    "$@" >/dev/null 2>&1 || actual=$?
+    if [[ "$actual" -eq "$expected" ]]; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s (exit %d)\n' "$desc" "$actual"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s — expected exit %d, got %d\n' "$desc" "$expected" "$actual"
+    fi
+}
+
+# Capture stdout; assert it contains a substring
+assert_stdout_contains() {
+    local desc="$1" needle="$2"; shift 2
+    local out
+    out="$("$@" 2>/dev/null || true)"
+    if printf '%s' "$out" | grep -qFe "$needle"; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s\n' "$desc"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s — stdout did not contain %q\n' "$desc" "$needle"
+        printf '      stdout was: %s\n' "$out"
+    fi
+}
+
+# Capture stderr; assert it contains a substring
+assert_stderr_contains() {
+    local desc="$1" needle="$2"; shift 2
+    local err
+    err="$("$@" 2>&1 >/dev/null || true)"
+    if printf '%s' "$err" | grep -qFe "$needle"; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s\n' "$desc"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s — stderr did not contain %q\n' "$desc" "$needle"
+        printf '      stderr was: %s\n' "$err"
+    fi
+}
+
+finish() {
+    printf '\n%d passed, %d failed\n' "$_pass" "$_fail"
+    [[ "$_fail" -eq 0 ]]
+}
+
+# ---- helpers -----------------------------------------------------------------
+
+# Create a scratch dir; register cleanup
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Stub cargo so the script never actually builds anything.
+# We create a fake cargo in $SCRATCH/bin that exits 0.
+mkdir -p "$SCRATCH/bin"
+cat >"$SCRATCH/bin/cargo" <<'SH'
+#!/usr/bin/env bash
+# Stub: pretend build succeeded (binary must already exist in the test)
+exit 0
+SH
+chmod +x "$SCRATCH/bin/cargo"
+
+# Helper: run script with our stub cargo on PATH
+run_script() {
+    PATH="$SCRATCH/bin:$PATH" bash "$SCRIPT" "$@"
+}
+
+# ---- basic flag tests --------------------------------------------------------
+
+assert_exit_code "--help exits 0"          0  bash "$SCRIPT" --help
+assert_stdout_contains "--help prints usage" "Usage:" bash "$SCRIPT" --help
+
+assert_exit_code "no flags → exit 2"       2  run_script
+assert_stderr_contains "no flags → usage error" "--absolute-max" run_script
+
+assert_exit_code "unknown flag → exit 2"   2  run_script --bogus-flag
+assert_stderr_contains "unknown flag → stderr"  "unknown flag"  run_script --bogus-flag
+
+# ---- dry-run -----------------------------------------------------------------
+
+assert_exit_code "--dry-run --absolute-max 30MB → exit 0" 0 \
+    run_script --dry-run --absolute-max 30MB
+
+assert_stdout_contains "--dry-run prints [dry-run]" "[dry-run]" \
+    run_script --dry-run --absolute-max 30MB
+
+assert_exit_code "CI_DRY_RUN=1 → exit 0" 0 \
+    env CI_DRY_RUN=1 PATH="$SCRATCH/bin:$PATH" bash "$SCRIPT" --absolute-max 30MB
+
+# ---- size parser (tested via --dry-run so no filesystem needed) --------------
+
+parse_ok() {
+    local desc="$1" raw="$2"
+    assert_exit_code "parse_ok: $desc" 0 run_script --dry-run --absolute-max "$raw"
+}
+parse_fail() {
+    local desc="$1" raw="$2"
+    assert_exit_code "parse_fail: $desc → exit 2" 2 run_script --dry-run --absolute-max "$raw"
+}
+
+parse_ok  "30MB"   30MB
+parse_ok  "30mb"   30mb
+parse_ok  "30M"    30M
+parse_ok  "30MiB"  30MiB
+parse_ok  "1024 bytes" 1024
+parse_ok  "1K"     1K
+parse_ok  "1G"     1G
+parse_ok  "1GB"    1GB
+parse_ok  "1GiB"   1GiB
+
+parse_fail "invalid unit 30XB" 30XB
+
+# ---- integration: absolute-max -----------------------------------------------
+
+# Create a synthetic binary (exactly 5 MB)
+FAKE_BINARY_DIR="$SCRATCH/target/release"
+mkdir -p "$FAKE_BINARY_DIR"
+dd if=/dev/zero of="$FAKE_BINARY_DIR/ghost-complete" bs=1024 count=5120 2>/dev/null
+
+# Override REPO_ROOT by creating a wrapper that points at our scratch tree.
+# We achieve this by sourcing the library with an overridden path, but the
+# simplest approach is to build a temporary copy of the script with patched paths.
+PATCHED="$SCRATCH/check-binary-size-patched.sh"
+sed \
+    -e "s|REPO_ROOT=\"\$(cd \"\$SCRIPT_DIR/..\" && pwd)\"|REPO_ROOT=\"$SCRATCH\"|" \
+    "$SCRIPT" > "$PATCHED"
+# Fix the source path for common.sh in the patched copy
+sed -i.bak "s|source \"\$SCRIPT_DIR/lib/common.sh\"|source \"$SCRIPT_DIR/lib/common.sh\"|" "$PATCHED"
+chmod +x "$PATCHED"
+
+run_patched() {
+    PATH="$SCRATCH/bin:$PATH" bash "$PATCHED" "$@"
+}
+
+# 5 MB binary vs 10 MB limit → PASS
+assert_exit_code "absolute: 5MB < 10MB limit → pass" 0 \
+    run_patched --absolute-max 10MB
+
+# 5 MB binary vs 4 MB limit → FAIL (exit 1)
+assert_exit_code "absolute: 5MB > 4MB limit → fail" 1 \
+    run_patched --absolute-max 4MB
+
+# ---- integration: delta-max --------------------------------------------------
+
+# Baseline: 4 MB
+BASELINE_DIR="$SCRATCH/benchmarks"
+mkdir -p "$BASELINE_DIR"
+printf '%d\n' $(( 4 * 1024 * 1024 )) > "$BASELINE_DIR/binary-size-baseline.txt"
+
+# Binary is 5 MB → delta = 1 MB
+# delta-max 2MB → PASS
+assert_exit_code "delta: 1MB delta < 2MB limit → pass" 0 \
+    run_patched --delta-max 2MB
+
+# delta-max 512K → FAIL (1 MB > 512 KB)
+assert_exit_code "delta: 1MB delta > 512K limit → fail" 1 \
+    run_patched --delta-max 512K
+
+# Baseline in du -b format: "<bytes>\t<path>"
+printf '%d\ttarget/release/ghost-complete\n' $(( 4 * 1024 * 1024 )) \
+    > "$BASELINE_DIR/binary-size-baseline.txt"
+
+assert_exit_code "delta: du-b format baseline → pass" 0 \
+    run_patched --delta-max 2MB
+
+# Baseline with leading whitespace
+printf '  %d\n' $(( 4 * 1024 * 1024 )) \
+    > "$BASELINE_DIR/binary-size-baseline.txt"
+
+assert_exit_code "delta: leading-whitespace baseline → pass" 0 \
+    run_patched --delta-max 2MB
+
+# Missing baseline file for --delta-max → exit 2
+rm "$BASELINE_DIR/binary-size-baseline.txt"
+assert_exit_code "delta: missing baseline → exit 2" 2 \
+    run_patched --delta-max 2MB
+
+# ---- done --------------------------------------------------------------------
+
+finish

--- a/scripts/check-snapshots.sh
+++ b/scripts/check-snapshots.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# scripts/check-snapshots.sh — CI gate: spec snapshot diff check (STUB)
+#
+# Compares specs/*.json against specs/__snapshots__/<name>.snap.
+# Real snapshot-format decision deferred to session D.
+#
+# EXIT CODES
+#   0 — pass (or snapshots dir absent, or dry-run)
+#   1 — snapshots differ (gate violation)
+#   2 — script/usage error
+#
+# DRY-RUN
+#   Pass --dry-run or set CI_DRY_RUN=1.  Argument validation still runs;
+#   the actual diff is skipped and the script exits 0.
+#
+# TODO (session D): replace the `diff -r` placeholder below with real
+# snapshot-aware comparison once the snapshot format is decided.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+SPECS_DIR="$REPO_ROOT/specs"
+SNAPSHOTS_DIR="$SPECS_DIR/__snapshots__"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  check-snapshots.sh [--dry-run] [--help]
+
+Compares specs/*.json against corresponding specs/__snapshots__/<name>.snap.
+If the snapshots directory does not exist, exits 0 with a warning.
+
+Options:
+  --dry-run   Skip diff; print what would be checked; exit 0.
+  --help      Print this help and exit 0.
+
+Environment:
+  CI_DRY_RUN=1   Equivalent to --dry-run.
+EOF
+}
+
+# ---- parse args ---------------------------------------------------------------
+
+dry_run=0
+[[ "${CI_DRY_RUN:-0}" == "1" ]] && dry_run=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)  usage; exit 0 ;;
+        --dry-run)  dry_run=1; shift ;;
+        *) die "unknown flag: $1 (use --help for usage)" ;;
+    esac
+done
+
+# ---- dry-run early exit -------------------------------------------------------
+
+if [[ "$dry_run" -eq 1 ]]; then
+    log "[dry-run] would diff specs/*.json against $SNAPSHOTS_DIR"
+    exit 0
+fi
+
+# ---- guard: snapshots dir must exist ------------------------------------------
+
+if [[ ! -d "$SNAPSHOTS_DIR" ]]; then
+    printf 'warning: %s does not exist — skipping snapshot check\n' "$SNAPSHOTS_DIR" >&2
+    exit 0
+fi
+
+# ---- diff specs against snapshots --------------------------------------------
+# TODO (session D): replace this with format-aware snapshot comparison.
+# The real implementation should:
+#   1. Parse the decided snapshot format (JSON? plain-text normalised?)
+#   2. For each specs/<name>.json, load the corresponding snapshot
+#   3. Apply any normalisation (e.g. sort keys, strip volatile fields)
+#   4. Report per-file diffs with a clear summary
+#
+# For now, use a recursive diff as a placeholder so the gate runs end-to-end.
+
+fail_count=0
+checked=0
+
+for spec_file in "$SPECS_DIR"/*.json; do
+    [[ -f "$spec_file" ]] || continue
+    name="$(basename "$spec_file" .json)"
+    snap_file="$SNAPSHOTS_DIR/${name}.snap"
+
+    if [[ ! -f "$snap_file" ]]; then
+        # Snapshot missing — treat as no-diff (snapshot hasn't been recorded yet)
+        continue
+    fi
+
+    checked=$(( checked + 1 ))
+    if ! diff -q "$spec_file" "$snap_file" >/dev/null 2>&1; then
+        printf 'DIFF: %s differs from snapshot\n' "$name" >&2
+        fail_count=$(( fail_count + 1 ))
+    fi
+done
+
+if (( fail_count > 0 )); then
+    printf 'FAIL: %d spec(s) differ from their snapshots (checked %d)\n' \
+        "$fail_count" "$checked" >&2
+    exit 1
+fi
+
+log "PASS: all $checked snapshot(s) match."
+exit 0

--- a/scripts/check-snapshots.test.sh
+++ b/scripts/check-snapshots.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# scripts/check-snapshots.test.sh — tests for check-snapshots.sh
+# Self-contained; no bats dependency.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-snapshots.sh"
+
+# ---- tiny test harness -------------------------------------------------------
+
+_pass=0
+_fail=0
+
+assert_exit_code() {
+    local desc="$1" expected="$2"; shift 2
+    local actual=0
+    "$@" >/dev/null 2>&1 || actual=$?
+    if [[ "$actual" -eq "$expected" ]]; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s (exit %d)\n' "$desc" "$actual"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s — expected exit %d, got %d\n' "$desc" "$expected" "$actual"
+    fi
+}
+
+assert_stdout_contains() {
+    local desc="$1" needle="$2"; shift 2
+    local out
+    out="$("$@" 2>/dev/null || true)"
+    if printf '%s' "$out" | grep -qFe "$needle"; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s\n' "$desc"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s — stdout did not contain %q\n' "$desc" "$needle"
+        printf '      stdout was: %s\n' "$out"
+    fi
+}
+
+assert_stderr_contains() {
+    local desc="$1" needle="$2"; shift 2
+    local err
+    err="$("$@" 2>&1 >/dev/null || true)"
+    if printf '%s' "$err" | grep -qFe "$needle"; then
+        _pass=$(( _pass + 1 ))
+        printf 'PASS: %s\n' "$desc"
+    else
+        _fail=$(( _fail + 1 ))
+        printf 'FAIL: %s — stderr did not contain %q\n' "$desc" "$needle"
+        printf '      stderr was: %s\n' "$err"
+    fi
+}
+
+finish() {
+    printf '\n%d passed, %d failed\n' "$_pass" "$_fail"
+    [[ "$_fail" -eq 0 ]]
+}
+
+# ---- scratch setup -----------------------------------------------------------
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Build a patched copy of the script pointing at our scratch tree.
+# The script uses REPO_ROOT derived from SCRIPT_DIR; patch that derivation.
+PATCHED="$SCRATCH/check-snapshots-patched.sh"
+sed \
+    -e "s|REPO_ROOT=\"\$(cd \"\$SCRIPT_DIR/..\" && pwd)\"|REPO_ROOT=\"$SCRATCH\"|" \
+    "$SCRIPT" > "$PATCHED"
+sed -i.bak "s|source \"\$SCRIPT_DIR/lib/common.sh\"|source \"$SCRIPT_DIR/lib/common.sh\"|" "$PATCHED"
+chmod +x "$PATCHED"
+
+run_patched() { bash "$PATCHED" "$@"; }
+
+# ---- tests -------------------------------------------------------------------
+
+assert_exit_code "--help exits 0"  0  bash "$SCRIPT" --help
+assert_stdout_contains "--help prints usage" "Usage:" bash "$SCRIPT" --help
+
+assert_exit_code "unknown flag → exit 2" 2  bash "$SCRIPT" --bogus
+
+# Missing __snapshots__ dir → exit 0 with warning
+mkdir -p "$SCRATCH/specs"
+# (no __snapshots__ dir)
+assert_exit_code "missing snapshots dir → exit 0" 0 run_patched
+assert_stderr_contains "missing snapshots dir → stderr warning" "warning" run_patched
+
+# --dry-run → exit 0 (even with specs present)
+mkdir -p "$SCRATCH/specs/__snapshots__"
+printf '{}' > "$SCRATCH/specs/foo.json"
+printf '{}' > "$SCRATCH/specs/__snapshots__/foo.snap"
+assert_exit_code "--dry-run exits 0" 0 run_patched --dry-run
+assert_exit_code "CI_DRY_RUN=1 exits 0" 0 env CI_DRY_RUN=1 bash "$PATCHED"
+
+# ---- done --------------------------------------------------------------------
+
+finish

--- a/scripts/check-snapshots.test.sh
+++ b/scripts/check-snapshots.test.sh
@@ -93,6 +93,18 @@ printf '{}' > "$SCRATCH/specs/__snapshots__/foo.snap"
 assert_exit_code "--dry-run exits 0" 0 run_patched --dry-run
 assert_exit_code "CI_DRY_RUN=1 exits 0" 0 env CI_DRY_RUN=1 bash "$PATCHED"
 
+# Matching snapshots → exit 0
+# foo.json and foo.snap are already identical (both '{}' written above)
+assert_exit_code "matching snapshots → exit 0" 0 run_patched
+
+# Differing snapshots → exit 1
+# Mutate foo.json so it no longer matches the snapshot
+printf '{"changed":true}' > "$SCRATCH/specs/foo.json"
+assert_exit_code "differing snapshots → exit 1" 1 run_patched
+
+# Restore for any future tests
+printf '{}' > "$SCRATCH/specs/foo.json"
+
 # ---- done --------------------------------------------------------------------
 
 finish

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# scripts/lib/common.sh — shared helpers for CI gate scripts
+# Sourced by check-*.sh; not executed directly.
+
+# log <msg>  — print an info line to stdout
+log() { printf '%s\n' "$*"; }
+
+# die <msg>  — print error to stderr and exit 2 (usage/script error)
+die() { printf 'error: %s\n' "$*" >&2; exit 2; }
+
+# parse_size <string> → prints integer byte count, exits 2 on bad input.
+# Accepted suffixes (case-insensitive):
+#   (none) = bytes
+#   K / KB / KiB  = 1024
+#   M / MB / MiB  = 1024^2   (MB and MiB are treated identically — no SI/IEC distinction)
+#   G / GB / GiB  = 1024^3
+parse_size() {
+    local raw="${1:?parse_size requires an argument}"
+    # Extract numeric part and suffix
+    local num suffix
+    if [[ "$raw" =~ ^([0-9]+)([a-zA-Z]*)$ ]]; then
+        num="${BASH_REMATCH[1]}"
+        suffix="${BASH_REMATCH[2]}"
+    else
+        printf 'error: invalid size value: %s\n' "$raw" >&2
+        exit 2
+    fi
+
+    # Normalise suffix to upper-case
+    local upper_suffix
+    upper_suffix="$(printf '%s' "$suffix" | tr '[:lower:]' '[:upper:]')"
+
+    local multiplier
+    case "$upper_suffix" in
+        ""|B)          multiplier=1 ;;
+        K|KB|KIB)      multiplier=1024 ;;
+        M|MB|MIB)      multiplier=$((1024 * 1024)) ;;
+        G|GB|GIB)      multiplier=$((1024 * 1024 * 1024)) ;;
+        *)
+            printf 'error: unrecognised size unit: %s (in %s)\n' "$suffix" "$raw" >&2
+            exit 2
+            ;;
+    esac
+
+    printf '%d' $(( num * multiplier ))
+}
+
+# bytes_to_mb <bytes> → prints human-readable "X.XX MB"
+bytes_to_mb() {
+    local bytes="${1:?}"
+    # Use awk for floating-point division
+    awk -v b="$bytes" 'BEGIN { printf "%.2f MB", b / (1024*1024) }'
+}

--- a/tools/fig-converter/package.json
+++ b/tools/fig-converter/package.json
@@ -7,7 +7,8 @@
   "main": "src/index.js",
   "scripts": {
     "convert": "node src/index.js",
-    "test": "node --test src/*.test.js"
+    "test": "node --test src/*.test.js",
+    "oracle:changed": "echo 'oracle not yet implemented — Phase 0 content lands later' && exit 0"
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",


### PR DESCRIPTION
## Summary

Installs the four CI gates called for by plan §0.5 of `docs/plans/2026-04-21-requires-js-specs.md`: binary-size, snapshot-diff, oracle, and bench-regression. Each is added as a sibling job in `.github/workflows/ci.yml` with explicit `needs:` dependencies for intra-run ordering. Merge blocking requires branch protection, documented in [`docs/ci-gates.md`](../blob/feature/phase-0.5-ci-gates/docs/ci-gates.md).

## What's live vs. stub

| Gate | Job name | Status |
|------|----------|--------|
| `binary-size-gate` | `Binary size gate` | **Live (delta).** Absolute-ceiling (30 MB) intentionally fails red until requires-js-specs work shrinks the binary below 30 MB. Delta budget (+2 MB `PHASE_BUDGET`) actively enforced against baseline. |
| `snapshot-diff-gate` | `Snapshot diff gate` | **Stub.** Exits 0 with warning until `specs/__snapshots__/` lands (Phase 0, session D). |
| `oracle-gate` | `Oracle gate (fig-converter)` | **Stub.** `npm run oracle:changed` echoes "not yet implemented" until Phase 0 lands real oracle (session A). Guarded by PR event + `tools/fig-converter/**` path filter via `dorny/paths-filter@v3`. |
| `bench-regression` | `Bench regression gate` | **Stub.** Exits 0 with warning until `benchmarks/baseline-pre-js-port.md` lands (Phase 0.4). |

## Binary size baseline

`benchmarks/binary-size-baseline.txt`: **49,385,984 bytes (47.10 MB)** — matches plan §-1's ~47 MB acknowledgement. Delta is measured from here forward.

## Files changed

- `.github/workflows/ci.yml` — 4 new sibling jobs (existing 6 untouched)
- `scripts/check-binary-size.sh` — full implementation (absolute + delta modes, baseline parsing, dry-run)
- `scripts/check-snapshots.sh`, `scripts/check-bench.sh` — stubs with graceful-no-baseline behavior
- `scripts/lib/common.sh` — shared log/die/parse_size helpers
- `scripts/check-*.test.sh` — 47 bash tests (self-contained harness, `mktemp -d` hermetic)
- `docs/ci-gates.md` — purpose, failure modes, debug steps, **branch-protection admin instructions**
- `tools/fig-converter/package.json` — `oracle:changed` stub npm script
- `benchmarks/binary-size-baseline.txt` — starting baseline

## Admin action required (human-only — not automated)

To make these gates block merges, a repo admin must add the following status checks under branch-protection rules for `master`:

- `Snapshot diff gate`
- `Oracle gate (fig-converter)`
- `Bench regression gate`
- `Binary size gate` — **hold this one** until the binary fits under 30 MB, otherwise every PR is blocked.

Full steps in [`docs/ci-gates.md`](../blob/feature/phase-0.5-ci-gates/docs/ci-gates.md#branch-protection-configuration).

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `bash scripts/check-*.test.sh` — 47/47 pass (26 + 9 + 12)
- [x] `cd tools/fig-converter && npm test` — 89/89 pass
- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` — all clean (no Rust touched)
- [x] `npm run oracle:changed` — exits 0 with "not yet implemented" message
- [x] `scripts/check-binary-size.sh --delta-max 2MB` against recorded baseline — PASS (0 delta)
- [x] `scripts/check-binary-size.sh --absolute-max 30MB` — FAIL (47.10 MB > 30 MB) as designed
- [ ] Validate CI run once pushed — the actual GitHub Actions execution