### PR TITLE
Phase 2 recount: callback-body fingerprinting + authKeywords fix

### DIFF
--- a/tools/fig-converter/docs/candidate-providers.json
+++ b/tools/fig-converter/docs/candidate-providers.json
@@ -2,69 +2,6 @@
   "schema_version": "1.0",
   "candidates": [
     {
-      "command": "flyctl",
-      "total_requires_js_generators": 92,
-      "fig_api_ref_generators": 0,
-      "script_commands_observed": [
-        "fly orgs list --json",
-        "flyctl apps list --json"
-      ],
-      "qualification": {
-        "single_subprocess_no_pipeline": true,
-        "no_auth": true,
-        "no_pagination": true,
-        "stable_line_output": true,
-        "no_file_system_parsing": true,
-        "output_bounded": true,
-        "no_rate_limits": true,
-        "no_new_transitive_deps": true
-      },
-      "qualifies": true,
-      "rationale": "Command 'flyctl' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
-    },
-    {
-      "command": "tsh",
-      "total_requires_js_generators": 85,
-      "fig_api_ref_generators": 0,
-      "script_commands_observed": [
-        "tsh ls --format=json",
-        "tsh clusters --format=json",
-        "tsh status --format json"
-      ],
-      "qualification": {
-        "single_subprocess_no_pipeline": true,
-        "no_auth": true,
-        "no_pagination": true,
-        "stable_line_output": true,
-        "no_file_system_parsing": true,
-        "output_bounded": true,
-        "no_rate_limits": true,
-        "no_new_transitive_deps": true
-      },
-      "qualifies": true,
-      "rationale": "Command 'tsh' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
-    },
-    {
-      "command": "pulumi",
-      "total_requires_js_generators": 20,
-      "fig_api_ref_generators": 0,
-      "script_commands_observed": [
-        "pulumi stack ls --json"
-      ],
-      "qualification": {
-        "single_subprocess_no_pipeline": true,
-        "no_auth": true,
-        "no_pagination": true,
-        "stable_line_output": true,
-        "no_file_system_parsing": true,
-        "output_bounded": true,
-        "no_rate_limits": true,
-        "no_new_transitive_deps": true
-      },
-      "qualifies": true,
-      "rationale": "Command 'pulumi' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
-    },
-    {
       "command": "arduino-cli",
       "total_requires_js_generators": 19,
       "fig_api_ref_generators": 0,
@@ -265,26 +202,6 @@
       "rationale": "Command 'youtube-dl' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
     },
     {
-      "command": "amplify",
-      "total_requires_js_generators": 4,
-      "fig_api_ref_generators": 0,
-      "script_commands_observed": [
-        "amplify env list --json"
-      ],
-      "qualification": {
-        "single_subprocess_no_pipeline": true,
-        "no_auth": true,
-        "no_pagination": true,
-        "stable_line_output": true,
-        "no_file_system_parsing": true,
-        "output_bounded": true,
-        "no_rate_limits": true,
-        "no_new_transitive_deps": true
-      },
-      "qualifies": true,
-      "rationale": "Command 'amplify' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
-    },
-    {
       "command": "pandoc",
       "total_requires_js_generators": 4,
       "fig_api_ref_generators": 2,
@@ -345,26 +262,6 @@
       },
       "qualifies": true,
       "rationale": "Command 'watson' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
-    },
-    {
-      "command": "deployctl",
-      "total_requires_js_generators": 2,
-      "fig_api_ref_generators": 1,
-      "script_commands_observed": [
-        "curl -sL https://cdn.deno.land/deploy/meta/versions.json"
-      ],
-      "qualification": {
-        "single_subprocess_no_pipeline": true,
-        "no_auth": true,
-        "no_pagination": true,
-        "stable_line_output": true,
-        "no_file_system_parsing": true,
-        "output_bounded": true,
-        "no_rate_limits": true,
-        "no_new_transitive_deps": true
-      },
-      "qualifies": true,
-      "rationale": "Command 'deployctl' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
     },
     {
       "command": "envchain",
@@ -428,27 +325,6 @@
       "rationale": "Command 'ng' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
     },
     {
-      "command": "stepzen",
-      "total_requires_js_generators": 2,
-      "fig_api_ref_generators": 0,
-      "script_commands_observed": [
-        "stepzen list schemas",
-        "curl https://api.github.com/repos/steprz/stepzen-schemas/contents"
-      ],
-      "qualification": {
-        "single_subprocess_no_pipeline": true,
-        "no_auth": true,
-        "no_pagination": true,
-        "stable_line_output": true,
-        "no_file_system_parsing": true,
-        "output_bounded": true,
-        "no_rate_limits": true,
-        "no_new_transitive_deps": true
-      },
-      "qualifies": true,
-      "rationale": "Command 'stepzen' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
-    },
-    {
       "command": "ansible-doc",
       "total_requires_js_generators": 1,
       "fig_api_ref_generators": 0,
@@ -487,26 +363,6 @@
       },
       "qualifies": true,
       "rationale": "Command 'assimp' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
-    },
-    {
-      "command": "bosh",
-      "total_requires_js_generators": 1,
-      "fig_api_ref_generators": 0,
-      "script_commands_observed": [
-        "bosh --json deployments"
-      ],
-      "qualification": {
-        "single_subprocess_no_pipeline": true,
-        "no_auth": true,
-        "no_pagination": true,
-        "stable_line_output": true,
-        "no_file_system_parsing": true,
-        "output_bounded": true,
-        "no_rate_limits": true,
-        "no_new_transitive_deps": true
-      },
-      "qualifies": true,
-      "rationale": "Command 'bosh' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
     },
     {
       "command": "elm",
@@ -563,26 +419,6 @@
       },
       "qualifies": true,
       "rationale": "Command 'eslint' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
-    },
-    {
-      "command": "firebase",
-      "total_requires_js_generators": 1,
-      "fig_api_ref_generators": 0,
-      "script_commands_observed": [
-        "firebase projects:list"
-      ],
-      "qualification": {
-        "single_subprocess_no_pipeline": true,
-        "no_auth": true,
-        "no_pagination": true,
-        "stable_line_output": true,
-        "no_file_system_parsing": true,
-        "output_bounded": true,
-        "no_rate_limits": true,
-        "no_new_transitive_deps": true
-      },
-      "qualifies": true,
-      "rationale": "Command 'firebase' meets all 8 criteria — subprocess-based, no auth, no pagination, stable line output."
     },
     {
       "command": "git-profile",
@@ -756,7 +592,7 @@
       ],
       "qualification": {
         "single_subprocess_no_pipeline": true,
-        "no_auth": true,
+        "no_auth": false,
         "no_pagination": true,
         "stable_line_output": true,
         "no_file_system_parsing": true,
@@ -765,7 +601,50 @@
         "no_new_transitive_deps": true
       },
       "qualifies": false,
-      "rationale": "Disqualified: no rate limits."
+      "rationale": "Disqualified: no auth, no rate limits."
+    },
+    {
+      "command": "flyctl",
+      "total_requires_js_generators": 92,
+      "fig_api_ref_generators": 0,
+      "script_commands_observed": [
+        "fly orgs list --json",
+        "flyctl apps list --json"
+      ],
+      "qualification": {
+        "single_subprocess_no_pipeline": true,
+        "no_auth": false,
+        "no_pagination": true,
+        "stable_line_output": true,
+        "no_file_system_parsing": true,
+        "output_bounded": true,
+        "no_rate_limits": false,
+        "no_new_transitive_deps": true
+      },
+      "qualifies": false,
+      "rationale": "Disqualified: no auth, no rate limits."
+    },
+    {
+      "command": "tsh",
+      "total_requires_js_generators": 85,
+      "fig_api_ref_generators": 0,
+      "script_commands_observed": [
+        "tsh ls --format=json",
+        "tsh clusters --format=json",
+        "tsh status --format json"
+      ],
+      "qualification": {
+        "single_subprocess_no_pipeline": true,
+        "no_auth": false,
+        "no_pagination": true,
+        "stable_line_output": true,
+        "no_file_system_parsing": true,
+        "output_bounded": true,
+        "no_rate_limits": false,
+        "no_new_transitive_deps": true
+      },
+      "qualifies": false,
+      "rationale": "Disqualified: no auth, no rate limits."
     },
     {
       "command": "chezmoi",
@@ -1192,6 +1071,26 @@
       },
       "qualifies": false,
       "rationale": "Disqualified: single subprocess no pipeline, no file system parsing."
+    },
+    {
+      "command": "pulumi",
+      "total_requires_js_generators": 20,
+      "fig_api_ref_generators": 0,
+      "script_commands_observed": [
+        "pulumi stack ls --json"
+      ],
+      "qualification": {
+        "single_subprocess_no_pipeline": true,
+        "no_auth": false,
+        "no_pagination": true,
+        "stable_line_output": true,
+        "no_file_system_parsing": true,
+        "output_bounded": true,
+        "no_rate_limits": false,
+        "no_new_transitive_deps": true
+      },
+      "qualifies": false,
+      "rationale": "Disqualified: no auth, no rate limits."
     },
     {
       "command": "dscl",
@@ -1782,6 +1681,26 @@
       "rationale": "Disqualified: stable line output."
     },
     {
+      "command": "amplify",
+      "total_requires_js_generators": 4,
+      "fig_api_ref_generators": 0,
+      "script_commands_observed": [
+        "amplify env list --json"
+      ],
+      "qualification": {
+        "single_subprocess_no_pipeline": true,
+        "no_auth": false,
+        "no_pagination": true,
+        "stable_line_output": true,
+        "no_file_system_parsing": true,
+        "output_bounded": true,
+        "no_rate_limits": false,
+        "no_new_transitive_deps": true
+      },
+      "qualifies": false,
+      "rationale": "Disqualified: no auth, no rate limits."
+    },
+    {
       "command": "make",
       "total_requires_js_generators": 4,
       "fig_api_ref_generators": 0,
@@ -2185,6 +2104,26 @@
       "rationale": "Disqualified: no auth, stable line output."
     },
     {
+      "command": "deployctl",
+      "total_requires_js_generators": 2,
+      "fig_api_ref_generators": 1,
+      "script_commands_observed": [
+        "curl -sL https://cdn.deno.land/deploy/meta/versions.json"
+      ],
+      "qualification": {
+        "single_subprocess_no_pipeline": true,
+        "no_auth": false,
+        "no_pagination": true,
+        "stable_line_output": true,
+        "no_file_system_parsing": true,
+        "output_bounded": true,
+        "no_rate_limits": false,
+        "no_new_transitive_deps": true
+      },
+      "qualifies": false,
+      "rationale": "Disqualified: no auth, no rate limits."
+    },
+    {
       "command": "dscacheutil",
       "total_requires_js_generators": 2,
       "fig_api_ref_generators": 2,
@@ -2497,6 +2436,27 @@
       "rationale": "Disqualified: stable line output."
     },
     {
+      "command": "stepzen",
+      "total_requires_js_generators": 2,
+      "fig_api_ref_generators": 0,
+      "script_commands_observed": [
+        "stepzen list schemas",
+        "curl https://api.github.com/repos/steprz/stepzen-schemas/contents"
+      ],
+      "qualification": {
+        "single_subprocess_no_pipeline": true,
+        "no_auth": false,
+        "no_pagination": true,
+        "stable_line_output": true,
+        "no_file_system_parsing": true,
+        "output_bounded": true,
+        "no_rate_limits": false,
+        "no_new_transitive_deps": true
+      },
+      "qualifies": false,
+      "rationale": "Disqualified: no auth, no rate limits."
+    },
+    {
       "command": "tailscale",
       "total_requires_js_generators": 2,
       "fig_api_ref_generators": 2,
@@ -2605,6 +2565,26 @@
       },
       "qualifies": false,
       "rationale": "Disqualified: stable line output."
+    },
+    {
+      "command": "bosh",
+      "total_requires_js_generators": 1,
+      "fig_api_ref_generators": 0,
+      "script_commands_observed": [
+        "bosh --json deployments"
+      ],
+      "qualification": {
+        "single_subprocess_no_pipeline": true,
+        "no_auth": false,
+        "no_pagination": true,
+        "stable_line_output": true,
+        "no_file_system_parsing": true,
+        "output_bounded": true,
+        "no_rate_limits": false,
+        "no_new_transitive_deps": true
+      },
+      "qualifies": false,
+      "rationale": "Disqualified: no auth, no rate limits."
     },
     {
       "command": "brew",
@@ -2785,6 +2765,26 @@
       },
       "qualifies": false,
       "rationale": "Disqualified: stable line output."
+    },
+    {
+      "command": "firebase",
+      "total_requires_js_generators": 1,
+      "fig_api_ref_generators": 0,
+      "script_commands_observed": [
+        "firebase projects:list"
+      ],
+      "qualification": {
+        "single_subprocess_no_pipeline": true,
+        "no_auth": false,
+        "no_pagination": true,
+        "stable_line_output": true,
+        "no_file_system_parsing": true,
+        "output_bounded": true,
+        "no_rate_limits": false,
+        "no_new_transitive_deps": true
+      },
+      "qualifies": false,
+      "rationale": "Disqualified: no auth, no rate limits."
     },
     {
       "command": "firefox",

--- a/tools/fig-converter/docs/shape-inventory.json
+++ b/tools/fig-converter/docs/shape-inventory.json
@@ -4,7 +4,7 @@
   "shapes": [
     {
       "shape_id": "parse-map",
-      "fingerprint": "JSON.parse(...).map(FN)",
+      "fingerprint": "JSON.parse(...).map(<OBJ>)",
       "count": 174,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -350,7 +350,7 @@
     },
     {
       "shape_id": "startswith-split-map-with-fig-refs",
-      "fingerprint": "(.startsWith(STR) ? ARR : .split(STR).map(FN))",
+      "fingerprint": "(.startsWith(STR) ? ARR : .split(STR).map(<OBJ>))",
       "count": 68,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -502,8 +502,8 @@
       ]
     },
     {
-      "shape_id": "split-map",
-      "fingerprint": ".split(STR).map(FN).map(FN)",
+      "shape_id": "split-map-parse",
+      "fingerprint": ".split(STR).map(<JSON.parse(...)>).map(<OBJ>)",
       "count": 63,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -643,8 +643,8 @@
       ]
     },
     {
-      "shape_id": "ue-fn-with-fig-refs",
-      "fingerprint": "ue(...,...,...,FN)",
+      "shape_id": "ue-with-fig-refs",
+      "fingerprint": "ue(...,...,...,<>)",
       "count": 51,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -764,68 +764,8 @@
       ]
     },
     {
-      "shape_id": "parse-map-2",
-      "fingerprint": "JSON.parse(...).map(FN)",
-      "count": 50,
-      "verdict": "existing_transforms",
-      "has_fig_api_refs": false,
-      "example_spec": "elm-json.json",
-      "generator_ids": [
-        "elm-json:/subcommands[1]/args[0]/generators[0]",
-        "elm-json:/subcommands[3]/args[0]/generators[0]",
-        "elm-json:/subcommands[4]/args[0]/generators[0]",
-        "elm:/subcommands[3]/args/generators[0]",
-        "nativescript:/subcommands[9]/options[0]/args/generators[0]",
-        "ns:/subcommands[9]/options[0]/args/generators[0]",
-        "tns:/subcommands[9]/options[0]/args/generators[0]",
-        "tsh:/options[1]/args/generators[0]",
-        "tsh:/subcommands[10]/options[1]/args/generators[0]",
-        "tsh:/subcommands[11]/options[1]/args/generators[0]",
-        "tsh:/subcommands[12]/options[1]/args/generators[0]",
-        "tsh:/subcommands[13]/options[1]/args/generators[0]",
-        "tsh:/subcommands[14]/options[1]/args/generators[0]",
-        "tsh:/subcommands[15]/options[1]/args/generators[0]",
-        "tsh:/subcommands[15]/subcommands[0]/options[1]/args/generators[0]",
-        "tsh:/subcommands[15]/subcommands[1]/options[1]/args/generators[0]",
-        "tsh:/subcommands[15]/subcommands[2]/options[1]/args/generators[0]",
-        "tsh:/subcommands[15]/subcommands[3]/options[1]/args/generators[0]",
-        "tsh:/subcommands[16]/options[1]/args/generators[0]",
-        "tsh:/subcommands[16]/subcommands[0]/options[1]/args/generators[0]",
-        "tsh:/subcommands[16]/subcommands[1]/options[1]/args/generators[0]",
-        "tsh:/subcommands[16]/subcommands[2]/options[1]/args/generators[0]",
-        "tsh:/subcommands[16]/subcommands[3]/options[1]/args/generators[0]",
-        "tsh:/subcommands[16]/subcommands[4]/options[1]/args/generators[0]",
-        "tsh:/subcommands[17]/options[1]/args/generators[0]",
-        "tsh:/subcommands[17]/subcommands[0]/options[1]/args/generators[0]",
-        "tsh:/subcommands[17]/subcommands[1]/options[1]/args/generators[0]",
-        "tsh:/subcommands[17]/subcommands[2]/options[1]/args/generators[0]",
-        "tsh:/subcommands[18]/options[1]/args/generators[0]",
-        "tsh:/subcommands[1]/args/generators[0]",
-        "tsh:/subcommands[2]/options[1]/args/generators[0]",
-        "tsh:/subcommands[3]/options[1]/args/generators[0]",
-        "tsh:/subcommands[3]/subcommands[0]/options[1]/args/generators[0]",
-        "tsh:/subcommands[3]/subcommands[1]/options[1]/args/generators[0]",
-        "tsh:/subcommands[3]/subcommands[2]/options[1]/args/generators[0]",
-        "tsh:/subcommands[3]/subcommands[3]/options[1]/args/generators[0]",
-        "tsh:/subcommands[4]/options[1]/args/generators[0]",
-        "tsh:/subcommands[4]/subcommands[0]/options[1]/args/generators[0]",
-        "tsh:/subcommands[4]/subcommands[1]/options[1]/args/generators[0]",
-        "tsh:/subcommands[5]/options[1]/args/generators[0]",
-        "tsh:/subcommands[5]/subcommands[0]/options[1]/args/generators[0]",
-        "tsh:/subcommands[5]/subcommands[1]/options[1]/args/generators[0]",
-        "tsh:/subcommands[5]/subcommands[2]/options[1]/args/generators[0]",
-        "tsh:/subcommands[5]/subcommands[3]/options[1]/args/generators[0]",
-        "tsh:/subcommands[5]/subcommands[4]/options[1]/args/generators[0]",
-        "tsh:/subcommands[5]/subcommands[5]/options[1]/args/generators[0]",
-        "tsh:/subcommands[6]/options[1]/args/generators[0]",
-        "tsh:/subcommands[7]/options[1]/args/generators[0]",
-        "tsh:/subcommands[8]/options[1]/args/generators[0]",
-        "tsh:/subcommands[9]/options[1]/args/generators[0]"
-      ]
-    },
-    {
-      "shape_id": "match-map",
-      "fingerprint": ".match(REGEX).map(FN).map(FN).map(FN)",
+      "shape_id": "match-map-split-trim",
+      "fingerprint": ".match(REGEX).map(<.split(STR)>).map(<.map(<.trim()>)>).map(<OBJ>)",
       "count": 50,
       "verdict": "needs_new_transform_regex_match",
       "has_fig_api_refs": false,
@@ -885,7 +825,7 @@
     },
     {
       "shape_id": "map-with-fig-refs",
-      "fingerprint": "o(...).map(FN)",
+      "fingerprint": "o(...).map(<OBJ>)",
       "count": 45,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -993,59 +933,6 @@
       ]
     },
     {
-      "shape_id": "a-fn-with-fig-refs",
-      "fingerprint": "A(...,...,...,FN)",
-      "count": 43,
-      "verdict": "hand_audit_required",
-      "has_fig_api_refs": true,
-      "example_spec": "cargo.json",
-      "generator_ids": [
-        "cargo:/options[2]/args/generators[0]",
-        "cargo:/subcommands[0]/options[14]/args/generators[0]",
-        "cargo:/subcommands[10]/options[5]/args/generators[0]",
-        "cargo:/subcommands[11]/options[18]/args/generators[0]",
-        "cargo:/subcommands[12]/options[3]/args/generators[0]",
-        "cargo:/subcommands[13]/options[2]/args/generators[0]",
-        "cargo:/subcommands[14]/options[2]/args/generators[0]",
-        "cargo:/subcommands[15]/options[5]/args/generators[0]",
-        "cargo:/subcommands[16]/options[5]/args/generators[0]",
-        "cargo:/subcommands[17]/options[6]/args/generators[0]",
-        "cargo:/subcommands[18]/options[8]/args/generators[0]",
-        "cargo:/subcommands[19]/options[3]/args/generators[0]",
-        "cargo:/subcommands[1]/options[15]/args/generators[0]",
-        "cargo:/subcommands[20]/options[10]/args/generators[0]",
-        "cargo:/subcommands[21]/options[2]/args/generators[0]",
-        "cargo:/subcommands[22]/options[1]/args/generators[0]",
-        "cargo:/subcommands[22]/subcommands[0]/options[3]/args/generators[0]",
-        "cargo:/subcommands[22]/subcommands[1]/options[1]/args/generators[0]",
-        "cargo:/subcommands[23]/options[11]/args/generators[0]",
-        "cargo:/subcommands[24]/options[15]/args/generators[0]",
-        "cargo:/subcommands[25]/options[13]/args/generators[0]",
-        "cargo:/subcommands[26]/options[4]/args/generators[0]",
-        "cargo:/subcommands[27]/options[14]/args/generators[0]",
-        "cargo:/subcommands[28]/options[13]/args/generators[0]",
-        "cargo:/subcommands[29]/options[4]/args/generators[0]",
-        "cargo:/subcommands[2]/options[14]/args/generators[0]",
-        "cargo:/subcommands[30]/options[4]/args/generators[0]",
-        "cargo:/subcommands[31]/options[3]/args/generators[0]",
-        "cargo:/subcommands[32]/options[2]/args/generators[0]",
-        "cargo:/subcommands[33]/options[1]/args/generators[0]",
-        "cargo:/subcommands[34]/options[5]/args/generators[0]",
-        "cargo:/subcommands[35]/options[1]/args/generators[0]",
-        "cargo:/subcommands[3]/options[6]/args/generators[0]",
-        "cargo:/subcommands[4]/options[1]/args/generators[0]",
-        "cargo:/subcommands[4]/subcommands[0]/options[3]/args/generators[0]",
-        "cargo:/subcommands[4]/subcommands[1]/options[1]/args/generators[0]",
-        "cargo:/subcommands[5]/options[12]/args/generators[0]",
-        "cargo:/subcommands[6]/options[3]/args/generators[0]",
-        "cargo:/subcommands[7]/options[14]/args/generators[0]",
-        "cargo:/subcommands[8]/options[2]/args/generators[0]",
-        "cargo:/subcommands[9]/options[1]/args/generators[0]",
-        "gh:/subcommands[17]/subcommands[8]/subcommands[0]/args/generators[0]",
-        "gh:/subcommands[17]/subcommands[8]/subcommands[1]/args/generators[0]"
-      ]
-    },
-    {
       "shape_id": "typewithoutname-with-fig-refs",
       "fingerprint": ".typeWithoutName(...)",
       "count": 42,
@@ -1095,6 +982,109 @@
         "kubectl:/subcommands[4]/subcommands[2]/args[1]/generators[0]",
         "kubectl:/subcommands[6]/subcommands[0]/args[2]/generators[0]",
         "kubectl:/subcommands[7]/args[1]/generators[0]"
+      ]
+    },
+    {
+      "shape_id": "parse-map-2",
+      "fingerprint": "JSON.parse(...).map(<.PROP>)",
+      "count": 42,
+      "verdict": "existing_transforms",
+      "has_fig_api_refs": false,
+      "example_spec": "tsh.json",
+      "generator_ids": [
+        "tsh:/options[1]/args/generators[0]",
+        "tsh:/subcommands[10]/options[1]/args/generators[0]",
+        "tsh:/subcommands[11]/options[1]/args/generators[0]",
+        "tsh:/subcommands[12]/options[1]/args/generators[0]",
+        "tsh:/subcommands[13]/options[1]/args/generators[0]",
+        "tsh:/subcommands[14]/options[1]/args/generators[0]",
+        "tsh:/subcommands[15]/options[1]/args/generators[0]",
+        "tsh:/subcommands[15]/subcommands[0]/options[1]/args/generators[0]",
+        "tsh:/subcommands[15]/subcommands[1]/options[1]/args/generators[0]",
+        "tsh:/subcommands[15]/subcommands[2]/options[1]/args/generators[0]",
+        "tsh:/subcommands[15]/subcommands[3]/options[1]/args/generators[0]",
+        "tsh:/subcommands[16]/options[1]/args/generators[0]",
+        "tsh:/subcommands[16]/subcommands[0]/options[1]/args/generators[0]",
+        "tsh:/subcommands[16]/subcommands[1]/options[1]/args/generators[0]",
+        "tsh:/subcommands[16]/subcommands[2]/options[1]/args/generators[0]",
+        "tsh:/subcommands[16]/subcommands[3]/options[1]/args/generators[0]",
+        "tsh:/subcommands[16]/subcommands[4]/options[1]/args/generators[0]",
+        "tsh:/subcommands[17]/options[1]/args/generators[0]",
+        "tsh:/subcommands[17]/subcommands[0]/options[1]/args/generators[0]",
+        "tsh:/subcommands[17]/subcommands[1]/options[1]/args/generators[0]",
+        "tsh:/subcommands[17]/subcommands[2]/options[1]/args/generators[0]",
+        "tsh:/subcommands[18]/options[1]/args/generators[0]",
+        "tsh:/subcommands[2]/options[1]/args/generators[0]",
+        "tsh:/subcommands[3]/options[1]/args/generators[0]",
+        "tsh:/subcommands[3]/subcommands[0]/options[1]/args/generators[0]",
+        "tsh:/subcommands[3]/subcommands[1]/options[1]/args/generators[0]",
+        "tsh:/subcommands[3]/subcommands[2]/options[1]/args/generators[0]",
+        "tsh:/subcommands[3]/subcommands[3]/options[1]/args/generators[0]",
+        "tsh:/subcommands[4]/options[1]/args/generators[0]",
+        "tsh:/subcommands[4]/subcommands[0]/options[1]/args/generators[0]",
+        "tsh:/subcommands[4]/subcommands[1]/options[1]/args/generators[0]",
+        "tsh:/subcommands[5]/options[1]/args/generators[0]",
+        "tsh:/subcommands[5]/subcommands[0]/options[1]/args/generators[0]",
+        "tsh:/subcommands[5]/subcommands[1]/options[1]/args/generators[0]",
+        "tsh:/subcommands[5]/subcommands[2]/options[1]/args/generators[0]",
+        "tsh:/subcommands[5]/subcommands[3]/options[1]/args/generators[0]",
+        "tsh:/subcommands[5]/subcommands[4]/options[1]/args/generators[0]",
+        "tsh:/subcommands[5]/subcommands[5]/options[1]/args/generators[0]",
+        "tsh:/subcommands[6]/options[1]/args/generators[0]",
+        "tsh:/subcommands[7]/options[1]/args/generators[0]",
+        "tsh:/subcommands[8]/options[1]/args/generators[0]",
+        "tsh:/subcommands[9]/options[1]/args/generators[0]"
+      ]
+    },
+    {
+      "shape_id": "a-m-with-fig-refs",
+      "fingerprint": "A(...,...,...,<M(...,...,...,...)>)",
+      "count": 41,
+      "verdict": "hand_audit_required",
+      "has_fig_api_refs": true,
+      "example_spec": "cargo.json",
+      "generator_ids": [
+        "cargo:/options[2]/args/generators[0]",
+        "cargo:/subcommands[0]/options[14]/args/generators[0]",
+        "cargo:/subcommands[10]/options[5]/args/generators[0]",
+        "cargo:/subcommands[11]/options[18]/args/generators[0]",
+        "cargo:/subcommands[12]/options[3]/args/generators[0]",
+        "cargo:/subcommands[13]/options[2]/args/generators[0]",
+        "cargo:/subcommands[14]/options[2]/args/generators[0]",
+        "cargo:/subcommands[15]/options[5]/args/generators[0]",
+        "cargo:/subcommands[16]/options[5]/args/generators[0]",
+        "cargo:/subcommands[17]/options[6]/args/generators[0]",
+        "cargo:/subcommands[18]/options[8]/args/generators[0]",
+        "cargo:/subcommands[19]/options[3]/args/generators[0]",
+        "cargo:/subcommands[1]/options[15]/args/generators[0]",
+        "cargo:/subcommands[20]/options[10]/args/generators[0]",
+        "cargo:/subcommands[21]/options[2]/args/generators[0]",
+        "cargo:/subcommands[22]/options[1]/args/generators[0]",
+        "cargo:/subcommands[22]/subcommands[0]/options[3]/args/generators[0]",
+        "cargo:/subcommands[22]/subcommands[1]/options[1]/args/generators[0]",
+        "cargo:/subcommands[23]/options[11]/args/generators[0]",
+        "cargo:/subcommands[24]/options[15]/args/generators[0]",
+        "cargo:/subcommands[25]/options[13]/args/generators[0]",
+        "cargo:/subcommands[26]/options[4]/args/generators[0]",
+        "cargo:/subcommands[27]/options[14]/args/generators[0]",
+        "cargo:/subcommands[28]/options[13]/args/generators[0]",
+        "cargo:/subcommands[29]/options[4]/args/generators[0]",
+        "cargo:/subcommands[2]/options[14]/args/generators[0]",
+        "cargo:/subcommands[30]/options[4]/args/generators[0]",
+        "cargo:/subcommands[31]/options[3]/args/generators[0]",
+        "cargo:/subcommands[32]/options[2]/args/generators[0]",
+        "cargo:/subcommands[33]/options[1]/args/generators[0]",
+        "cargo:/subcommands[34]/options[5]/args/generators[0]",
+        "cargo:/subcommands[35]/options[1]/args/generators[0]",
+        "cargo:/subcommands[3]/options[6]/args/generators[0]",
+        "cargo:/subcommands[4]/options[1]/args/generators[0]",
+        "cargo:/subcommands[4]/subcommands[0]/options[3]/args/generators[0]",
+        "cargo:/subcommands[4]/subcommands[1]/options[1]/args/generators[0]",
+        "cargo:/subcommands[5]/options[12]/args/generators[0]",
+        "cargo:/subcommands[6]/options[3]/args/generators[0]",
+        "cargo:/subcommands[7]/options[14]/args/generators[0]",
+        "cargo:/subcommands[8]/options[2]/args/generators[0]",
+        "cargo:/subcommands[9]/options[1]/args/generators[0]"
       ]
     },
     {
@@ -1149,7 +1139,7 @@
     },
     {
       "shape_id": "keys-map",
-      "fingerprint": "Object.keys(...).map(FN)",
+      "fingerprint": "Object.keys(...).map(<...>)",
       "count": 38,
       "verdict": "needs_new_transform_conditional_split",
       "has_fig_api_refs": false,
@@ -1193,51 +1183,6 @@
         "pass:/subcommands[2]/subcommands[17]/args[0]/generators[0]",
         "pre-commit:/subcommands[6]/options[13]/args/generators[0]",
         "pre-commit:/subcommands[8]/options[13]/args/generators[0]"
-      ]
-    },
-    {
-      "shape_id": "parse-map-3",
-      "fingerprint": "JSON.parse(...).PROP.map(FN)",
-      "count": 35,
-      "verdict": "existing_transforms",
-      "has_fig_api_refs": false,
-      "example_spec": "cargo.json",
-      "generator_ids": [
-        "cargo:/subcommands[0]/options[4]/args/generators[0]",
-        "cargo:/subcommands[0]/options[5]/args/generators[0]",
-        "cargo:/subcommands[18]/options[3]/args/generators[0]",
-        "cargo:/subcommands[18]/options[4]/args/generators[0]",
-        "cargo:/subcommands[19]/args/generators[0]",
-        "cargo:/subcommands[19]/options[0]/args/generators[0]",
-        "cargo:/subcommands[1]/options[0]/args/generators[0]",
-        "cargo:/subcommands[1]/options[1]/args/generators[0]",
-        "cargo:/subcommands[20]/options[4]/args/generators[0]",
-        "cargo:/subcommands[22]/subcommands[0]/options[1]/args/generators[0]",
-        "cargo:/subcommands[23]/options[2]/args/generators[0]",
-        "cargo:/subcommands[24]/options[0]/args/generators[0]",
-        "cargo:/subcommands[25]/options[0]/args/generators[0]",
-        "cargo:/subcommands[27]/options[4]/args/generators[0]",
-        "cargo:/subcommands[27]/options[5]/args/generators[0]",
-        "cargo:/subcommands[28]/options[1]/args/generators[0]",
-        "cargo:/subcommands[28]/options[2]/args/generators[0]",
-        "cargo:/subcommands[2]/options[0]/args/generators[0]",
-        "cargo:/subcommands[2]/options[1]/args/generators[0]",
-        "cargo:/subcommands[36]/options[11]/args/generators[0]",
-        "cargo:/subcommands[37]/options[3]/args/generators[0]",
-        "cargo:/subcommands[3]/options[0]/args/generators[0]",
-        "cargo:/subcommands[5]/options[0]/args/generators[0]",
-        "cargo:/subcommands[5]/options[1]/args/generators[0]",
-        "cargo:/subcommands[7]/options[0]/args/generators[0]",
-        "cargo:/subcommands[7]/options[1]/args/generators[0]",
-        "multipass:/subcommands[13]/args/generators[0]",
-        "multipass:/subcommands[14]/args/generators[0]",
-        "multipass:/subcommands[16]/args/generators[0]",
-        "multipass:/subcommands[17]/args/generators[0]",
-        "multipass:/subcommands[18]/args/generators[0]",
-        "multipass:/subcommands[19]/args/generators[0]",
-        "multipass:/subcommands[2]/args/generators[0]",
-        "multipass:/subcommands[3]/args[0]/generators[0]",
-        "multipass:/subcommands[7]/args/generators[0]"
       ]
     },
     {
@@ -1285,8 +1230,8 @@
       ]
     },
     {
-      "shape_id": "de-fn-with-fig-refs",
-      "fingerprint": "de(...,...,...,FN)",
+      "shape_id": "de-with-fig-refs",
+      "fingerprint": "de(...,...,...,<>)",
       "count": 28,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -1361,8 +1306,44 @@
       ]
     },
     {
-      "shape_id": "r-fn-with-fig-refs",
-      "fingerprint": "R(...,...,...,FN)",
+      "shape_id": "parse-map-3",
+      "fingerprint": "JSON.parse(...).PROP.map(<OBJ>)",
+      "count": 26,
+      "verdict": "existing_transforms",
+      "has_fig_api_refs": false,
+      "example_spec": "cargo.json",
+      "generator_ids": [
+        "cargo:/subcommands[0]/options[4]/args/generators[0]",
+        "cargo:/subcommands[0]/options[5]/args/generators[0]",
+        "cargo:/subcommands[18]/options[3]/args/generators[0]",
+        "cargo:/subcommands[18]/options[4]/args/generators[0]",
+        "cargo:/subcommands[19]/args/generators[0]",
+        "cargo:/subcommands[19]/options[0]/args/generators[0]",
+        "cargo:/subcommands[1]/options[0]/args/generators[0]",
+        "cargo:/subcommands[1]/options[1]/args/generators[0]",
+        "cargo:/subcommands[20]/options[4]/args/generators[0]",
+        "cargo:/subcommands[22]/subcommands[0]/options[1]/args/generators[0]",
+        "cargo:/subcommands[23]/options[2]/args/generators[0]",
+        "cargo:/subcommands[24]/options[0]/args/generators[0]",
+        "cargo:/subcommands[25]/options[0]/args/generators[0]",
+        "cargo:/subcommands[27]/options[4]/args/generators[0]",
+        "cargo:/subcommands[27]/options[5]/args/generators[0]",
+        "cargo:/subcommands[28]/options[1]/args/generators[0]",
+        "cargo:/subcommands[28]/options[2]/args/generators[0]",
+        "cargo:/subcommands[2]/options[0]/args/generators[0]",
+        "cargo:/subcommands[2]/options[1]/args/generators[0]",
+        "cargo:/subcommands[36]/options[11]/args/generators[0]",
+        "cargo:/subcommands[37]/options[3]/args/generators[0]",
+        "cargo:/subcommands[3]/options[0]/args/generators[0]",
+        "cargo:/subcommands[5]/options[0]/args/generators[0]",
+        "cargo:/subcommands[5]/options[1]/args/generators[0]",
+        "cargo:/subcommands[7]/options[0]/args/generators[0]",
+        "cargo:/subcommands[7]/options[1]/args/generators[0]"
+      ]
+    },
+    {
+      "shape_id": "r-d-with-fig-refs",
+      "fingerprint": "R(...,...,...,<D(...,...)>)",
       "count": 25,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -1396,8 +1377,8 @@
       ]
     },
     {
-      "shape_id": "pe-fn-with-fig-refs",
-      "fingerprint": "pe(...,...,...,FN)",
+      "shape_id": "pe-with-fig-refs",
+      "fingerprint": "pe(...,...,...,<>)",
       "count": 24,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -1463,8 +1444,8 @@
       ]
     },
     {
-      "shape_id": "re-fn-with-fig-refs",
-      "fingerprint": "Re(...,...,...,FN)",
+      "shape_id": "re-with-fig-refs",
+      "fingerprint": "Re(...,...,...,<>)",
       "count": 22,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -1495,8 +1476,8 @@
       ]
     },
     {
-      "shape_id": "entries-sort-map",
-      "fingerprint": "Object.entries(...).sort(FN).map(FN)",
+      "shape_id": "entries-sort-localecompare-map",
+      "fingerprint": "Object.entries(...).sort(<(... ? ... : (... ? NUM : .localeCompare(...)))>).map(<OBJ>)",
       "count": 22,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -1589,7 +1570,7 @@
     },
     {
       "shape_id": "trim-split-map-with-fig-refs",
-      "fingerprint": ".trim().split(STR).map(FN)",
+      "fingerprint": ".trim().split(STR).map(<OBJ>)",
       "count": 19,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -1618,7 +1599,7 @@
     },
     {
       "shape_id": "filter-map",
-      "fingerprint": ".filter(FN).map(FN)",
+      "fingerprint": ".filter(<...>).map(<OBJ>)",
       "count": 19,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -1835,8 +1816,8 @@
       ]
     },
     {
-      "shape_id": "le-fn-with-fig-refs",
-      "fingerprint": "le(...,...,...,FN)",
+      "shape_id": "le-with-fig-refs",
+      "fingerprint": "le(...,...,...,<>)",
       "count": 15,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -1886,7 +1867,7 @@
     },
     {
       "shape_id": "trim-split-filter-map",
-      "fingerprint": ".trim().split(STR).filter(FN).map(FN)",
+      "fingerprint": ".trim().split(STR).filter(<(... && ...)>).map(<OBJ>)",
       "count": 15,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -1911,7 +1892,7 @@
     },
     {
       "shape_id": "keys-map-2",
-      "fingerprint": "Object.keys(...).map(FN)",
+      "fingerprint": "Object.keys(...).map(<OBJ>)",
       "count": 14,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -1934,32 +1915,8 @@
       ]
     },
     {
-      "shape_id": "parse-map-4",
-      "fingerprint": "JSON.parse(...).PROP.PROP.map(FN)",
-      "count": 14,
-      "verdict": "needs_dotted_path_json_extract",
-      "has_fig_api_refs": false,
-      "example_spec": "expo-cli.json",
-      "generator_ids": [
-        "expo-cli:/subcommands[37]/options[6]/args/generators[0]",
-        "expo-cli:/subcommands[37]/options[7]/args/generators[0]",
-        "expo:/subcommands[37]/options[6]/args/generators[0]",
-        "expo:/subcommands[37]/options[7]/args/generators[0]",
-        "pnpx:/subcommands[1]/subcommands[16]/options[1]/args/generators[0]",
-        "pnpx:/subcommands[1]/subcommands[16]/options[2]/args/generators[0]",
-        "react-native:/subcommands[16]/options[1]/args/generators[0]",
-        "react-native:/subcommands[16]/options[2]/args/generators[0]",
-        "scarb:/subcommands[0]/options[1]/args/generators[0]",
-        "scarb:/subcommands[12]/options[0]/args/generators[0]",
-        "scarb:/subcommands[13]/options[7]/args/generators[0]",
-        "scarb:/subcommands[1]/options[1]/args/generators[0]",
-        "scarb:/subcommands[2]/options[0]/args/generators[0]",
-        "scarb:/subcommands[7]/options[3]/args/generators[0]"
-      ]
-    },
-    {
-      "shape_id": "ce-fn-with-fig-refs",
-      "fingerprint": "ce(...,...,...,FN)",
+      "shape_id": "ce-with-fig-refs",
+      "fingerprint": "ce(...,...,...,<>)",
       "count": 12,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2002,8 +1959,8 @@
       ]
     },
     {
-      "shape_id": "split-map-2",
-      "fingerprint": ".split(STR).map(FN).map(FN)",
+      "shape_id": "split-map",
+      "fingerprint": ".split(STR).map(<.split(STR)>).map(<OBJ>)",
       "count": 11,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -2043,8 +2000,8 @@
       ]
     },
     {
-      "shape_id": "ge-fn-with-fig-refs",
-      "fingerprint": "ge(...,...,...,FN)",
+      "shape_id": "ge-with-fig-refs",
+      "fingerprint": "ge(...,...,...,<>)",
       "count": 9,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2062,8 +2019,8 @@
       ]
     },
     {
-      "shape_id": "ae-fn-with-fig-refs",
-      "fingerprint": "ae(...,...,...,FN)",
+      "shape_id": "ae-with-fig-refs",
+      "fingerprint": "ae(...,...,...,<>)",
       "count": 9,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2082,7 +2039,7 @@
     },
     {
       "shape_id": "split-map-filter-with-fig-refs",
-      "fingerprint": ".split(STR).map(FN).filter(FN).map(FN)",
+      "fingerprint": ".split(STR).map(<>).filter(<(... && ...)>).map(<OBJ>)",
       "count": 9,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2100,8 +2057,27 @@
       ]
     },
     {
-      "shape_id": "split-map-3",
-      "fingerprint": ".split(STR).map(FN)",
+      "shape_id": "parse-map-4",
+      "fingerprint": "JSON.parse(...).PROP.map(<>)",
+      "count": 9,
+      "verdict": "existing_transforms",
+      "has_fig_api_refs": false,
+      "example_spec": "multipass.json",
+      "generator_ids": [
+        "multipass:/subcommands[13]/args/generators[0]",
+        "multipass:/subcommands[14]/args/generators[0]",
+        "multipass:/subcommands[16]/args/generators[0]",
+        "multipass:/subcommands[17]/args/generators[0]",
+        "multipass:/subcommands[18]/args/generators[0]",
+        "multipass:/subcommands[19]/args/generators[0]",
+        "multipass:/subcommands[2]/args/generators[0]",
+        "multipass:/subcommands[3]/args[0]/generators[0]",
+        "multipass:/subcommands[7]/args/generators[0]"
+      ]
+    },
+    {
+      "shape_id": "split-map-2",
+      "fingerprint": ".split(STR).map(<OBJ>)",
       "count": 8,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -2118,21 +2094,39 @@
       ]
     },
     {
-      "shape_id": "split-map-4",
-      "fingerprint": ".split(STR).map(FN).map(FN)",
+      "shape_id": "parse-map-5",
+      "fingerprint": "JSON.parse(...).map(<OBJ>)",
       "count": 8,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
-      "example_spec": "docker.json",
+      "example_spec": "elm-json.json",
       "generator_ids": [
-        "docker:/subcommands[13]/args/generators[1]",
-        "podman:/subcommands[13]/args/generators[1]",
-        "podman:/subcommands[42]/subcommands[0]/args[0]/generators[0]",
-        "podman:/subcommands[42]/subcommands[2]/args[0]/generators[0]",
-        "podman:/subcommands[42]/subcommands[3]/args/generators[0]",
-        "podman:/subcommands[42]/subcommands[6]/args/generators[0]",
-        "podman:/subcommands[43]/subcommands[1]/args/generators[0]",
-        "podman:/subcommands[43]/subcommands[3]/args/generators[0]"
+        "elm-json:/subcommands[1]/args[0]/generators[0]",
+        "elm-json:/subcommands[3]/args[0]/generators[0]",
+        "elm-json:/subcommands[4]/args[0]/generators[0]",
+        "elm:/subcommands[3]/args/generators[0]",
+        "nativescript:/subcommands[9]/options[0]/args/generators[0]",
+        "ns:/subcommands[9]/options[0]/args/generators[0]",
+        "tns:/subcommands[9]/options[0]/args/generators[0]",
+        "tsh:/subcommands[1]/args/generators[0]"
+      ]
+    },
+    {
+      "shape_id": "parse-map-6",
+      "fingerprint": "JSON.parse(...).PROP.PROP.map(<OBJ>)",
+      "count": 8,
+      "verdict": "needs_dotted_path_json_extract",
+      "has_fig_api_refs": false,
+      "example_spec": "expo-cli.json",
+      "generator_ids": [
+        "expo-cli:/subcommands[37]/options[6]/args/generators[0]",
+        "expo-cli:/subcommands[37]/options[7]/args/generators[0]",
+        "expo:/subcommands[37]/options[6]/args/generators[0]",
+        "expo:/subcommands[37]/options[7]/args/generators[0]",
+        "pnpx:/subcommands[1]/subcommands[16]/options[1]/args/generators[0]",
+        "pnpx:/subcommands[1]/subcommands[16]/options[2]/args/generators[0]",
+        "react-native:/subcommands[16]/options[1]/args/generators[0]",
+        "react-native:/subcommands[16]/options[2]/args/generators[0]"
       ]
     },
     {
@@ -2154,8 +2148,8 @@
       ]
     },
     {
-      "shape_id": "parse-map-5",
-      "fingerprint": "JSON.parse(...).PROP.map(FN)",
+      "shape_id": "parse-map-7",
+      "fingerprint": "JSON.parse(...).PROP.map(<OBJ>)",
       "count": 7,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -2171,8 +2165,8 @@
       ]
     },
     {
-      "shape_id": "trim-split-filter-map-2",
-      "fingerprint": ".trim().split(STR).filter(FN).map(FN).map(FN)",
+      "shape_id": "trim-split-filter-startswith-map-replace",
+      "fingerprint": ".trim().split(STR).filter(<.startsWith(...)>).map(<.replace(REGEX,STR)>).map(<OBJ>)",
       "count": 7,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -2189,7 +2183,7 @@
     },
     {
       "shape_id": "split-map-with-fig-refs",
-      "fingerprint": ".split(STR).map(FN)",
+      "fingerprint": ".split(STR).map(<OBJ>)",
       "count": 7,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2239,8 +2233,8 @@
       ]
     },
     {
-      "shape_id": "k-fn-with-fig-refs",
-      "fingerprint": "k(...,...,...,FN)",
+      "shape_id": "k-w-with-fig-refs",
+      "fingerprint": "k(...,...,...,<W(...,...)>)",
       "count": 7,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2274,7 +2268,7 @@
     },
     {
       "shape_id": "from-map",
-      "fingerprint": "Array.from(...).map(FN)",
+      "fingerprint": "Array.from(...).map(<OBJ>)",
       "count": 7,
       "verdict": "needs_new_transform_substring_slice",
       "has_fig_api_refs": false,
@@ -2290,8 +2284,8 @@
       ]
     },
     {
-      "shape_id": "split-map-5",
-      "fingerprint": ".split(STR).map(FN)",
+      "shape_id": "split-map-3",
+      "fingerprint": ".split(STR).map(<OBJ>)",
       "count": 6,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -2338,8 +2332,8 @@
       ]
     },
     {
-      "shape_id": "me-fn-with-fig-refs",
-      "fingerprint": "me(...,...,...,FN)",
+      "shape_id": "me-with-fig-refs",
+      "fingerprint": "me(...,...,...,<>)",
       "count": 6,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2354,8 +2348,40 @@
       ]
     },
     {
+      "shape_id": "split-map-parse-2",
+      "fingerprint": ".split(STR).map(<JSON.parse(...)>).map(<OBJ>)",
+      "count": 6,
+      "verdict": "existing_transforms",
+      "has_fig_api_refs": false,
+      "example_spec": "podman.json",
+      "generator_ids": [
+        "podman:/subcommands[42]/subcommands[0]/args[0]/generators[0]",
+        "podman:/subcommands[42]/subcommands[2]/args[0]/generators[0]",
+        "podman:/subcommands[42]/subcommands[3]/args/generators[0]",
+        "podman:/subcommands[42]/subcommands[6]/args/generators[0]",
+        "podman:/subcommands[43]/subcommands[1]/args/generators[0]",
+        "podman:/subcommands[43]/subcommands[3]/args/generators[0]"
+      ]
+    },
+    {
+      "shape_id": "parse-map-split",
+      "fingerprint": "JSON.parse(...).PROP.PROP.map(<.split(STR)[COMPUTED]>)",
+      "count": 6,
+      "verdict": "needs_dotted_path_json_extract",
+      "has_fig_api_refs": false,
+      "example_spec": "scarb.json",
+      "generator_ids": [
+        "scarb:/subcommands[0]/options[1]/args/generators[0]",
+        "scarb:/subcommands[12]/options[0]/args/generators[0]",
+        "scarb:/subcommands[13]/options[7]/args/generators[0]",
+        "scarb:/subcommands[1]/options[1]/args/generators[0]",
+        "scarb:/subcommands[2]/options[0]/args/generators[0]",
+        "scarb:/subcommands[7]/options[3]/args/generators[0]"
+      ]
+    },
+    {
       "shape_id": "trim-split-map",
-      "fingerprint": ".trim().split(STR)[COMPUTED].split(STR)[COMPUTED].split(STR)[COMPUTED].split(STR).map(FN)",
+      "fingerprint": ".trim().split(STR)[COMPUTED].split(STR)[COMPUTED].split(STR)[COMPUTED].split(STR).map(<OBJ>)",
       "count": 5,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -2369,8 +2395,8 @@
       ]
     },
     {
-      "shape_id": "fe-fn-with-fig-refs",
-      "fingerprint": "Fe(...,...,...,FN)",
+      "shape_id": "fe-with-fig-refs",
+      "fingerprint": "Fe(...,...,...,<>)",
       "count": 5,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2385,7 +2411,7 @@
     },
     {
       "shape_id": "from-map-2",
-      "fingerprint": "Array.from(...).map(FN)",
+      "fingerprint": "Array.from(...).map(<OBJ>)",
       "count": 5,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -2399,23 +2425,8 @@
       ]
     },
     {
-      "shape_id": "j-fn-with-fig-refs",
-      "fingerprint": "j(...,...,...,FN)",
-      "count": 5,
-      "verdict": "hand_audit_required",
-      "has_fig_api_refs": true,
-      "example_spec": "file.json",
-      "generator_ids": [
-        "file:/options[24]/args/generators[0]",
-        "swift:/options[11]/args/generators[0]",
-        "swift:/options[35]/args/generators[0]",
-        "swift:/options[54]/args/generators[0]",
-        "swift:/options[8]/args/generators[0]"
-      ]
-    },
-    {
-      "shape_id": "filter-map-with-fig-refs",
-      "fingerprint": "await c(STR,...,...,STR).filter(FN).map(FN)",
+      "shape_id": "filter-trim-tolowercase-startswith-map-with-fig-refs",
+      "fingerprint": "await c(STR,...,...,STR).filter(<(.trim().toLowerCase().startsWith(STR) && ...)>).map(<OBJ>)",
       "count": 5,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2444,8 +2455,8 @@
       ]
     },
     {
-      "shape_id": "fe-fn-with-fig-refs-2",
-      "fingerprint": "fe(...,...,...,FN)",
+      "shape_id": "fe-with-fig-refs-2",
+      "fingerprint": "fe(...,...,...,<>)",
       "count": 4,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2529,7 +2540,7 @@
     },
     {
       "shape_id": "keys-map-3",
-      "fingerprint": "Object.keys(...).map(FN)",
+      "fingerprint": "Object.keys(...).map(<OBJ>)",
       "count": 4,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -2542,8 +2553,8 @@
       ]
     },
     {
-      "shape_id": "t-fn-with-fig-refs",
-      "fingerprint": "T(...,...,...,FN)",
+      "shape_id": "t-q-with-fig-refs",
+      "fingerprint": "T(...,...,...,<q(...,...)>)",
       "count": 4,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2556,8 +2567,8 @@
       ]
     },
     {
-      "shape_id": "filter-map-with-fig-refs-2",
-      "fingerprint": "await d(STR,...,...,STR).filter(FN).map(FN)",
+      "shape_id": "filter-trim-tolowercase-startswith-map-with-fig-refs-2",
+      "fingerprint": "await d(STR,...,...,STR).filter(<(.trim().toLowerCase().startsWith(STR) && ...)>).map(<OBJ>)",
       "count": 4,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2567,6 +2578,20 @@
         "scp:/args[1]/generators[1]",
         "sftp:/args[0]/generators[1]",
         "sftp:/args[1]/generators[1]"
+      ]
+    },
+    {
+      "shape_id": "j-q-with-fig-refs",
+      "fingerprint": "j(...,...,...,<q(...,...,...,...)>)",
+      "count": 4,
+      "verdict": "hand_audit_required",
+      "has_fig_api_refs": true,
+      "example_spec": "swift.json",
+      "generator_ids": [
+        "swift:/options[11]/args/generators[0]",
+        "swift:/options[35]/args/generators[0]",
+        "swift:/options[54]/args/generators[0]",
+        "swift:/options[8]/args/generators[0]"
       ]
     },
     {
@@ -2583,8 +2608,8 @@
       ]
     },
     {
-      "shape_id": "te-fn-with-fig-refs",
-      "fingerprint": "Te(...,...,...,FN)",
+      "shape_id": "te-arr-with-fig-refs",
+      "fingerprint": "Te(...,...,...,<((... && ...) ? ... : ARR)>)",
       "count": 3,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2609,8 +2634,8 @@
       ]
     },
     {
-      "shape_id": "filter",
-      "fingerprint": ".filter(FN)",
+      "shape_id": "filter-has",
+      "fingerprint": ".filter(<(.has(...) ? ... : ...)>)",
       "count": 3,
       "verdict": "needs_new_transform_substring_slice",
       "has_fig_api_refs": false,
@@ -2635,8 +2660,8 @@
       ]
     },
     {
-      "shape_id": "x-fn-with-fig-refs",
-      "fingerprint": "x(...,...,...,FN)",
+      "shape_id": "x-j-with-fig-refs",
+      "fingerprint": "x(...,...,...,<j(...,...)>)",
       "count": 3,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2713,8 +2738,8 @@
       ]
     },
     {
-      "shape_id": "ye-fn-with-fig-refs",
-      "fingerprint": "ye(...,...,...,FN)",
+      "shape_id": "ye-with-fig-refs",
+      "fingerprint": "ye(...,...,...,<>)",
       "count": 3,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2726,8 +2751,8 @@
       ]
     },
     {
-      "shape_id": "parse-map-6",
-      "fingerprint": "JSON.parse(...).map(FN)",
+      "shape_id": "parse-map-8",
+      "fingerprint": "JSON.parse(...).map(<OBJ>)",
       "count": 3,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -2740,7 +2765,7 @@
     },
     {
       "shape_id": "keys-map-4",
-      "fingerprint": "Object.keys(...).map(FN)",
+      "fingerprint": "Object.keys(...).map(<OBJ>)",
       "count": 2,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -2751,8 +2776,8 @@
       ]
     },
     {
-      "shape_id": "g-fn-with-fig-refs",
-      "fingerprint": "G(...,...,...,FN)",
+      "shape_id": "g-te-with-fig-refs",
+      "fingerprint": "G(...,...,...,<te(...,...)>)",
       "count": 2,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2763,8 +2788,8 @@
       ]
     },
     {
-      "shape_id": "g-fn-with-fig-refs-2",
-      "fingerprint": "G(...,...,...,FN)",
+      "shape_id": "g-te-with-fig-refs-2",
+      "fingerprint": "G(...,...,...,<te(...,...)>)",
       "count": 2,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2776,7 +2801,7 @@
     },
     {
       "shape_id": "trim-split-slice-map-with-fig-refs",
-      "fingerprint": ".trim().split(STR).slice(NUM).map(FN)",
+      "fingerprint": ".trim().split(STR).slice(NUM).map(<OBJ>)",
       "count": 2,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2799,6 +2824,30 @@
       ]
     },
     {
+      "shape_id": "split-map-parse-3",
+      "fingerprint": ".split(STR).map(<JSON.parse(...)>).map(<...>)",
+      "count": 2,
+      "verdict": "existing_transforms",
+      "has_fig_api_refs": false,
+      "example_spec": "docker.json",
+      "generator_ids": [
+        "docker:/subcommands[13]/args/generators[1]",
+        "podman:/subcommands[13]/args/generators[1]"
+      ]
+    },
+    {
+      "shape_id": "a-g-with-fig-refs",
+      "fingerprint": "A(...,...,...,<G(...,...,...,...)>)",
+      "count": 2,
+      "verdict": "hand_audit_required",
+      "has_fig_api_refs": true,
+      "example_spec": "gh.json",
+      "generator_ids": [
+        "gh:/subcommands[17]/subcommands[8]/subcommands[0]/args/generators[0]",
+        "gh:/subcommands[17]/subcommands[8]/subcommands[1]/args/generators[0]"
+      ]
+    },
+    {
       "shape_id": "unknown-9",
       "fingerprint": "...",
       "count": 2,
@@ -2811,8 +2860,8 @@
       ]
     },
     {
-      "shape_id": "he-fn-with-fig-refs",
-      "fingerprint": "he(...,...,...,FN)",
+      "shape_id": "he-with-fig-refs",
+      "fingerprint": "he(...,...,...,<>)",
       "count": 2,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2823,8 +2872,8 @@
       ]
     },
     {
-      "shape_id": "q-fn-with-fig-refs",
-      "fingerprint": "q(...,...,...,FN)",
+      "shape_id": "q-j-with-fig-refs",
+      "fingerprint": "q(...,...,...,<j(...,...)>)",
       "count": 2,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2836,7 +2885,7 @@
     },
     {
       "shape_id": "entries-map-reduce-with-fig-refs",
-      "fingerprint": "Object.entries(...).map(FN).reduce(FN,ARR).map(FN)",
+      "fingerprint": "Object.entries(...).map(<...>).reduce(<ARR>,ARR).map(<OBJ>)",
       "count": 2,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2847,8 +2896,8 @@
       ]
     },
     {
-      "shape_id": "parse-map-7",
-      "fingerprint": "JSON.parse(...).map(FN)",
+      "shape_id": "parse-map-9",
+      "fingerprint": "JSON.parse(...).map(<OBJ>)",
       "count": 2,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -2860,7 +2909,7 @@
     },
     {
       "shape_id": "map-with-fig-refs-2",
-      "fingerprint": "(... ? .PROP.PROP.map(FN) : ARR)",
+      "fingerprint": "(... ? .PROP.PROP.map(<OBJ>) : ARR)",
       "count": 2,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2872,7 +2921,7 @@
     },
     {
       "shape_id": "values-map-with-fig-refs",
-      "fingerprint": "Object.values(...).map(FN)",
+      "fingerprint": "Object.values(...).map(<OBJ>)",
       "count": 2,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2883,8 +2932,8 @@
       ]
     },
     {
-      "shape_id": "we-fn-with-fig-refs",
-      "fingerprint": "we(...,...,...,FN)",
+      "shape_id": "we-with-fig-refs",
+      "fingerprint": "we(...,...,...,<>)",
       "count": 2,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2907,8 +2956,8 @@
       ]
     },
     {
-      "shape_id": "i-fn-with-fig-refs",
-      "fingerprint": "I(...,...,...,FN)",
+      "shape_id": "i-h-with-fig-refs",
+      "fingerprint": "I(...,...,...,<H(...,...)>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2919,7 +2968,7 @@
     },
     {
       "shape_id": "slice-some-map",
-      "fingerprint": "(.slice(NUM,...).some(FN) ? ARR.map(FN) : ARR.map(FN))",
+      "fingerprint": "(.slice(NUM,...).some(<...>) ? ARR.map(<OBJ>) : ARR.map(<OBJ>))",
       "count": 1,
       "verdict": "needs_new_transform_substring_slice",
       "has_fig_api_refs": false,
@@ -2951,8 +3000,8 @@
       ]
     },
     {
-      "shape_id": "d-fn-with-fig-refs",
-      "fingerprint": "D(...,...,...,FN)",
+      "shape_id": "d-c-with-fig-refs",
+      "fingerprint": "D(...,...,...,<C(...,...)>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2973,8 +3022,8 @@
       ]
     },
     {
-      "shape_id": "parse-map-8",
-      "fingerprint": "JSON.parse(...).map(FN)",
+      "shape_id": "parse-map-10",
+      "fingerprint": "JSON.parse(...).map(<OBJ>)",
       "count": 1,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -2985,7 +3034,7 @@
     },
     {
       "shape_id": "entries-map-with-fig-refs",
-      "fingerprint": "(... ? ARR : Object.entries(...).map(FN))",
+      "fingerprint": "(... ? ARR : Object.entries(...).map(<OBJ>))",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -2995,8 +3044,8 @@
       ]
     },
     {
-      "shape_id": "parse-map-9",
-      "fingerprint": "JSON.parse(...).PROP.map(FN)",
+      "shape_id": "parse-map-11",
+      "fingerprint": "JSON.parse(...).PROP.map(<OBJ>)",
       "count": 1,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -3007,7 +3056,7 @@
     },
     {
       "shape_id": "map",
-      "fingerprint": ".PROP.map(FN)",
+      "fingerprint": ".PROP.map(<OBJ>)",
       "count": 1,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -3018,7 +3067,7 @@
     },
     {
       "shape_id": "includes-map-with-fig-refs",
-      "fingerprint": "(.includes(...) ? [COMPUTED].map(FN) : ARR)",
+      "fingerprint": "(.includes(...) ? [COMPUTED].map(<OBJ>) : ARR)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3040,7 +3089,7 @@
     },
     {
       "shape_id": "startswith-keys-map",
-      "fingerprint": "((... || [COMPUTED].startsWith(STR)) ? Object.keys(...).map(FN) : ARR)",
+      "fingerprint": "((... || [COMPUTED].startsWith(STR)) ? Object.keys(...).map(<OBJ>) : ARR)",
       "count": 1,
       "verdict": "needs_new_transform_conditional_split",
       "has_fig_api_refs": false,
@@ -3051,7 +3100,7 @@
     },
     {
       "shape_id": "values-map",
-      "fingerprint": "Object.values(...).map(FN)",
+      "fingerprint": "Object.values(...).map(<OBJ>)",
       "count": 1,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -3061,14 +3110,25 @@
       ]
     },
     {
-      "shape_id": "k-fn-with-fig-refs-2",
-      "fingerprint": "k(...,...,...,FN)",
+      "shape_id": "k-w-with-fig-refs-2",
+      "fingerprint": "k(...,...,...,<W(...,...)>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
       "example_spec": "esbuild.json",
       "generator_ids": [
         "esbuild:/options[11]/args/generators[0]"
+      ]
+    },
+    {
+      "shape_id": "j-p-with-fig-refs",
+      "fingerprint": "j(...,...,...,<P(...,...,...,...)>)",
+      "count": 1,
+      "verdict": "hand_audit_required",
+      "has_fig_api_refs": true,
+      "example_spec": "file.json",
+      "generator_ids": [
+        "file:/options[24]/args/generators[0]"
       ]
     },
     {
@@ -3084,7 +3144,7 @@
     },
     {
       "shape_id": "map-with-fig-refs-3",
-      "fingerprint": "h(ARR,FN).map(FN)",
+      "fingerprint": "h(ARR,<...>).map(<((.PROP && ...) ? OBJ : OBJ)>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3095,7 +3155,7 @@
     },
     {
       "shape_id": "map-reverse-with-fig-refs",
-      "fingerprint": "ARR.map(FN).reverse()",
+      "fingerprint": "ARR.map(<OBJ>).reverse()",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3116,8 +3176,8 @@
       ]
     },
     {
-      "shape_id": "filter-map-2",
-      "fingerprint": ".filter(FN).map(FN)",
+      "shape_id": "filter-every-includes-map",
+      "fingerprint": ".filter(<.every(<.includes(...)>)>).map(<>)",
       "count": 1,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -3139,7 +3199,7 @@
     },
     {
       "shape_id": "trim-split-map-2",
-      "fingerprint": ".trim().split(STR).map(FN)",
+      "fingerprint": ".trim().split(STR).map(<OBJ>)",
       "count": 1,
       "verdict": "needs_new_transform_substring_slice",
       "has_fig_api_refs": false,
@@ -3150,7 +3210,7 @@
     },
     {
       "shape_id": "map-2",
-      "fingerprint": "ARR.map(FN)",
+      "fingerprint": "ARR.map(<OBJ>)",
       "count": 1,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -3161,7 +3221,7 @@
     },
     {
       "shape_id": "map-3",
-      "fingerprint": ".map(FN)",
+      "fingerprint": ".map(<OBJ>)",
       "count": 1,
       "verdict": "needs_new_transform_regex_match",
       "has_fig_api_refs": false,
@@ -3172,7 +3232,7 @@
     },
     {
       "shape_id": "map-4",
-      "fingerprint": ".map(FN)",
+      "fingerprint": ".map(<OBJ>)",
       "count": 1,
       "verdict": "needs_new_transform_conditional_split",
       "has_fig_api_refs": false,
@@ -3182,8 +3242,8 @@
       ]
     },
     {
-      "shape_id": "f-fn-with-fig-refs",
-      "fingerprint": "F(...,...,...,FN)",
+      "shape_id": "f-e-with-fig-refs",
+      "fingerprint": "F(...,...,...,<E(...,...)>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3204,8 +3264,8 @@
       ]
     },
     {
-      "shape_id": "split-filter-map",
-      "fingerprint": ".split(STR).filter(FN).map(FN)",
+      "shape_id": "split-filter-endswith-map",
+      "fingerprint": ".split(STR).filter(<.endsWith(STR)>).map(<OBJ>)",
       "count": 1,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -3227,7 +3287,7 @@
     },
     {
       "shape_id": "parse-map-with-fig-refs-2",
-      "fingerprint": "JSON.parse(...).map(FN)",
+      "fingerprint": "JSON.parse(...).map(<OBJ>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3237,8 +3297,8 @@
       ]
     },
     {
-      "shape_id": "ln-fn-with-fig-refs",
-      "fingerprint": "ln(...,...,...,FN)",
+      "shape_id": "ln-with-fig-refs",
+      "fingerprint": "ln(...,...,...,<>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3271,7 +3331,7 @@
     },
     {
       "shape_id": "map-5",
-      "fingerprint": "ARR.map(FN).map(FN)",
+      "fingerprint": "ARR.map(<[COMPUTED]>).map(<OBJ>)",
       "count": 1,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,
@@ -3282,7 +3342,7 @@
     },
     {
       "shape_id": "keys-reduce",
-      "fingerprint": "Object.keys(...).reduce(FN,ARR)",
+      "fingerprint": "Object.keys(...).reduce(<ARR>,ARR)",
       "count": 1,
       "verdict": "existing_transforms",
       "has_fig_api_refs": false,
@@ -3292,8 +3352,8 @@
       ]
     },
     {
-      "shape_id": "t-fn-with-fig-refs-2",
-      "fingerprint": "T(...,...,...,FN)",
+      "shape_id": "t-q-with-fig-refs-2",
+      "fingerprint": "T(...,...,...,<q(...,...)>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3303,8 +3363,8 @@
       ]
     },
     {
-      "shape_id": "flatmap-filter-sort-map-with-fig-refs",
-      "fingerprint": ".PROP.PROP.flatMap(FN).filter(FN).sort(FN).map(FN)",
+      "shape_id": "flatmap-filter-sort-localecompare-map-with-fig-refs",
+      "fingerprint": ".PROP.PROP.flatMap(<...>).filter(<...>).sort(<.PROP.localeCompare(...)>).map(<OBJ>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3314,8 +3374,8 @@
       ]
     },
     {
-      "shape_id": "split-filter-map-with-fig-refs",
-      "fingerprint": ".split(STR).filter(FN).map(FN)",
+      "shape_id": "split-filter-test-map-with-fig-refs",
+      "fingerprint": ".split(STR).filter(<.test(...)>).map(<OBJ>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3326,7 +3386,7 @@
     },
     {
       "shape_id": "map-with-fig-refs-4",
-      "fingerprint": "ARR.map(FN)",
+      "fingerprint": "ARR.map(<OBJ>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3336,8 +3396,8 @@
       ]
     },
     {
-      "shape_id": "pe-fn-with-fig-refs-2",
-      "fingerprint": "Pe(...,...,...,FN)",
+      "shape_id": "pe-with-fig-refs-2",
+      "fingerprint": "Pe(...,...,...,<>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3348,7 +3408,7 @@
     },
     {
       "shape_id": "entries-map-with-fig-refs-2",
-      "fingerprint": "Object.entries(...).map(FN)",
+      "fingerprint": "Object.entries(...).map(<...>)",
       "count": 1,
       "verdict": "hand_audit_required",
       "has_fig_api_refs": true,
@@ -3359,7 +3419,7 @@
     },
     {
       "shape_id": "trim-slice-split-filter-map",
-      "fingerprint": ".trim().slice(NUM,...).split(STR).filter(FN).map(FN)",
+      "fingerprint": ".trim().slice(NUM,...).split(STR).filter(<...>).map(<OBJ>)",
       "count": 1,
       "verdict": "needs_new_transform_substring_slice",
       "has_fig_api_refs": false,
@@ -3381,7 +3441,7 @@
     },
     {
       "shape_id": "map-6",
-      "fingerprint": "ARR.map(FN)",
+      "fingerprint": "ARR.map(<OBJ>)",
       "count": 1,
       "verdict": "needs_new_transform_conditional_split",
       "has_fig_api_refs": false,
@@ -3392,7 +3452,7 @@
     },
     {
       "shape_id": "split-slice-map",
-      "fingerprint": ".split(STR).slice(NUM).map(FN)",
+      "fingerprint": ".split(STR).slice(NUM).map(<OBJ>)",
       "count": 1,
       "verdict": "requires_runtime",
       "has_fig_api_refs": false,

--- a/tools/fig-converter/docs/shape-inventory.md
+++ b/tools/fig-converter/docs/shape-inventory.md
@@ -3,7 +3,7 @@
 > Canonical machine-readable data: [shape-inventory.json](./shape-inventory.json)
 
 **Total generators analysed:** 1889
-**Total distinct shapes:** 151
+**Total distinct shapes:** 157
 
 ## Verdict Distribution
 
@@ -21,36 +21,36 @@
 
 | shape_id | count | fingerprint (≤80 chars) | verdict | has_fig_api_refs | example_spec |
 |----------|-------|-------------------------|---------|------------------|--------------|
-| `parse-map` | 174 | `JSON.parse(...).map(FN)` | `existing_transforms` | false | fly.json |
+| `parse-map` | 174 | `JSON.parse(...).map(<OBJ>)` | `existing_transforms` | false | fly.json |
 | `unknown` | 73 | `...` | `needs_new_transform_conditional_split` | false | bazel.json |
 | `arr-with-fig-refs` | 69 | `ARR` | `hand_audit_required` | true | docker-compose.json |
-| `startswith-split-map-with-fig-refs` | 68 | `(.startsWith(STR) ? ARR : .split(STR).map(FN))` | `hand_audit_required` | true | chezmoi.json |
+| `startswith-split-map-with-fig-refs` | 68 | `(.startsWith(STR) ? ARR : .split(STR).map(<OBJ>))` | `hand_audit_required` | true | chezmoi.json |
 | `unknown-with-fig-refs` | 65 | `...` | `hand_audit_required` | true | copilot.json |
-| `split-map` | 63 | `.split(STR).map(FN).map(FN)` | `existing_transforms` | false | docker.json |
+| `split-map-parse` | 63 | `.split(STR).map(<JSON.parse(...)>).map(<OBJ>)` | `existing_transforms` | false | docker.json |
 | `unknown-2` | 58 | `...` | `requires_runtime` | false | meteor.json |
-| `ue-fn-with-fig-refs` | 51 | `ue(...,...,...,FN)` | `hand_audit_required` | true | cloudflared.json |
+| `ue-with-fig-refs` | 51 | `ue(...,...,...,<>)` | `hand_audit_required` | true | cloudflared.json |
 | `empty` | 50 | `` | `existing_transforms` | false | arduino-cli.json |
-| `parse-map-2` | 50 | `JSON.parse(...).map(FN)` | `existing_transforms` | false | elm-json.json |
-| `match-map` | 50 | `.match(REGEX).map(FN).map(FN).map(FN)` | `needs_new_transform_regex_match` | false | flutter.json |
-| `map-with-fig-refs` | 45 | `o(...).map(FN)` | `hand_audit_required` | true | tsuru.json |
+| `match-map-split-trim` | 50 | `.match(REGEX).map(<.split(STR)>).map(<.map(<.trim()>)>).map(<OBJ>)` | `needs_new_transform_regex_match` | false | flutter.json |
+| `map-with-fig-refs` | 45 | `o(...).map(<OBJ>)` | `hand_audit_required` | true | tsuru.json |
 | `arr` | 44 | `ARR` | `existing_transforms` | false | ng.json |
-| `a-fn-with-fig-refs` | 43 | `A(...,...,...,FN)` | `hand_audit_required` | true | cargo.json |
 | `typewithoutname-with-fig-refs` | 42 | `.typeWithoutName(...)` | `hand_audit_required` | true | kubecolor.json |
+| `parse-map-2` | 42 | `JSON.parse(...).map(<.PROP>)` | `existing_transforms` | false | tsh.json |
+| `a-m-with-fig-refs` | 41 | `A(...,...,...,<M(...,...,...,...)>)` | `hand_audit_required` | true | cargo.json |
 | `includes-typewithoutname-with-fig-refs` | 40 | `(.includes(STR) ? .typeWithoutName(...) : .PROP)` | `hand_audit_required` | true | kubecolor.json |
-| `keys-map` | 38 | `Object.keys(...).map(FN)` | `needs_new_transform_conditional_split` | false | chezmoi.json |
-| `parse-map-3` | 35 | `JSON.parse(...).PROP.map(FN)` | `existing_transforms` | false | cargo.json |
+| `keys-map` | 38 | `Object.keys(...).map(<...>)` | `needs_new_transform_conditional_split` | false | chezmoi.json |
 | `unknown-with-fig-refs-2` | 34 | `...` | `hand_audit_required` | true | cargo.json |
-| `de-fn-with-fig-refs` | 28 | `de(...,...,...,FN)` | `hand_audit_required` | true | coda.json |
+| `de-with-fig-refs` | 28 | `de(...,...,...,<>)` | `hand_audit_required` | true | coda.json |
 | `unknown-3` | 28 | `...` | `existing_transforms` | false | conda.json |
-| `r-fn-with-fig-refs` | 25 | `R(...,...,...,FN)` | `hand_audit_required` | true | chezmoi.json |
-| `pe-fn-with-fig-refs` | 24 | `pe(...,...,...,FN)` | `hand_audit_required` | true | dotenv-vault.json |
+| `parse-map-3` | 26 | `JSON.parse(...).PROP.map(<OBJ>)` | `existing_transforms` | false | cargo.json |
+| `r-d-with-fig-refs` | 25 | `R(...,...,...,<D(...,...)>)` | `hand_audit_required` | true | chezmoi.json |
+| `pe-with-fig-refs` | 24 | `pe(...,...,...,<>)` | `hand_audit_required` | true | dotenv-vault.json |
 | `unknown-with-fig-refs-3` | 23 | `...` | `hand_audit_required` | true | nx.json |
-| `re-fn-with-fig-refs` | 22 | `Re(...,...,...,FN)` | `hand_audit_required` | true | cargo.json |
-| `entries-sort-map` | 22 | `Object.entries(...).sort(FN).map(FN)` | `existing_transforms` | false | fly.json |
+| `re-with-fig-refs` | 22 | `Re(...,...,...,<>)` | `hand_audit_required` | true | cargo.json |
+| `entries-sort-localecompare-map` | 22 | `Object.entries(...).sort(<(... ? ... : (... ? NUM : .localeCompare(...)))>).m...` | `existing_transforms` | false | fly.json |
 | `unknown-4` | 22 | `...` | `requires_runtime` | false | systemctl.json |
 | `empty-with-fig-refs` | 19 | `` | `hand_audit_required` | true | bun.json |
-| `trim-split-map-with-fig-refs` | 19 | `.trim().split(STR).map(FN)` | `hand_audit_required` | true | dscl.json |
-| `filter-map` | 19 | `.filter(FN).map(FN)` | `existing_transforms` | false | eslint.json |
+| `trim-split-map-with-fig-refs` | 19 | `.trim().split(STR).map(<OBJ>)` | `hand_audit_required` | true | dscl.json |
+| `filter-map` | 19 | `.filter(<...>).map(<OBJ>)` | `existing_transforms` | false | eslint.json |
 | `empty-2` | 18 | `` | `existing_transforms` | false | bosh.json |
 | `unknown-with-fig-refs-4` | 18 | `...` | `hand_audit_required` | true | chezmoi.json |
 | `unknown-with-fig-refs-5` | 18 | `...` | `hand_audit_required` | true | rush.json |
@@ -58,170 +58,177 @@
 | `arr-3` | 16 | `ARR` | `existing_transforms` | false | bun.json |
 | `empty-3` | 16 | `` | `requires_runtime` | false | bun.json |
 | `arr-arr` | 16 | `(... ? ARR : ARR)` | `needs_new_transform_conditional_split` | false | kubecolor.json |
-| `le-fn-with-fig-refs` | 15 | `le(...,...,...,FN)` | `hand_audit_required` | true | asr.json |
+| `le-with-fig-refs` | 15 | `le(...,...,...,<>)` | `hand_audit_required` | true | asr.json |
 | `parse-error` | 15 | `<parse_error>` | `hand_audit_required` | false | dotnet.json |
-| `trim-split-filter-map` | 15 | `.trim().split(STR).filter(FN).map(FN)` | `requires_runtime` | false | gem.json |
-| `keys-map-2` | 14 | `Object.keys(...).map(FN)` | `existing_transforms` | false | cargo.json |
-| `parse-map-4` | 14 | `JSON.parse(...).PROP.PROP.map(FN)` | `needs_dotted_path_json_extract` | false | expo-cli.json |
-| `ce-fn-with-fig-refs` | 12 | `ce(...,...,...,FN)` | `hand_audit_required` | true | ansible-playbook.json |
+| `trim-split-filter-map` | 15 | `.trim().split(STR).filter(<(... && ...)>).map(<OBJ>)` | `requires_runtime` | false | gem.json |
+| `keys-map-2` | 14 | `Object.keys(...).map(<OBJ>)` | `existing_transforms` | false | cargo.json |
+| `ce-with-fig-refs` | 12 | `ce(...,...,...,<>)` | `hand_audit_required` | true | ansible-playbook.json |
 | `from` | 12 | `Array.from(...)` | `existing_transforms` | false | expo-cli.json |
-| `split-map-2` | 11 | `.split(STR).map(FN).map(FN)` | `requires_runtime` | false | chown.json |
+| `split-map` | 11 | `.split(STR).map(<.split(STR)>).map(<OBJ>)` | `requires_runtime` | false | chown.json |
 | `unknown-5` | 10 | `...` | `needs_new_transform_substring_slice` | false | deno.json |
-| `ge-fn-with-fig-refs` | 9 | `ge(...,...,...,FN)` | `hand_audit_required` | true | apt.json |
-| `ae-fn-with-fig-refs` | 9 | `ae(...,...,...,FN)` | `hand_audit_required` | true | dotnet.json |
-| `split-map-filter-with-fig-refs` | 9 | `.split(STR).map(FN).filter(FN).map(FN)` | `hand_audit_required` | true | kitty.json |
-| `split-map-3` | 8 | `.split(STR).map(FN)` | `requires_runtime` | false | bun.json |
-| `split-map-4` | 8 | `.split(STR).map(FN).map(FN)` | `existing_transforms` | false | docker.json |
+| `ge-with-fig-refs` | 9 | `ge(...,...,...,<>)` | `hand_audit_required` | true | apt.json |
+| `ae-with-fig-refs` | 9 | `ae(...,...,...,<>)` | `hand_audit_required` | true | dotnet.json |
+| `split-map-filter-with-fig-refs` | 9 | `.split(STR).map(<>).filter(<(... && ...)>).map(<OBJ>)` | `hand_audit_required` | true | kitty.json |
+| `parse-map-4` | 9 | `JSON.parse(...).PROP.map(<>)` | `existing_transforms` | false | multipass.json |
+| `split-map-2` | 8 | `.split(STR).map(<OBJ>)` | `requires_runtime` | false | bun.json |
+| `parse-map-5` | 8 | `JSON.parse(...).map(<OBJ>)` | `existing_transforms` | false | elm-json.json |
+| `parse-map-6` | 8 | `JSON.parse(...).PROP.PROP.map(<OBJ>)` | `needs_dotted_path_json_extract` | false | expo-cli.json |
 | `unknown-6` | 8 | `...` | `needs_new_transform_substring_slice` | false | gpg.json |
-| `parse-map-5` | 7 | `JSON.parse(...).PROP.map(FN)` | `existing_transforms` | false | amplify.json |
-| `trim-split-filter-map-2` | 7 | `.trim().split(STR).filter(FN).map(FN).map(FN)` | `requires_runtime` | false | apt.json |
-| `split-map-with-fig-refs` | 7 | `.split(STR).map(FN)` | `hand_audit_required` | true | asdf.json |
+| `parse-map-7` | 7 | `JSON.parse(...).PROP.map(<OBJ>)` | `existing_transforms` | false | amplify.json |
+| `trim-split-filter-startswith-map-replace` | 7 | `.trim().split(STR).filter(<.startsWith(...)>).map(<.replace(REGEX,STR)>).map(...` | `requires_runtime` | false | apt.json |
+| `split-map-with-fig-refs` | 7 | `.split(STR).map(<OBJ>)` | `hand_audit_required` | true | asdf.json |
 | `unknown-7` | 7 | `...` | `existing_transforms` | false | cordova.json |
 | `empty-with-fig-refs-2` | 7 | `` | `hand_audit_required` | true | deno.json |
-| `k-fn-with-fig-refs` | 7 | `k(...,...,...,FN)` | `hand_audit_required` | true | esbuild.json |
+| `k-w-with-fig-refs` | 7 | `k(...,...,...,<W(...,...)>)` | `hand_audit_required` | true | esbuild.json |
 | `arr-with-fig-refs-2` | 7 | `ARR` | `hand_audit_required` | true | gh.json |
-| `from-map` | 7 | `Array.from(...).map(FN)` | `needs_new_transform_substring_slice` | false | n.json |
-| `split-map-5` | 6 | `.split(STR).map(FN)` | `existing_transforms` | false | assimp.json |
+| `from-map` | 7 | `Array.from(...).map(<OBJ>)` | `needs_new_transform_substring_slice` | false | n.json |
+| `split-map-3` | 6 | `.split(STR).map(<OBJ>)` | `existing_transforms` | false | assimp.json |
 | `arr-4` | 6 | `(... ? ... : ARR)` | `needs_new_transform_conditional_split` | false | bun.json |
 | `includes-with-fig-refs` | 6 | `(.includes(STR) ? ... : ...)` | `hand_audit_required` | true | chezmoi.json |
-| `me-fn-with-fig-refs` | 6 | `me(...,...,...,FN)` | `hand_audit_required` | true | pnpx.json |
+| `me-with-fig-refs` | 6 | `me(...,...,...,<>)` | `hand_audit_required` | true | pnpx.json |
+| `split-map-parse-2` | 6 | `.split(STR).map(<JSON.parse(...)>).map(<OBJ>)` | `existing_transforms` | false | podman.json |
+| `parse-map-split` | 6 | `JSON.parse(...).PROP.PROP.map(<.split(STR)[COMPUTED]>)` | `needs_dotted_path_json_extract` | false | scarb.json |
 | `trim-split-map` | 5 | `.trim().split(STR)[COMPUTED].split(STR)[COMPUTED].split(STR)[COMPUTED].split(...` | `existing_transforms` | false | bat.json |
-| `fe-fn-with-fig-refs` | 5 | `Fe(...,...,...,FN)` | `hand_audit_required` | true | bun.json |
-| `from-map-2` | 5 | `Array.from(...).map(FN)` | `existing_transforms` | false | envchain.json |
-| `j-fn-with-fig-refs` | 5 | `j(...,...,...,FN)` | `hand_audit_required` | true | file.json |
-| `filter-map-with-fig-refs` | 5 | `await c(STR,...,...,STR).filter(FN).map(FN)` | `hand_audit_required` | true | kitty.json |
+| `fe-with-fig-refs` | 5 | `Fe(...,...,...,<>)` | `hand_audit_required` | true | bun.json |
+| `from-map-2` | 5 | `Array.from(...).map(<OBJ>)` | `existing_transforms` | false | envchain.json |
+| `filter-trim-tolowercase-startswith-map-with-fig-refs` | 5 | `await c(STR,...,...,STR).filter(<(.trim().toLowerCase().startsWith(STR) && .....` | `hand_audit_required` | true | kitty.json |
 | `unknown-8` | 5 | `...` | `requires_runtime` | false | wd.json |
-| `fe-fn-with-fig-refs-2` | 4 | `fe(...,...,...,FN)` | `hand_audit_required` | true | dotnet.json |
+| `fe-with-fig-refs-2` | 4 | `fe(...,...,...,<>)` | `hand_audit_required` | true | dotnet.json |
 | `parse-map-with-fig-refs` | 4 | `(... ? ARR : JSON.parse(...).map(...))` | `hand_audit_required` | true | gh.json |
 | `empty-4` | 4 | `` | `needs_new_transform_conditional_split` | false | ipatool.json |
 | `arr-5` | 4 | `ARR` | `needs_new_transform_conditional_split` | false | kubecolor.json |
 | `typewithoutname-with-fig-refs-2` | 4 | `.typeWithoutName(STR)` | `hand_audit_required` | true | kubecolor.json |
 | `arr-6` | 4 | `ARR` | `requires_runtime` | false | make.json |
-| `keys-map-3` | 4 | `Object.keys(...).map(FN)` | `requires_runtime` | false | projj.json |
-| `t-fn-with-fig-refs` | 4 | `T(...,...,...,FN)` | `hand_audit_required` | true | scc.json |
-| `filter-map-with-fig-refs-2` | 4 | `await d(STR,...,...,STR).filter(FN).map(FN)` | `hand_audit_required` | true | scp.json |
+| `keys-map-3` | 4 | `Object.keys(...).map(<OBJ>)` | `requires_runtime` | false | projj.json |
+| `t-q-with-fig-refs` | 4 | `T(...,...,...,<q(...,...)>)` | `hand_audit_required` | true | scc.json |
+| `filter-trim-tolowercase-startswith-map-with-fig-refs-2` | 4 | `await d(STR,...,...,STR).filter(<(.trim().toLowerCase().startsWith(STR) && .....` | `hand_audit_required` | true | scp.json |
+| `j-q-with-fig-refs` | 4 | `j(...,...,...,<q(...,...,...,...)>)` | `hand_audit_required` | true | swift.json |
 | `empty-with-fig-refs-3` | 3 | `` | `hand_audit_required` | true | cargo.json |
-| `te-fn-with-fig-refs` | 3 | `Te(...,...,...,FN)` | `hand_audit_required` | true | chezmoi.json |
+| `te-arr-with-fig-refs` | 3 | `Te(...,...,...,<((... && ...) ? ... : ARR)>)` | `hand_audit_required` | true | chezmoi.json |
 | `includes` | 3 | `((.includes(STR) \|\| .includes(STR)) ? ARR : ARR)` | `needs_new_transform_conditional_split` | false | chezmoi.json |
-| `filter` | 3 | `.filter(FN)` | `needs_new_transform_substring_slice` | false | chezmoi.json |
+| `filter-has` | 3 | `.filter(<(.has(...) ? ... : ...)>)` | `needs_new_transform_substring_slice` | false | chezmoi.json |
 | `unknown-with-fig-refs-6` | 3 | `...` | `hand_audit_required` | true | dd.json |
-| `x-fn-with-fig-refs` | 3 | `x(...,...,...,FN)` | `hand_audit_required` | true | deno.json |
+| `x-j-with-fig-refs` | 3 | `x(...,...,...,<j(...,...)>)` | `hand_audit_required` | true | deno.json |
 | `o-arr-with-fig-refs` | 3 | `o(...,ARR)` | `hand_audit_required` | true | git-flow.json |
 | `arr-7` | 3 | `ARR` | `requires_runtime` | false | goto.json |
 | `d-with-fig-refs` | 3 | `d(...)` | `hand_audit_required` | true | just.json |
 | `unknown-with-fig-refs-7` | 3 | `...` | `hand_audit_required` | true | nx.json |
 | `resolve-with-fig-refs` | 3 | `Promise.resolve(...)` | `hand_audit_required` | true | oxlint.json |
-| `ye-fn-with-fig-refs` | 3 | `ye(...,...,...,FN)` | `hand_audit_required` | true | pm2.json |
-| `parse-map-6` | 3 | `JSON.parse(...).map(FN)` | `existing_transforms` | false | watson.json |
-| `keys-map-4` | 2 | `Object.keys(...).map(FN)` | `existing_transforms` | false | ansible-doc.json |
-| `g-fn-with-fig-refs` | 2 | `G(...,...,...,FN)` | `hand_audit_required` | true | bun.json |
-| `g-fn-with-fig-refs-2` | 2 | `G(...,...,...,FN)` | `hand_audit_required` | true | bun.json |
-| `trim-split-slice-map-with-fig-refs` | 2 | `.trim().split(STR).slice(NUM).map(FN)` | `hand_audit_required` | true | cap.json |
+| `ye-with-fig-refs` | 3 | `ye(...,...,...,<>)` | `hand_audit_required` | true | pm2.json |
+| `parse-map-8` | 3 | `JSON.parse(...).map(<OBJ>)` | `existing_transforms` | false | watson.json |
+| `keys-map-4` | 2 | `Object.keys(...).map(<OBJ>)` | `existing_transforms` | false | ansible-doc.json |
+| `g-te-with-fig-refs` | 2 | `G(...,...,...,<te(...,...)>)` | `hand_audit_required` | true | bun.json |
+| `g-te-with-fig-refs-2` | 2 | `G(...,...,...,<te(...,...)>)` | `hand_audit_required` | true | bun.json |
+| `trim-split-slice-map-with-fig-refs` | 2 | `.trim().split(STR).slice(NUM).map(<OBJ>)` | `hand_audit_required` | true | cap.json |
 | `empty-with-fig-refs-4` | 2 | `` | `hand_audit_required` | true | dcli.json |
+| `split-map-parse-3` | 2 | `.split(STR).map(<JSON.parse(...)>).map(<...>)` | `existing_transforms` | false | docker.json |
+| `a-g-with-fig-refs` | 2 | `A(...,...,...,<G(...,...,...,...)>)` | `hand_audit_required` | true | gh.json |
 | `unknown-9` | 2 | `...` | `existing_transforms` | false | lerna.json |
-| `he-fn-with-fig-refs` | 2 | `he(...,...,...,FN)` | `hand_audit_required` | true | limactl.json |
-| `q-fn-with-fig-refs` | 2 | `q(...,...,...,FN)` | `hand_audit_required` | true | osqueryi.json |
-| `entries-map-reduce-with-fig-refs` | 2 | `Object.entries(...).map(FN).reduce(FN,ARR).map(FN)` | `hand_audit_required` | true | pnpx.json |
-| `parse-map-7` | 2 | `JSON.parse(...).map(FN)` | `requires_runtime` | false | shadcn-ui.json |
-| `map-with-fig-refs-2` | 2 | `(... ? .PROP.PROP.map(FN) : ARR)` | `hand_audit_required` | true | spring.json |
-| `values-map-with-fig-refs` | 2 | `Object.values(...).map(FN)` | `hand_audit_required` | true | tailscale.json |
-| `we-fn-with-fig-refs` | 2 | `we(...,...,...,FN)` | `hand_audit_required` | true | vsce.json |
+| `he-with-fig-refs` | 2 | `he(...,...,...,<>)` | `hand_audit_required` | true | limactl.json |
+| `q-j-with-fig-refs` | 2 | `q(...,...,...,<j(...,...)>)` | `hand_audit_required` | true | osqueryi.json |
+| `entries-map-reduce-with-fig-refs` | 2 | `Object.entries(...).map(<...>).reduce(<ARR>,ARR).map(<OBJ>)` | `hand_audit_required` | true | pnpx.json |
+| `parse-map-9` | 2 | `JSON.parse(...).map(<OBJ>)` | `requires_runtime` | false | shadcn-ui.json |
+| `map-with-fig-refs-2` | 2 | `(... ? .PROP.PROP.map(<OBJ>) : ARR)` | `hand_audit_required` | true | spring.json |
+| `values-map-with-fig-refs` | 2 | `Object.values(...).map(<OBJ>)` | `hand_audit_required` | true | tailscale.json |
+| `we-with-fig-refs` | 2 | `we(...,...,...,<>)` | `hand_audit_required` | true | vsce.json |
 | `arr-8` | 2 | `ARR` | `existing_transforms` | false | yarn.json |
-| `i-fn-with-fig-refs` | 1 | `I(...,...,...,FN)` | `hand_audit_required` | true | airflow.json |
-| `slice-some-map` | 1 | `(.slice(NUM,...).some(FN) ? ARR.map(FN) : ARR.map(FN))` | `needs_new_transform_substring_slice` | false | brew.json |
+| `i-h-with-fig-refs` | 1 | `I(...,...,...,<H(...,...)>)` | `hand_audit_required` | true | airflow.json |
+| `slice-some-map` | 1 | `(.slice(NUM,...).some(<...>) ? ARR.map(<OBJ>) : ARR.map(<OBJ>))` | `needs_new_transform_substring_slice` | false | brew.json |
 | `arr-with-fig-refs-3` | 1 | `ARR` | `hand_audit_required` | true | cargo.json |
 | `startswith-with-fig-refs` | 1 | `((... \|\| ...) ? ... : (.startsWith(STR) ? ... : ...))` | `hand_audit_required` | true | chezmoi.json |
-| `d-fn-with-fig-refs` | 1 | `D(...,...,...,FN)` | `hand_audit_required` | true | codesign.json |
+| `d-c-with-fig-refs` | 1 | `D(...,...,...,<C(...,...)>)` | `hand_audit_required` | true | codesign.json |
 | `empty-5` | 1 | `` | `requires_runtime` | false | dapr.json |
-| `parse-map-8` | 1 | `JSON.parse(...).map(FN)` | `requires_runtime` | false | degit.json |
-| `entries-map-with-fig-refs` | 1 | `(... ? ARR : Object.entries(...).map(FN))` | `hand_audit_required` | true | deno.json |
-| `parse-map-9` | 1 | `JSON.parse(...).PROP.map(FN)` | `existing_transforms` | false | deno.json |
-| `map` | 1 | `.PROP.map(FN)` | `existing_transforms` | false | deployctl.json |
-| `includes-map-with-fig-refs` | 1 | `(.includes(...) ? [COMPUTED].map(FN) : ARR)` | `hand_audit_required` | true | dscacheutil.json |
+| `parse-map-10` | 1 | `JSON.parse(...).map(<OBJ>)` | `requires_runtime` | false | degit.json |
+| `entries-map-with-fig-refs` | 1 | `(... ? ARR : Object.entries(...).map(<OBJ>))` | `hand_audit_required` | true | deno.json |
+| `parse-map-11` | 1 | `JSON.parse(...).PROP.map(<OBJ>)` | `existing_transforms` | false | deno.json |
+| `map` | 1 | `.PROP.map(<OBJ>)` | `existing_transforms` | false | deployctl.json |
+| `includes-map-with-fig-refs` | 1 | `(.includes(...) ? [COMPUTED].map(<OBJ>) : ARR)` | `hand_audit_required` | true | dscacheutil.json |
 | `unknown-with-fig-refs-8` | 1 | `(...)(...,...)` | `hand_audit_required` | true | dscacheutil.json |
-| `startswith-keys-map` | 1 | `((... \|\| [COMPUTED].startsWith(STR)) ? Object.keys(...).map(FN) : ARR)` | `needs_new_transform_conditional_split` | false | echo.json |
-| `values-map` | 1 | `Object.values(...).map(FN)` | `existing_transforms` | false | env.json |
-| `k-fn-with-fig-refs-2` | 1 | `k(...,...,...,FN)` | `hand_audit_required` | true | esbuild.json |
+| `startswith-keys-map` | 1 | `((... \|\| [COMPUTED].startsWith(STR)) ? Object.keys(...).map(<OBJ>) : ARR)` | `needs_new_transform_conditional_split` | false | echo.json |
+| `values-map` | 1 | `Object.values(...).map(<OBJ>)` | `existing_transforms` | false | env.json |
+| `k-w-with-fig-refs-2` | 1 | `k(...,...,...,<W(...,...)>)` | `hand_audit_required` | true | esbuild.json |
+| `j-p-with-fig-refs` | 1 | `j(...,...,...,<P(...,...,...,...)>)` | `hand_audit_required` | true | file.json |
 | `isnan-isinteger` | 1 | `(Number.isNaN(...) ? ARR : (Number.isInteger(...) ? ((... \|\| ...) ? ARR : ARR...` | `needs_new_transform_conditional_split` | false | firefox.json |
-| `map-with-fig-refs-3` | 1 | `h(ARR,FN).map(FN)` | `hand_audit_required` | true | fnm.json |
-| `map-reverse-with-fig-refs` | 1 | `ARR.map(FN).reverse()` | `hand_audit_required` | true | fvm.json |
+| `map-with-fig-refs-3` | 1 | `h(ARR,<...>).map(<((.PROP && ...) ? OBJ : OBJ)>)` | `hand_audit_required` | true | fnm.json |
+| `map-reverse-with-fig-refs` | 1 | `ARR.map(<OBJ>).reverse()` | `hand_audit_required` | true | fvm.json |
 | `arr-9` | 1 | `ARR` | `needs_new_transform_substring_slice` | false | git-cliff.json |
-| `filter-map-2` | 1 | `.filter(FN).map(FN)` | `requires_runtime` | false | j.json |
+| `filter-every-includes-map` | 1 | `.filter(<.every(<.includes(...)>)>).map(<>)` | `requires_runtime` | false | j.json |
 | `unknown-10` | 1 | `...` | `needs_new_transform_regex_match` | false | kill.json |
-| `trim-split-map-2` | 1 | `.trim().split(STR).map(FN)` | `needs_new_transform_substring_slice` | false | killall.json |
-| `map-2` | 1 | `ARR.map(FN)` | `existing_transforms` | false | lsof.json |
-| `map-3` | 1 | `.map(FN)` | `needs_new_transform_regex_match` | false | lsof.json |
-| `map-4` | 1 | `.map(FN)` | `needs_new_transform_conditional_split` | false | lsof.json |
-| `f-fn-with-fig-refs` | 1 | `F(...,...,...,FN)` | `hand_audit_required` | true | man.json |
+| `trim-split-map-2` | 1 | `.trim().split(STR).map(<OBJ>)` | `needs_new_transform_substring_slice` | false | killall.json |
+| `map-2` | 1 | `ARR.map(<OBJ>)` | `existing_transforms` | false | lsof.json |
+| `map-3` | 1 | `.map(<OBJ>)` | `needs_new_transform_regex_match` | false | lsof.json |
+| `map-4` | 1 | `.map(<OBJ>)` | `needs_new_transform_conditional_split` | false | lsof.json |
+| `f-e-with-fig-refs` | 1 | `F(...,...,...,<E(...,...)>)` | `hand_audit_required` | true | man.json |
 | `get-with-fig-refs` | 1 | `(.get(...) \|\| ARR)` | `hand_audit_required` | true | man.json |
-| `split-filter-map` | 1 | `.split(STR).filter(FN).map(FN)` | `requires_runtime` | false | mdfind.json |
+| `split-filter-endswith-map` | 1 | `.split(STR).filter(<.endsWith(STR)>).map(<OBJ>)` | `requires_runtime` | false | mdfind.json |
 | `arr-arr-2` | 1 | `(... ? ARR : ARR)` | `needs_new_transform_substring_slice` | false | nx.json |
-| `parse-map-with-fig-refs-2` | 1 | `JSON.parse(...).map(FN)` | `hand_audit_required` | true | op.json |
-| `ln-fn-with-fig-refs` | 1 | `ln(...,...,...,FN)` | `hand_audit_required` | true | pipenv.json |
+| `parse-map-with-fig-refs-2` | 1 | `JSON.parse(...).map(<OBJ>)` | `hand_audit_required` | true | op.json |
+| `ln-with-fig-refs` | 1 | `ln(...,...,...,<>)` | `hand_audit_required` | true | pipenv.json |
 | `unknown-with-fig-refs-9` | 1 | `(...)(...,...)` | `hand_audit_required` | true | pkgutil.json |
 | `arr-with-fig-refs-4` | 1 | `ARR` | `hand_audit_required` | true | rich.json |
-| `map-5` | 1 | `ARR.map(FN).map(FN)` | `requires_runtime` | false | robot.json |
-| `keys-reduce` | 1 | `Object.keys(...).reduce(FN,ARR)` | `existing_transforms` | false | sake.json |
-| `t-fn-with-fig-refs-2` | 1 | `T(...,...,...,FN)` | `hand_audit_required` | true | scc.json |
-| `flatmap-filter-sort-map-with-fig-refs` | 1 | `.PROP.PROP.flatMap(FN).filter(FN).sort(FN).map(FN)` | `hand_audit_required` | true | spring.json |
-| `split-filter-map-with-fig-refs` | 1 | `.split(STR).filter(FN).map(FN)` | `hand_audit_required` | true | tldr.json |
-| `map-with-fig-refs-4` | 1 | `ARR.map(FN)` | `hand_audit_required` | true | trap.json |
-| `pe-fn-with-fig-refs-2` | 1 | `Pe(...,...,...,FN)` | `hand_audit_required` | true | ts-node.json |
-| `entries-map-with-fig-refs-2` | 1 | `Object.entries(...).map(FN)` | `hand_audit_required` | true | turbo.json |
-| `trim-slice-split-filter-map` | 1 | `.trim().slice(NUM,...).split(STR).filter(FN).map(FN)` | `needs_new_transform_substring_slice` | false | v.json |
+| `map-5` | 1 | `ARR.map(<[COMPUTED]>).map(<OBJ>)` | `requires_runtime` | false | robot.json |
+| `keys-reduce` | 1 | `Object.keys(...).reduce(<ARR>,ARR)` | `existing_transforms` | false | sake.json |
+| `t-q-with-fig-refs-2` | 1 | `T(...,...,...,<q(...,...)>)` | `hand_audit_required` | true | scc.json |
+| `flatmap-filter-sort-localecompare-map-with-fig-refs` | 1 | `.PROP.PROP.flatMap(<...>).filter(<...>).sort(<.PROP.localeCompare(...)>).map(...` | `hand_audit_required` | true | spring.json |
+| `split-filter-test-map-with-fig-refs` | 1 | `.split(STR).filter(<.test(...)>).map(<OBJ>)` | `hand_audit_required` | true | tldr.json |
+| `map-with-fig-refs-4` | 1 | `ARR.map(<OBJ>)` | `hand_audit_required` | true | trap.json |
+| `pe-with-fig-refs-2` | 1 | `Pe(...,...,...,<>)` | `hand_audit_required` | true | ts-node.json |
+| `entries-map-with-fig-refs-2` | 1 | `Object.entries(...).map(<...>)` | `hand_audit_required` | true | turbo.json |
+| `trim-slice-split-filter-map` | 1 | `.trim().slice(NUM,...).split(STR).filter(<...>).map(<OBJ>)` | `needs_new_transform_substring_slice` | false | v.json |
 | `arr-10` | 1 | `ARR` | `requires_runtime` | false | yarn.json |
-| `map-6` | 1 | `ARR.map(FN)` | `needs_new_transform_conditional_split` | false | ykman.json |
-| `split-slice-map` | 1 | `.split(STR).slice(NUM).map(FN)` | `requires_runtime` | false | youtube-dl.json |
+| `map-6` | 1 | `ARR.map(<OBJ>)` | `needs_new_transform_conditional_split` | false | ykman.json |
+| `split-slice-map` | 1 | `.split(STR).slice(NUM).map(<OBJ>)` | `requires_runtime` | false | youtube-dl.json |
 
 ## Per-Verdict Breakdown (Top 5 Shapes Each)
 
-### `hand_audit_required` (866 generators, 79 shapes)
+### `hand_audit_required` (866 generators, 81 shapes)
 
 - **`arr-with-fig-refs`** (69): `ARR`
-- **`startswith-split-map-with-fig-refs`** (68): `(.startsWith(STR) ? ARR : .split(STR).map(FN))`
+- **`startswith-split-map-with-fig-refs`** (68): `(.startsWith(STR) ? ARR : .split(STR).map(<OBJ>))`
 - **`unknown-with-fig-refs`** (65): `...`
-- **`ue-fn-with-fig-refs`** (51): `ue(...,...,...,FN)`
-- **`map-with-fig-refs`** (45): `o(...).map(FN)`
+- **`ue-with-fig-refs`** (51): `ue(...,...,...,<>)`
+- **`map-with-fig-refs`** (45): `o(...).map(<OBJ>)`
 
-### `existing_transforms` (614 generators, 29 shapes)
+### `existing_transforms` (614 generators, 32 shapes)
 
-- **`parse-map`** (174): `JSON.parse(...).map(FN)`
-- **`split-map`** (63): `.split(STR).map(FN).map(FN)`
+- **`parse-map`** (174): `JSON.parse(...).map(<OBJ>)`
+- **`split-map-parse`** (63): `.split(STR).map(<JSON.parse(...)>).map(<OBJ>)`
 - **`empty`** (50): ``
-- **`parse-map-2`** (50): `JSON.parse(...).map(FN)`
 - **`arr`** (44): `ARR`
+- **`parse-map-2`** (42): `JSON.parse(...).map(<.PROP>)`
 
 ### `requires_runtime` (162 generators, 19 shapes)
 
 - **`unknown-2`** (58): `...`
 - **`unknown-4`** (22): `...`
 - **`empty-3`** (16): ``
-- **`trim-split-filter-map`** (15): `.trim().split(STR).filter(FN).map(FN)`
-- **`split-map-2`** (11): `.split(STR).map(FN).map(FN)`
+- **`trim-split-filter-map`** (15): `.trim().split(STR).filter(<(... && ...)>).map(<OBJ>)`
+- **`split-map`** (11): `.split(STR).map(<.split(STR)>).map(<OBJ>)`
 
 ### `needs_new_transform_conditional_split` (148 generators, 11 shapes)
 
 - **`unknown`** (73): `...`
-- **`keys-map`** (38): `Object.keys(...).map(FN)`
+- **`keys-map`** (38): `Object.keys(...).map(<...>)`
 - **`arr-arr`** (16): `(... ? ARR : ARR)`
 - **`arr-4`** (6): `(... ? ... : ARR)`
 - **`empty-4`** (4): ``
 
 ### `needs_new_transform_regex_match` (52 generators, 3 shapes)
 
-- **`match-map`** (50): `.match(REGEX).map(FN).map(FN).map(FN)`
+- **`match-map-split-trim`** (50): `.match(REGEX).map(<.split(STR)>).map(<.map(<.trim()>)>).map(<OBJ>)`
 - **`unknown-10`** (1): `...`
-- **`map-3`** (1): `.map(FN)`
+- **`map-3`** (1): `.map(<OBJ>)`
 
 ### `needs_new_transform_substring_slice` (33 generators, 9 shapes)
 
 - **`unknown-5`** (10): `...`
 - **`unknown-6`** (8): `...`
-- **`from-map`** (7): `Array.from(...).map(FN)`
-- **`filter`** (3): `.filter(FN)`
-- **`slice-some-map`** (1): `(.slice(NUM,...).some(FN) ? ARR.map(FN) : ARR.map(FN))`
+- **`from-map`** (7): `Array.from(...).map(<OBJ>)`
+- **`filter-has`** (3): `.filter(<(.has(...) ? ... : ...)>)`
+- **`slice-some-map`** (1): `(.slice(NUM,...).some(<...>) ? ARR.map(<OBJ>) : ARR.map(<OBJ>))`
 
-### `needs_dotted_path_json_extract` (14 generators, 1 shapes)
+### `needs_dotted_path_json_extract` (14 generators, 2 shapes)
 
-- **`parse-map-4`** (14): `JSON.parse(...).PROP.PROP.map(FN)`
+- **`parse-map-6`** (8): `JSON.parse(...).PROP.PROP.map(<OBJ>)`
+- **`parse-map-split`** (6): `JSON.parse(...).PROP.PROP.map(<.split(STR)[COMPUTED]>)`
 

--- a/tools/fig-converter/docs/spike-recount-decision.md
+++ b/tools/fig-converter/docs/spike-recount-decision.md
@@ -94,13 +94,15 @@ Rationale:
 |---|---|
 | `tools/fig-converter/docs/shape-inventory.json` | Post-recount canonical inventory (157 shapes, 1,889 generators) |
 | `tools/fig-converter/docs/shape-inventory.md` | Human-readable bucket table (post-recount) |
-| `tools/fig-converter/docs/candidate-providers.json` | Unchanged by T1/T2 (184 entries, 36 qualifying) |
+| `tools/fig-converter/docs/candidate-providers.json` | 184 entries, **28 qualifying** at HEAD (36 before the T4 authKeywords extension — see §9 for the delta) |
 | `tools/fig-converter/docs/spike-report.md` | Phase 1 report — pre-recount source of truth for §3 |
 
 **Commits:**
 
 - `1d568d0` — feat(fig-converter): descend into .map/.filter callback bodies for fingerprinting
 - `07131c0` — chore: re-run Phase 1 spike with callback-body fingerprinting
+- `c6c4950` — fix(fig-converter): extend authKeywords to catch flyctl/firebase and other auth CLIs (see §9)
+- `38555b9` — chore: re-run Phase 1 spike to apply authKeywords heuristic to candidate-providers (see §9)
 
 ---
 

--- a/tools/fig-converter/docs/spike-recount-decision.md
+++ b/tools/fig-converter/docs/spike-recount-decision.md
@@ -1,0 +1,103 @@
+# Phase 2 Recount Decision — `needs_dotted_path_json_extract`
+
+**Date:** 2026-04-22
+**Branch:** `feature/phase-2-recount`
+**Status:** DONE — Phase 2 go/no-go gate
+
+---
+
+## §1 Executive Summary
+
+Callback-body fingerprint descent produced **zero reclassification** across verdict boundaries. `needs_dotted_path_json_extract` stayed at **14 generators (0.7%)** — the old count was NOT a lower bound in the corpus. The single dotted-path shape bucket carved into 2 variants, and a handful of neighbouring buckets fragmented similarly, but no generator was promoted into the dotted-path verdict from anywhere else. **Recommendation: NO GO on Phase 2; fold the 14 cases into Phase 4 cleanup as a converter extension.**
+
+---
+
+## §2 Methodology
+
+- **T1 fingerprinter change** (commit `1d568d0`): `.map(FN)` / `.filter(FN)` calls now descend into the callback body and emit `.map(<inner>)` / `.filter(<inner>)` where `<inner>` is the recursively fingerprinted body. Prior behaviour was opaque `.map(FN)` regardless of body shape.
+- **T2 spike re-run** (commit `07131c0`): regenerated `shape-inventory.json` and `shape-inventory.md` against the updated fingerprinter. `candidate-providers.json` left untouched (T1/T2 do not affect provider qualification).
+- **Unchanged:** `run-spike.mjs` driver logic, the `assignVerdict` detector, the closed 7-verdict enum, and every heuristic used for `has_fig_api_refs`. Only the fingerprint string changed, which affects shape bucket cardinality, not verdict assignment.
+
+---
+
+## §3 Before / After Bucket Table
+
+| Verdict | Pre (count/%) | Post (count/%) | Shape variants (pre → post) |
+|---|---|---|---|
+| `hand_audit_required` | 866 (45.8%) | 866 (45.8%) | 79 → 81 (+2) |
+| `existing_transforms` | 614 (32.5%) | 614 (32.5%) | 29 → 32 (+3) |
+| `requires_runtime` | 162 (8.6%) | 162 (8.6%) | 19 → 19 |
+| `needs_new_transform_conditional_split` | 148 (7.8%) | 148 (7.8%) | 11 → 11 |
+| `needs_new_transform_regex_match` | 52 (2.8%) | 52 (2.8%) | 3 → 3 |
+| `needs_new_transform_substring_slice` | 33 (1.7%) | 33 (1.7%) | 9 → 9 |
+| `needs_dotted_path_json_extract` | 14 (0.7%) | 14 (0.7%) | 1 → 2 (+1) |
+| **Total** | **1,889 (100%)** | **1,889 (100%)** | **151 → 157 (+6)** |
+
+Pre-recount source: `spike-report.md` §3. Post-recount source: `shape-inventory.json` at HEAD (`07131c0`), verified with `jq`.
+
+---
+
+## §4 Reclassification Analysis
+
+**Zero generators moved across verdict boundaries.** The callback descent carved existing shape buckets more finely; it did not promote any generator from `existing_transforms` (or anywhere else) into `needs_dotted_path_json_extract`.
+
+The two post-recount dotted-path fingerprints are:
+
+1. `JSON.parse(...).PROP.PROP.map(<OBJ>)` — 8 generators
+2. `JSON.parse(...).PROP.PROP.map(<.split(STR)[COMPUTED]>)` — 6 generators
+
+Both have `JSON.parse(...).PROP.PROP` on the **outer** chain — already detected pre-T1 as a dotted-path signal by the verdict rules. The T1 descent only split the single pre-existing `JSON.parse(...).PROP.PROP.map(FN)` bucket (14 generators, 1 variant) by callback body shape, turning 1 variant into 2 while leaving total count fixed.
+
+Crucially, T1 did NOT surface any `JSON.parse`-inside-callback patterns elsewhere. Spike finding 3 hypothesised that buckets like `.split().map(x => JSON.parse(x).a.b)` might be hiding in `existing_transforms`. If any such shapes existed, the descent would have emitted `.map(<JSON.parse(...).PROP.PROP>)` fingerprints and the verdict detector would have routed them to the dotted-path bucket. Since `existing_transforms` held steady at 614 generators and the dotted-path bucket held steady at 14, those shapes do not exist in any material quantity in the 1,889-generator corpus.
+
+---
+
+## §5 Phase 2 Go/No-Go
+
+Decision rubric (plan §1.4 + spike §6):
+
+- ≥20% of total → GO as standalone Phase 2.
+- 5–20% → CONDITIONAL — keep scheduled, down-scope to 3 days.
+- <5% → NO GO — fold into `existing_transforms` as a converter fix, absorb into Phase 4 cleanup.
+
+14 / 1,889 = **0.74%** — well below the 5% threshold. **Recommendation: NO GO.**
+
+Rationale:
+
+- The old 14-count was not a lower bound. Spike finding 3's prediction did not hold against the corpus.
+- Callback descent was the principled way to test the hypothesis; it returned negative with zero cross-verdict movement.
+- The 14 cases fit the existing `json_extract` transform extension pattern — they need a dotted-path modifier, not a new transform class.
+- A dedicated 3-day Phase 2 build-out for 0.7% of the corpus is disproportionate infrastructure cost for marginal coverage.
+- Phase 4 cleanup is the natural home for a narrow converter extension covering the 2 identified shape variants.
+
+---
+
+## §6 Other Findings Surfaced by the Recount
+
+- **`hand_audit_required` variants 79 → 81 (+2).** Reflects callback descent on fig-api-containing generators; the inner shapes now differ where they previously collapsed into `.map(FN)`. Triage priority unchanged — these still require manual audit.
+- **`existing_transforms` variants 29 → 32 (+3).** The descent surfaced shape groupings previously indistinguishable. Candidates for converter-fix hardening in Phase 4 — the new variants may reveal tighter code-gen opportunities.
+- **No new shapes emerged outside existing verdict buckets.** All six new variants landed inside verdicts that already existed pre-T1. The verdict enum remains closed at 7.
+
+---
+
+## §7 Next Actions
+
+- **Phase 2:** CLOSE as "skipped per recount." Umbrella PR #75 checklist update is a separate step (session-close housekeeping, not this doc).
+- **Phase 4:** absorb the 14 dotted-path cases as a small converter extension in `post-process-matcher.js` (or equivalent). Targeted extension to emit `json_extract` with dotted-path support for the 2 identified shape variants. Expected diff: small. Bench/binary impact: negligible.
+- **T4 (authKeywords):** independent of the Phase 2 decision; proceeds this session per plan.
+
+---
+
+## §8 Artifact Pointers
+
+| Artifact | Description |
+|---|---|
+| `tools/fig-converter/docs/shape-inventory.json` | Post-recount canonical inventory (157 shapes, 1,889 generators) |
+| `tools/fig-converter/docs/shape-inventory.md` | Human-readable bucket table (post-recount) |
+| `tools/fig-converter/docs/candidate-providers.json` | Unchanged by T1/T2 (184 entries, 36 qualifying) |
+| `tools/fig-converter/docs/spike-report.md` | Phase 1 report — pre-recount source of truth for §3 |
+
+**Commits:**
+
+- `1d568d0` — feat(fig-converter): descend into .map/.filter callback bodies for fingerprinting
+- `07131c0` — chore: re-run Phase 1 spike with callback-body fingerprinting

--- a/tools/fig-converter/docs/spike-recount-decision.md
+++ b/tools/fig-converter/docs/spike-recount-decision.md
@@ -101,3 +101,30 @@ Rationale:
 
 - `1d568d0` — feat(fig-converter): descend into .map/.filter callback bodies for fingerprinting
 - `07131c0` — chore: re-run Phase 1 spike with callback-body fingerprinting
+
+---
+
+## §9 Candidate-providers post-authKeywords update
+
+**Date:** 2026-04-22 (same-session follow-up to T4)
+
+After T4 extended `authKeywords` with 13 new brand keywords (flyctl, firebase, tsh, pulumi, amplify, stepzen, deployctl, bosh, and related terms), the Phase 1 spike driver was re-run to propagate the heuristic into `candidate-providers.json`. The Phase 2 rubric count for `needs_dotted_path_json_extract` remains **unchanged at 14** (see §5) — T4 did not touch fingerprinting and `shape-inventory.json` was byte-identical to the T2 artifact (sha256 `5326b8ce…53af40`). The qualifying-candidates change affects **Phase 3A only** — it drops 8 auth-required false positives from the provider candidate list. The Phase 3A gate (≥4 viable candidates) is still met with ample margin.
+
+**Qualifying-candidate count:** 36 → **28** (−8).
+
+**Newly disqualified** (all dropped for matching extended `authKeywords`, so `needs_auth` now flips to `true`):
+
+1. `amplify` — AWS Amplify CLI (cloud auth)
+2. `bosh` — Cloud Foundry BOSH director (director auth)
+3. `deployctl` — Deno Deploy CLI (account auth)
+4. `firebase` — Firebase CLI (Google account auth)
+5. `flyctl` — Fly.io CLI (account auth)
+6. `pulumi` — Pulumi state backend (account/backend auth)
+7. `stepzen` — StepZen GraphQL CLI (account auth)
+8. `tsh` — Teleport `tsh` (cluster auth)
+
+Drop list matches T4's pre-run prediction exactly — no unexpected additions. Final qualifying list of 28 commands is captured in `candidate-providers.json` at HEAD.
+
+**Commit:**
+
+- `<T5 sha>` — chore: re-run Phase 1 spike to apply authKeywords heuristic to candidate-providers

--- a/tools/fig-converter/scripts/run-spike.mjs
+++ b/tools/fig-converter/scripts/run-spike.mjs
@@ -233,7 +233,22 @@ function qualifyCommand(command, members) {
   const allScripts = scriptCommands.join(' ').toLowerCase();
   const commandLower = command.toLowerCase();
 
-  const authKeywords = ['oauth', 'login', 'token', 'saml', 'auth', 'credential', 'secret', 'api-key', 'apikey'];
+  // Brand keywords for CLIs whose PRIMARY function requires auth (flyctl, firebase,
+  // tsh/teleport, pulumi, amplify, stepzen, deployctl, bosh). Added because the
+  // generic substrings above (oauth/login/token/...) miss brand-only matches.
+  // See spike-report.md §9 question 3.
+  const authKeywords = [
+    'oauth', 'login', 'token', 'saml', 'auth', 'credential', 'secret',
+    'api-key', 'apikey',
+    'flyctl', 'flyc', 'fly.io',
+    'firebase', 'firebase-tools',
+    'tsh', 'teleport',
+    'pulumi',
+    'amplify',
+    'stepzen',
+    'deployctl', 'deno-deploy',
+    'bosh',
+  ];
   const noAuth = !authKeywords.some(kw => commandLower.includes(kw) || allScripts.includes(kw));
 
   const paginationKeywords = ['--page', '--limit', '--offset', '--cursor', 'pagination', 'paginate'];
@@ -581,7 +596,14 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+// Guarded CLI entry point — only runs when invoked directly (not when
+// imported from tests). Exports below let tests unit-test qualifyCommand
+// without triggering the spike walk.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+export { qualifyCommand };

--- a/tools/fig-converter/src/ast-analyzer.js
+++ b/tools/fig-converter/src/ast-analyzer.js
@@ -752,7 +752,36 @@ function fingerprintCallChain(node) {
 
 /** Summarise a call's argument list as a comma-separated placeholder list. */
 function argsToken(args) {
-  return args.map(leafToken).join(',');
+  return args.map(argToken).join(',');
+}
+
+/**
+ * Map a single call-argument node to its fingerprint token.
+ *
+ * Arrow/function callbacks (e.g. `.map(x => JSON.parse(x).foo.bar)`) used to
+ * collapse to the opaque `FN` token, which hid dotted-path patterns inside
+ * higher-order function bodies (Phase 1 spike finding 3: the
+ * `needs_dotted_path_json_extract` count was a lower bound). We now descend
+ * into the callback body via `fingerprintExpression` and emit
+ * `.map(<inner>)`, where <inner> is the body's fingerprint.
+ *
+ * Trivial bodies are pinned deterministically:
+ *   - empty body (e.g. `() => {}`) → `<>`
+ *   - identity body (e.g. `x => x`) → `<...>`
+ *
+ * Plain identifier callbacks like `.filter(Boolean)` continue to fingerprint
+ * exactly as before — they stay in `leafToken` and never descend.
+ */
+function argToken(node) {
+  if (
+    node &&
+    (node.type === 'ArrowFunctionExpression' ||
+      node.type === 'FunctionExpression')
+  ) {
+    const inner = fingerprintExpression(node);
+    return '<' + inner + '>';
+  }
+  return leafToken(node);
 }
 
 /** Map a leaf node to its placeholder token. */

--- a/tools/fig-converter/src/ast-analyzer.test.js
+++ b/tools/fig-converter/src/ast-analyzer.test.js
@@ -197,8 +197,10 @@ describe('analyzeGenerator — shape fingerprint', () => {
     assert.equal(a.parse_error, null);
     assert.equal(b.parse_error, null);
     assert.equal(a.shape.fingerprint, b.shape.fingerprint);
-    // And it should be the canonical form.
-    assert.equal(a.shape.fingerprint, '.split(STR).filter(FN).map(FN)');
+    // And it should be the canonical form. Phase-2 recount: arrow callbacks
+    // now descend into their body — `e => ({name: e})` has an ObjectExpression
+    // body, so `.map(<OBJ>)` replaces the old `.map(FN)` shape.
+    assert.equal(a.shape.fingerprint, '.split(STR).filter(FN).map(<OBJ>)');
   });
 
   it('case 12: JSON.parse with property chain produces a documented fingerprint', () => {
@@ -277,5 +279,65 @@ describe('analyzeGenerator — shape fingerprint', () => {
     const result = analyzeGenerator(`(out) => out.split("\\n")`);
     assert.equal(result.parse_error, null);
     assert.equal(result.shape.has_json_parse, false);
+  });
+});
+
+describe('analyzeGenerator — callback-body fingerprint descent (Phase 2 recount)', () => {
+  // Phase 1 spike finding 3: `.map(FN)` hid dotted-path patterns inside
+  // higher-order-function callbacks, so `needs_dotted_path_json_extract`
+  // was undercounted. Arrow / function callbacks now descend into their
+  // body and emit `.map(<inner>)`.
+
+  it('descends into .map callback body and surfaces dotted JSON.parse path', () => {
+    const src = `(out) => out.split("\\n").map(line => JSON.parse(line).metadata.id)`;
+    const result = analyzeGenerator(src);
+    assert.equal(result.parse_error, null);
+    // Sanity: Pass-2 visitor still fires for symbols inside callbacks.
+    assert.equal(result.shape.has_json_parse, true);
+    // Pin exact fingerprint: dotted path nested inside .map(<...>).
+    assert.equal(
+      result.shape.fingerprint,
+      '.split(STR).map(<JSON.parse(...).PROP.PROP>)'
+    );
+  });
+
+  it('identity callback after .filter(Boolean) produces .map(<...>)', () => {
+    // identity callback descent yields <...>; doesn't add signal.
+    const src = `(out) => out.split("\\n").filter(Boolean).map(x => x)`;
+    const result = analyzeGenerator(src);
+    assert.equal(result.parse_error, null);
+    assert.equal(
+      result.shape.fingerprint,
+      '.split(STR).filter(FN).map(<...>)'
+    );
+  });
+
+  it('async callback preserves has_await AND descends into the body', () => {
+    const src = `(out) => out.split("\\n").map(async x => await ctx.run(x))`;
+    const result = analyzeGenerator(src);
+    assert.equal(result.parse_error, null);
+    // Pass-2 has_await flag unchanged.
+    assert.equal(result.shape.has_await, true);
+    // Pin exact fingerprint: `await ...` visible inside .map(<...>).
+    assert.equal(
+      result.shape.fingerprint,
+      '.split(STR).map(<await .run(...)>)'
+    );
+  });
+
+  it('plain identifier callback .map(Boolean) still fingerprints as .map(FN)', () => {
+    // Regression guard: descent is gated on ArrowFunctionExpression /
+    // FunctionExpression. Plain Identifiers stay in `leafToken`.
+    const src = `(out) => out.split("\\n").map(Boolean)`;
+    const result = analyzeGenerator(src);
+    assert.equal(result.parse_error, null);
+    assert.equal(result.shape.fingerprint, '.split(STR).map(FN)');
+  });
+
+  it('fingerprint is deterministic across repeated analyses', () => {
+    const src = `(out) => out.split("\\n").map(line => JSON.parse(line).metadata.id)`;
+    const a = analyzeGenerator(src).shape.fingerprint;
+    const b = analyzeGenerator(src).shape.fingerprint;
+    assert.equal(a, b);
   });
 });

--- a/tools/fig-converter/src/run-spike.test.js
+++ b/tools/fig-converter/src/run-spike.test.js
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { qualifyCommand } from '../scripts/run-spike.mjs';
+
+// Regression suite for the authKeywords heuristic in qualifyCommand.
+// See spike-report.md §9 question 3 — the pre-extension list missed
+// brand-only command names like `flyctl`, `firebase`, `pulumi`, etc.
+describe('qualifyCommand — authKeywords heuristic', () => {
+  it('flags flyctl as auth-requiring (brand match on command name)', () => {
+    const result = qualifyCommand('flyctl', [
+      { gen: { script: 'fly auth list' }, verdict: 'existing_transforms' },
+    ]);
+    assert.equal(result.qualification.no_auth, false);
+  });
+
+  it('flags firebase as auth-requiring (brand match on command name)', () => {
+    const result = qualifyCommand('firebase', [
+      { gen: { script: 'firebase deploy' }, verdict: 'existing_transforms' },
+    ]);
+    assert.equal(result.qualification.no_auth, false);
+  });
+
+  it('flags pulumi as auth-requiring (brand match on command name)', () => {
+    const result = qualifyCommand('pulumi', [
+      { gen: { script: 'pulumi stack ls' }, verdict: 'existing_transforms' },
+    ]);
+    assert.equal(result.qualification.no_auth, false);
+  });
+
+  it('does NOT flag elm as auth-requiring (regression: keyword set is not over-eager)', () => {
+    const result = qualifyCommand('elm', [
+      { gen: { script: 'elm make --list' }, verdict: 'existing_transforms' },
+    ]);
+    assert.equal(result.qualification.no_auth, true);
+  });
+
+  it('flags tsh as auth-requiring (Teleport login required)', () => {
+    const result = qualifyCommand('tsh', [
+      { gen: { script: 'tsh ls --format=json' }, verdict: 'existing_transforms' },
+    ]);
+    assert.equal(result.qualification.no_auth, false);
+  });
+
+  it('flags bosh as auth-requiring (Cloud Foundry director auth)', () => {
+    const result = qualifyCommand('bosh', [
+      { gen: { script: 'bosh --json deployments' }, verdict: 'existing_transforms' },
+    ]);
+    assert.equal(result.qualification.no_auth, false);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves Phase 2 go/no-go and fixes spike report §9 open question 3 (authKeywords heuristic).

**Verdict: NO GO on Phase 2.** The 14-count (0.7%) was NOT a lower bound; the recount returned negative with zero cross-verdict reclassification. Fold the 14 cases into Phase 4 cleanup as a small converter extension.

## Before / after bucket counts

| Verdict | Pre (count/%) | Post (count/%) | Variants (pre → post) |
|---|---|---|---|
| `hand_audit_required` | 866 (45.8%) | 866 (45.8%) | 79 → 81 |
| `existing_transforms` | 614 (32.5%) | 614 (32.5%) | 29 → 32 |
| `requires_runtime` | 162 (8.6%) | 162 (8.6%) | 19 → 19 |
| `needs_new_transform_conditional_split` | 148 (7.8%) | 148 (7.8%) | 11 → 11 |
| `needs_new_transform_regex_match` | 52 (2.8%) | 52 (2.8%) | 3 → 3 |
| `needs_new_transform_substring_slice` | 33 (1.7%) | 33 (1.7%) | 9 → 9 |
| `needs_dotted_path_json_extract` | 14 (0.7%) | **14 (0.74%)** | 1 → 2 |
| **Total** | 1,889 | 1,889 | **151 → 157 (+6)** |

- **Zero generators moved across verdict boundaries.** The callback descent only carved existing shapes into more granular variants.
- `.split().map(x => JSON.parse(x).a.b)`-shaped generators hypothesised by spike finding 3 do not exist in any material quantity in the corpus.
- Decision-rubric: 0.74% < 5% threshold → **NO GO**.

## Phase 2 recommendation

Skip the dedicated Phase 2. Absorb the 14 cases as a narrow `json_extract` dotted-path extension during Phase 4 cleanup (single targeted modifier for the 2 identified shape variants). Expected diff: small. Bench/binary impact: negligible.

## authKeywords heuristic fix (spike §9 Q3)

Extended `authKeywords` with 13 brand keywords so auth-requiring CLIs drop preemptively from Phase 3A's qualifying list.

**Qualifying-candidates delta: 36 → 28 (−8).**

Newly disqualified (all flip to `needs_auth=true`):
- `amplify` (AWS Amplify), `bosh` (Cloud Foundry), `deployctl` (Deno Deploy), `firebase`, `flyctl`, `pulumi`, `stepzen`, `tsh` (Teleport).

Phase 3A gate (≥4 viable candidates) still met with large margin (28 ≥ 4).

## Changes

- `tools/fig-converter/src/ast-analyzer.js` — HOF callback args now descend into the body and emit `.map(<inner>)` instead of opaque `.map(FN)`. Pass-1/Pass-2 visitors untouched.
- `tools/fig-converter/src/ast-analyzer.test.js` — 5 new tests (dotted-path descent, identity callback, async callback, plain-identifier regression, determinism). One pre-existing test expectation updated (case 11: `.map(FN)` → `.map(<OBJ>)` — flagged explicitly).
- `tools/fig-converter/scripts/run-spike.mjs` — extended authKeywords; exported `qualifyCommand` with guarded `main()` so it's unit-testable.
- `tools/fig-converter/src/run-spike.test.js` — new, 6 tests (flyctl/firebase/pulumi/tsh/bosh positive + elm negative regression).
- `tools/fig-converter/docs/{shape-inventory.json,shape-inventory.md,candidate-providers.json}` — regenerated.
- `tools/fig-converter/docs/spike-recount-decision.md` — new decision artifact with §1-§9.

## Test plan

- [x] `npm --prefix tools/fig-converter test` → 113/113 pass (24 suites, 0 failures).
- [x] Spike driver idempotent — two back-to-back runs produce byte-identical output for all three artifacts.
- [x] `shape-inventory.json` byte-identical between T2 commit (`07131c0`) and T5 commit (`38555b9`) — confirms T4/T5 did not accidentally regenerate fingerprints.
- [x] `jq` probes against HEAD: 14 dotted-path generators, 2 dotted-path variants, 28 qualifying, schema_version `"1.0"`, total_generators 1889, bucket counts sum to 1889.
- [x] All 5 new keywords from the spec are present in `authKeywords` (flyctl, flyc, fly.io, firebase, firebase-tools); 8 additional brand keywords added after manual spot-check of the other 35 qualifying candidates.
- [x] Final candidate drop list (8 commands) exactly matches T4's pre-run prediction — no unexpected false positives.
- [x] All 6 commits authored solely by StanMarek — no Co-Authored-By trailers.

## Commits (6)

- `1d568d0` feat(fig-converter): descend into .map/.filter callback bodies for fingerprinting
- `07131c0` chore: re-run Phase 1 spike with callback-body fingerprinting
- `5c6b01f` docs(fig-converter): document Phase 2 recount decision
- `c6c4950` fix(fig-converter): extend authKeywords to catch flyctl/firebase and other auth CLIs
- `38555b9` chore: re-run Phase 1 spike to apply authKeywords heuristic to candidate-providers
- `78a6e46` docs(fig-converter): refresh decision-doc §8 artifact pointers post-T5