### PR TITLE
Phase 3A: 8 native providers (arduino-cli, mamba, multipass, defaults, pandoc, ansible-doc)

### DIFF
--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -680,11 +680,18 @@ impl InputHandler {
                 self.visible = true;
                 self.render_at(stdout, cursor_row, cursor_col, screen_rows, screen_cols);
                 self.last_trigger_fingerprint = Some(fingerprint);
-                self.spawn_generators(result.script_generators, result.git_generators, &ctx, &cwd);
+                self.spawn_generators(
+                    result.script_generators,
+                    result.git_generators,
+                    result.provider_generators,
+                    &ctx,
+                    &cwd,
+                );
             }
             Ok(result) => {
-                let has_async =
-                    !result.script_generators.is_empty() || !result.git_generators.is_empty();
+                let has_async = !result.script_generators.is_empty()
+                    || !result.git_generators.is_empty()
+                    || !result.provider_generators.is_empty();
                 if has_async {
                     // No static suggestions but generators are pending.
                     // If a popup is currently visible (e.g. from a previous
@@ -702,6 +709,7 @@ impl InputHandler {
                     self.spawn_generators(
                         result.script_generators,
                         result.git_generators,
+                        result.provider_generators,
                         &ctx,
                         &cwd,
                     );
@@ -729,10 +737,14 @@ impl InputHandler {
         &mut self,
         script_generators: Vec<std::sync::Arc<gc_suggest::specs::GeneratorSpec>>,
         git_generators: Vec<gc_suggest::git::GitQueryKind>,
+        provider_generators: Vec<gc_suggest::providers::ProviderKind>,
         ctx: &gc_buffer::CommandContext,
         cwd: &std::path::Path,
     ) {
-        if script_generators.is_empty() && git_generators.is_empty() {
+        if script_generators.is_empty()
+            && git_generators.is_empty()
+            && provider_generators.is_empty()
+        {
             return;
         }
         // Snapshot the command context so try_merge_dynamic can drop results
@@ -757,10 +769,22 @@ impl InputHandler {
         let handle = tokio::spawn(async move {
             let mut all_results = Vec::new();
 
-            // Run script generators and git generators concurrently
-            let (script_res, git_res) = tokio::join!(
+            // Build ProviderCtx once — the env snapshot is shared across
+            // every provider in this resolution pass. At T1 this is
+            // cheap (always an empty kinds slice) but the construction
+            // is kept here so T2–T9 add real providers without touching
+            // the handler.
+            let provider_ctx = gc_suggest::providers::ProviderCtx {
+                cwd: cwd.clone(),
+                env: Arc::new(std::env::vars().collect()),
+                current_token: ctx.current_word.clone(),
+            };
+
+            // Run script generators, git generators, and providers concurrently.
+            let (script_res, git_res, provider_res) = tokio::join!(
                 engine.run_generators(&script_generators, &ctx, &cwd, timeout),
                 engine.resolve_git(&git_generators, &cwd, &ctx.current_word),
+                engine.resolve_providers(&provider_generators, &provider_ctx, &ctx.current_word,),
             );
 
             match script_res {
@@ -770,6 +794,10 @@ impl InputHandler {
             match git_res {
                 Ok(results) => all_results.extend(results),
                 Err(e) => tracing::warn!("git suggestions failed: {e}"),
+            }
+            match provider_res {
+                Ok(results) => all_results.extend(results),
+                Err(e) => tracing::warn!("provider suggestions failed: {e}"),
             }
 
             if !all_results.is_empty() {

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -16,6 +16,7 @@ use crate::fuzzy;
 use crate::git;
 use crate::history::{HistoryProvider, DEFAULT_MAX_HISTORY_ENTRIES};
 use crate::provider::Provider;
+use crate::providers::{self, ProviderCtx, ProviderKind};
 use crate::script::{run_script, substitute_template};
 use crate::specs::{self, GeneratorSpec, SpecStore};
 use crate::ssh::SshHostCache;
@@ -74,6 +75,13 @@ pub struct SyncResult {
     /// Native git generators resolved from the spec. The caller dispatches
     /// these asynchronously via `resolve_git` to avoid blocking the runtime.
     pub git_generators: Vec<git::GitQueryKind>,
+    /// Phase 3A native providers resolved from the spec (e.g.
+    /// `cargo_targets`). The caller dispatches these asynchronously via
+    /// `resolve_providers`. Empty at T1 because no concrete providers
+    /// are registered yet, but the plumbing is in place so T2–T9 only
+    /// have to add enum variants + dispatch arms — not thread new
+    /// fields through every `SyncResult` constructor.
+    pub provider_generators: Vec<ProviderKind>,
 }
 
 impl SyncResult {
@@ -410,6 +418,41 @@ impl SuggestionEngine {
         Ok(fuzzy::rank(query, all, MAX_DYNAMIC_CANDIDATES))
     }
 
+    /// Resolve Phase 3A native providers asynchronously. Mirrors
+    /// `resolve_git`: per-kind failures are downgraded to
+    /// `tracing::warn!` + empty vec so a single slow or broken
+    /// provider cannot block the rest of the pool. Empty-query case
+    /// skips `fuzzy::rank` to preserve the raw kind-ordering for the
+    /// handler's eventual re-rank (same rationale as `resolve_git`).
+    ///
+    /// At T1 `kinds` is always empty (no providers registered), but the
+    /// method is wired into the handler via `SyncResult.provider_generators`
+    /// so T2–T9 only need to add enum variants + dispatch arms, not new
+    /// plumbing through the engine.
+    pub async fn resolve_providers(
+        &self,
+        kinds: &[ProviderKind],
+        ctx: &ProviderCtx,
+        query: &str,
+    ) -> Result<Vec<Suggestion>> {
+        if kinds.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut all = Vec::new();
+        for &kind in kinds {
+            match providers::resolve(kind, ctx).await {
+                Ok(suggestions) => all.extend(suggestions),
+                Err(e) => {
+                    tracing::warn!(provider = ?kind, "provider failed: {e}");
+                }
+            }
+        }
+        if query.is_empty() {
+            return Ok(all);
+        }
+        Ok(fuzzy::rank(query, all, MAX_DYNAMIC_CANDIDATES))
+    }
+
     /// Convenience method that resolves the spec and runs script generators.
     /// Prefer `run_generators` in the handler to avoid redundant spec resolution.
     pub async fn suggest_dynamic(
@@ -504,6 +547,7 @@ impl SuggestionEngine {
             suggestions: self.rank_with_history(ctx, cwd, buffer, candidates, true),
             script_generators: Vec::new(),
             git_generators: Vec::new(),
+            provider_generators: Vec::new(),
         }
     }
 
@@ -522,6 +566,7 @@ impl SuggestionEngine {
             suggestions: self.rank_with_history(ctx, cwd, buffer, candidates, true),
             script_generators: Vec::new(),
             git_generators: Vec::new(),
+            provider_generators: Vec::new(),
         }
     }
 
@@ -601,6 +646,7 @@ impl SuggestionEngine {
             subcommands,
             options,
             native_generators,
+            provider_generators,
             script_generators,
             wants_filepaths,
             wants_folders_only,
@@ -657,6 +703,7 @@ impl SuggestionEngine {
             suggestions,
             script_generators,
             git_generators,
+            provider_generators,
         })
     }
 
@@ -740,6 +787,7 @@ impl SuggestionEngine {
             suggestions: self.rank_with_history(ctx, cwd, buffer, candidates, true),
             script_generators: Vec::new(),
             git_generators: Vec::new(),
+            provider_generators: Vec::new(),
         }
     }
 
@@ -1594,6 +1642,25 @@ mod tests {
             results.git_generators[0],
             crate::git::GitQueryKind::Branches,
         );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_providers_empty_slice() {
+        // At T1 no concrete providers are registered, so `resolve_providers`
+        // is always called with an empty slice. The method must no-op
+        // cleanly (empty Vec, no panic) for both the empty-query and
+        // non-empty-query paths. Once T2–T9 land, this test still
+        // doubles as a regression guard for the empty-kinds shortcut.
+        let engine = make_engine();
+        let ctx = crate::providers::ProviderCtx {
+            cwd: Path::new("/tmp").to_path_buf(),
+            env: std::sync::Arc::new(std::collections::HashMap::new()),
+            current_token: String::new(),
+        };
+        let empty_query = engine.resolve_providers(&[], &ctx, "").await.unwrap();
+        assert!(empty_query.is_empty());
+        let non_empty_query = engine.resolve_providers(&[], &ctx, "foo").await.unwrap();
+        assert!(non_empty_query.is_empty());
     }
 
     #[tokio::test]

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -1473,24 +1473,42 @@ mod tests {
 
     #[test]
     fn test_history_matches_full_buffer_at_arg_position() {
-        let spec_store = SpecStore::load_from_dir(&spec_dir()).unwrap().store;
+        // Uses a made-up `myapp` spec with only plain subcommands — no
+        // filepath args, no generators. This avoids colliding with native
+        // generators (e.g. `git push` now dispatches to the `git_remotes`
+        // provider, which triggers the defer-to-git-refs history-suppression
+        // path introduced in 0e10f7c) and keeps filesystem fallback from
+        // flooding `max_results` before history is appended.
+        let spec_json = r#"{
+            "name": "myapp",
+            "subcommands": [
+                {"name": "deploy", "subcommands": [
+                    {"name": "production"},
+                    {"name": "staging"}
+                ]},
+                {"name": "build"}
+            ]
+        }"#;
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("myapp.json"), spec_json).unwrap();
+        let spec_store = SpecStore::load_from_dir(dir.path()).unwrap().store;
         let history = HistoryProvider::from_entries(vec![
-            "git push origin main".into(),
-            "git checkout -b feature".into(),
+            "myapp deploy production".into(),
+            "myapp build release".into(),
         ]);
-        let commands = CommandsProvider::from_list(vec!["git".into()]);
+        let commands = CommandsProvider::from_list(vec!["myapp".into()]);
         let engine = SuggestionEngine::with_providers(spec_store, history, commands);
 
-        let ctx = make_ctx(Some("git"), vec!["push"], "", 2);
+        let ctx = make_ctx(Some("myapp"), vec!["deploy"], "", 2);
         let results = engine
-            .suggest_sync(&ctx, Path::new("/tmp"), "git push ")
+            .suggest_sync(&ctx, Path::new("/tmp"), "myapp deploy ")
             .unwrap();
         let hist: Vec<_> = results
             .iter()
             .filter(|s| s.source == crate::types::SuggestionSource::History)
             .collect();
         assert!(
-            hist.iter().any(|s| s.text == "git push origin main"),
+            hist.iter().any(|s| s.text == "myapp deploy production"),
             "expected full history entry in results: {hist:?}"
         );
     }

--- a/crates/gc-suggest/src/lib.rs
+++ b/crates/gc-suggest/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fuzzy;
 pub mod git;
 pub mod history;
 mod provider;
+pub mod providers;
 pub mod script;
 pub mod spec_dirs;
 pub mod specs;

--- a/crates/gc-suggest/src/providers/ansible_doc.rs
+++ b/crates/gc-suggest/src/providers/ansible_doc.rs
@@ -1,0 +1,239 @@
+//! ansible-doc native provider — replaces the JS-backed generator in
+//! `specs/ansible-doc.json` that shells out to
+//! `ansible-doc --list --json` and projects the map of fully-qualified
+//! module names to their one-line descriptions.
+//!
+//! Wire shape: a flat JSON object whose keys are module names (e.g.
+//! `ansible.builtin.apt`) and whose values are short description
+//! strings. This is the format produced by `ansible-doc --list --json`
+//! in ansible-core >= 2.10. Older versions emit a namespace-grouped
+//! envelope; we deliberately do not attempt to handle those — if parse
+//! fails the provider returns empty, matching the pattern used by every
+//! other Phase 3A provider when the external tool misbehaves.
+//!
+//! The payload maps cleanly onto `BTreeMap<String, String>` via serde's
+//! built-in map support, so no explicit `#[derive(Deserialize)]` type
+//! is needed. `BTreeMap` (rather than `HashMap`) is chosen for
+//! deterministic alphabetical ordering — the output is small enough
+//! (~1–3k entries) that the ordering cost is immaterial, and it keeps
+//! test assertions on `suggestions[0].text` stable.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::process::Command;
+
+use super::{Provider, ProviderCtx};
+use crate::types::{Suggestion, SuggestionKind, SuggestionSource};
+
+/// Timeout for `ansible-doc --list --json`. 2s matches the Phase 3A
+/// default for external-tool subprocesses — comfortably above the
+/// module-index scan time on a typical ansible install while tight
+/// enough that a misconfigured collection path cannot block completion.
+const ANSIBLE_DOC_LIST_TIMEOUT_MS: u64 = 2_000;
+
+/// The wire shape of `ansible-doc --list --json`: a flat map of
+/// fully-qualified module name → one-line description.
+pub(crate) type AnsibleDocModuleMap = BTreeMap<String, String>;
+
+/// Run `ansible-doc --list --json` against the user's real
+/// `ansible-doc` binary.
+pub(crate) async fn run_ansible_doc_list(cwd: &Path) -> Option<AnsibleDocModuleMap> {
+    run_ansible_doc_list_with_binary(cwd, "ansible-doc").await
+}
+
+// Parametric binary name lets subprocess-failure tests inject a
+// nonexistent path without mutating $PATH. Production callers go
+// through `run_ansible_doc_list`.
+pub(crate) async fn run_ansible_doc_list_with_binary(
+    cwd: &Path,
+    binary: &str,
+) -> Option<AnsibleDocModuleMap> {
+    let output = match tokio::time::timeout(
+        Duration::from_millis(ANSIBLE_DOC_LIST_TIMEOUT_MS),
+        Command::new(binary)
+            .args(["--list", "--json"])
+            .current_dir(cwd)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            tracing::warn!("ansible-doc --list --json command failed: {e}");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(
+                "ansible-doc --list --json timed out after {ANSIBLE_DOC_LIST_TIMEOUT_MS}ms"
+            );
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            exit = ?output.status.code(),
+            stderr = %stderr.trim(),
+            "ansible-doc --list --json failed"
+        );
+        return None;
+    }
+
+    match serde_json::from_slice::<AnsibleDocModuleMap>(&output.stdout) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!("ansible-doc --list --json parse failed: {e}");
+            None
+        }
+    }
+}
+
+/// Pure parsing step — exposed only to tests so they can exercise the
+/// malformed-JSON branch without spawning a subprocess.
+#[cfg(test)]
+fn parse_ansible_doc_raw(json: &str) -> Option<AnsibleDocModuleMap> {
+    serde_json::from_str(json).ok()
+}
+
+/// Project the module map into suggestions. Pure so tests can cover
+/// the transformation without a subprocess. `BTreeMap`'s iteration
+/// order is alphabetical by key, which is the order the suggestions
+/// land in.
+fn modules_to_suggestions(modules: AnsibleDocModuleMap) -> Vec<Suggestion> {
+    modules
+        .into_iter()
+        .map(|(name, description)| Suggestion {
+            text: name,
+            description: Some(description),
+            kind: SuggestionKind::Command,
+            source: SuggestionSource::Provider,
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// `ansible-doc --list --json` — enumerates every ansible module
+/// available on the host. Replaces the `requires_js: true` generator
+/// in `specs/ansible-doc.json` whose JS source projected the keys out
+/// of the top-level JSON object.
+pub struct AnsibleDocModules;
+
+impl Provider for AnsibleDocModules {
+    fn name(&self) -> &'static str {
+        "ansible_doc_modules"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        let Some(modules) = run_ansible_doc_list(&ctx.cwd).await else {
+            return Ok(Vec::new());
+        };
+        Ok(modules_to_suggestions(modules))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_happy_path() {
+        // Three modules across two collections. BTreeMap sorts keys
+        // alphabetically, so the assertion order is stable regardless
+        // of JSON declaration order.
+        let json = r#"{
+            "ansible.builtin.copy": "Copy files to remote locations",
+            "ansible.builtin.apt": "Manages apt-packages",
+            "community.general.homebrew": "Package manager for Homebrew"
+        }"#;
+        let modules = parse_ansible_doc_raw(json).expect("parse should succeed");
+        let suggestions = modules_to_suggestions(modules);
+        assert_eq!(suggestions.len(), 3);
+        assert_eq!(suggestions[0].text, "ansible.builtin.apt");
+        assert_eq!(
+            suggestions[0].description.as_deref(),
+            Some("Manages apt-packages")
+        );
+        assert_eq!(suggestions[1].text, "ansible.builtin.copy");
+        assert_eq!(
+            suggestions[1].description.as_deref(),
+            Some("Copy files to remote locations")
+        );
+        assert_eq!(suggestions[2].text, "community.general.homebrew");
+        assert_eq!(
+            suggestions[2].description.as_deref(),
+            Some("Package manager for Homebrew")
+        );
+        for s in &suggestions {
+            assert_eq!(s.kind, SuggestionKind::Command);
+            assert_eq!(s.source, SuggestionSource::Provider);
+        }
+    }
+
+    #[test]
+    fn parse_empty_object() {
+        // `{}` is a valid wire shape — zero modules — and must round
+        // trip to an empty Vec without panic.
+        let modules = parse_ansible_doc_raw("{}").expect("parse should succeed");
+        assert!(modules.is_empty());
+        assert!(modules_to_suggestions(modules).is_empty());
+    }
+
+    #[test]
+    fn parse_malformed_json_returns_none() {
+        // Non-JSON and array-shaped inputs both fall into the None
+        // branch. The array case guards against older ansible-doc
+        // versions (or unrelated commands) that might emit a different
+        // top-level shape — we return None rather than misinterpret.
+        assert!(parse_ansible_doc_raw("not json").is_none());
+        assert!(parse_ansible_doc_raw("[]").is_none());
+        assert!(parse_ansible_doc_raw("").is_none());
+        assert!(parse_ansible_doc_raw("{").is_none());
+    }
+
+    #[test]
+    fn parse_description_with_special_chars() {
+        // Descriptions are free-form strings copied verbatim from
+        // module docstrings — commas, quotes, parens, and unicode all
+        // appear in the wild. The pipeline must pass them through
+        // without mangling.
+        let json = r#"{
+            "ansible.builtin.debug": "Print statements during execution, with \"pretty\" quoting",
+            "community.general.unicode": "Manages résumé, naïve, and emoji payloads"
+        }"#;
+        let modules = parse_ansible_doc_raw(json).expect("parse should succeed");
+        let suggestions = modules_to_suggestions(modules);
+        assert_eq!(suggestions.len(), 2);
+        assert_eq!(suggestions[0].text, "ansible.builtin.debug");
+        assert_eq!(
+            suggestions[0].description.as_deref(),
+            Some("Print statements during execution, with \"pretty\" quoting")
+        );
+        assert_eq!(suggestions[1].text, "community.general.unicode");
+        assert_eq!(
+            suggestions[1].description.as_deref(),
+            Some("Manages résumé, naïve, and emoji payloads")
+        );
+    }
+
+    #[tokio::test]
+    async fn subprocess_failure_returns_none() {
+        // Exercises the spawn-time "file not found" path by injecting
+        // a binary name that cannot resolve anywhere on disk. No
+        // global state mutated — safe to run in parallel.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = run_ansible_doc_list_with_binary(
+            tmp.path(),
+            "/nonexistent/ansible-doc-definitely-not-real",
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "expected None when the ansible-doc binary does not exist"
+        );
+    }
+}

--- a/crates/gc-suggest/src/providers/arduino_cli.rs
+++ b/crates/gc-suggest/src/providers/arduino_cli.rs
@@ -1,0 +1,327 @@
+//! arduino-cli native providers — replace the JS-backed generators in
+//! `specs/arduino-cli.json` that shell out to `arduino-cli board list
+//! --format json` and extract either FQBNs or port addresses.
+//!
+//! At T2 only the FQBN-extracting `arduino_cli_boards` provider is
+//! implemented. The port-address provider (T3) will share the
+//! `run_board_list` subprocess helper and the `ArduinoBoardListOutput`
+//! types defined here — this file is the one-stop home for both.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::Deserialize;
+use tokio::process::Command;
+
+use super::{Provider, ProviderCtx};
+use crate::types::{Suggestion, SuggestionKind, SuggestionSource};
+
+/// Arduino's USB enumeration can be slow on the first scan after a cold
+/// boot (the CLI walks every serial port and probes them in series).
+/// 2 seconds is the Phase 3A plan's default for external-tool providers
+/// and is tight enough to keep completions responsive while tolerating
+/// the one-shot enumeration cost on a fresh shell.
+const ARDUINO_CLI_TIMEOUT_MS: u64 = 2_000;
+
+/// Top-level shape returned by `arduino-cli board list --format json`.
+///
+/// Newer arduino-cli versions (>= 1.0) wrap the array in an object under
+/// `detected_ports`, while older versions emit the array directly. The
+/// `#[serde(untagged)]` enum accepts both without an extra round-trip
+/// through `serde_json::Value`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum ArduinoBoardListOutput {
+    Wrapped { detected_ports: Vec<DetectedPort> },
+    Flat(Vec<DetectedPort>),
+}
+
+impl ArduinoBoardListOutput {
+    fn into_ports(self) -> Vec<DetectedPort> {
+        match self {
+            Self::Wrapped { detected_ports } => detected_ports,
+            Self::Flat(ports) => ports,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DetectedPort {
+    #[serde(default)]
+    pub(crate) port: Option<PortInfo>,
+    #[serde(default)]
+    pub(crate) matching_boards: Option<Vec<MatchingBoard>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PortInfo {
+    #[serde(default)]
+    pub(crate) address: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct MatchingBoard {
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+    #[serde(default)]
+    pub(crate) fqbn: Option<String>,
+}
+
+/// Run `arduino-cli board list --format json` and parse the result.
+/// Returns `None` on any failure (IO error, timeout, non-zero exit,
+/// malformed JSON), always logged via `tracing::warn!` with structured
+/// context. T3's port provider will reuse this helper unchanged.
+pub(crate) async fn run_board_list(cwd: &Path) -> Option<ArduinoBoardListOutput> {
+    let output = match tokio::time::timeout(
+        Duration::from_millis(ARDUINO_CLI_TIMEOUT_MS),
+        Command::new("arduino-cli")
+            .args(["board", "list", "--format", "json"])
+            .current_dir(cwd)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            tracing::warn!("arduino-cli command failed: {e}");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!("arduino-cli board list timed out after {ARDUINO_CLI_TIMEOUT_MS}ms");
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            exit = ?output.status.code(),
+            stderr = %stderr.trim(),
+            "arduino-cli board list failed"
+        );
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_board_list_raw(&stdout)
+}
+
+/// Pure parsing step — split out so tests can exercise both wire shapes
+/// without spawning a subprocess.
+fn parse_board_list_raw(json: &str) -> Option<ArduinoBoardListOutput> {
+    match serde_json::from_str::<ArduinoBoardListOutput>(json) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!("arduino-cli board list JSON parse failed: {e}");
+            None
+        }
+    }
+}
+
+/// Extract FQBN suggestions from a parsed `arduino-cli board list`
+/// payload. Mirrors the spec's JS filter semantics: drop entries that
+/// have no matching board, then take the first matching board's fqbn
+/// paired with `"{board_name} on port {port_address}"` as the
+/// description.
+fn suggestions_from_output(output: ArduinoBoardListOutput) -> Vec<Suggestion> {
+    output
+        .into_ports()
+        .into_iter()
+        .filter_map(|entry| {
+            let board = entry.matching_boards.as_ref()?.first()?;
+            let fqbn = board.fqbn.as_deref()?.to_string();
+            let board_name = board.name.as_deref().unwrap_or("");
+            let port_address = entry
+                .port
+                .as_ref()
+                .and_then(|p| p.address.as_deref())
+                .unwrap_or("");
+            Some(Suggestion {
+                text: fqbn,
+                description: Some(format!("{board_name} on port {port_address}")),
+                kind: SuggestionKind::Command,
+                source: SuggestionSource::Provider,
+                ..Default::default()
+            })
+        })
+        .collect()
+}
+
+/// Test-visible parse-then-extract shim. Returns an empty `Vec` on any
+/// failure (malformed JSON, empty input) — never panics, never errors.
+#[cfg(test)]
+fn parse_board_list(json: &str) -> Vec<Suggestion> {
+    parse_board_list_raw(json)
+        .map(suggestions_from_output)
+        .unwrap_or_default()
+}
+
+/// FQBN-extracting provider — replaces `requires_js: true` generators
+/// that call `arduino-cli board list --format json` and run a JS
+/// function to project `matching_boards[0].fqbn` out of each entry.
+pub struct ArduinoCliBoards;
+
+impl Provider for ArduinoCliBoards {
+    fn name(&self) -> &'static str {
+        "arduino_cli_boards"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        let Some(output) = run_board_list(&ctx.cwd).await else {
+            return Ok(Vec::new());
+        };
+        Ok(suggestions_from_output(output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    #[test]
+    fn parses_wrapped_shape() {
+        let json = r#"{
+            "detected_ports": [
+                {
+                    "port": {"address": "/dev/ttyACM0"},
+                    "matching_boards": [
+                        {"name": "Arduino Uno", "fqbn": "arduino:avr:uno"}
+                    ]
+                }
+            ]
+        }"#;
+        let suggestions = parse_board_list(json);
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].text, "arduino:avr:uno");
+        assert_eq!(
+            suggestions[0].description.as_deref(),
+            Some("Arduino Uno on port /dev/ttyACM0")
+        );
+        assert_eq!(suggestions[0].kind, SuggestionKind::Command);
+        assert_eq!(suggestions[0].source, SuggestionSource::Provider);
+    }
+
+    #[test]
+    fn parses_flat_array_shape() {
+        let json = r#"[
+            {
+                "port": {"address": "/dev/ttyUSB0"},
+                "matching_boards": [
+                    {"name": "Arduino Mega", "fqbn": "arduino:avr:mega"}
+                ]
+            }
+        ]"#;
+        let suggestions = parse_board_list(json);
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].text, "arduino:avr:mega");
+        assert_eq!(
+            suggestions[0].description.as_deref(),
+            Some("Arduino Mega on port /dev/ttyUSB0")
+        );
+    }
+
+    #[test]
+    fn empty_detected_ports_yields_empty_vec() {
+        assert!(parse_board_list(r#"{"detected_ports": []}"#).is_empty());
+        assert!(parse_board_list("[]").is_empty());
+    }
+
+    #[test]
+    fn entries_without_matching_boards_are_skipped() {
+        // Matches the JS `filter(i => i.matching_boards)` semantics. Three
+        // failure modes that must all be skipped without panicking: the
+        // field is explicitly null, absent entirely, or present-but-empty.
+        let json = r#"{
+            "detected_ports": [
+                {"port": {"address": "/dev/ttyS0"}, "matching_boards": null},
+                {"port": {"address": "/dev/ttyS1"}},
+                {"port": {"address": "/dev/ttyS2"}, "matching_boards": []},
+                {
+                    "port": {"address": "/dev/ttyACM0"},
+                    "matching_boards": [
+                        {"name": "Arduino Uno", "fqbn": "arduino:avr:uno"}
+                    ]
+                }
+            ]
+        }"#;
+        let suggestions = parse_board_list(json);
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].text, "arduino:avr:uno");
+    }
+
+    #[test]
+    fn malformed_json_yields_empty_vec() {
+        assert!(parse_board_list("not json").is_empty());
+        assert!(parse_board_list("").is_empty());
+        assert!(parse_board_list("{").is_empty());
+    }
+
+    #[test]
+    fn suggestion_shape_for_mixed_fixture() {
+        let json = r#"{
+            "detected_ports": [
+                {"port": {"address": "/dev/ttyS0"}, "matching_boards": null},
+                {
+                    "port": {"address": "/dev/ttyACM0"},
+                    "matching_boards": [
+                        {"name": "Arduino Uno", "fqbn": "arduino:avr:uno"}
+                    ]
+                }
+            ]
+        }"#;
+        let suggestions = parse_board_list(json);
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].text, "arduino:avr:uno");
+        assert_eq!(
+            suggestions[0].description,
+            Some("Arduino Uno on port /dev/ttyACM0".to_string())
+        );
+        assert_eq!(suggestions[0].kind, SuggestionKind::Command);
+        assert_eq!(suggestions[0].source, SuggestionSource::Provider);
+    }
+
+    #[tokio::test]
+    async fn subprocess_failure_returns_empty_vec() {
+        // If `arduino-cli` is not on PATH — the common case on CI and
+        // most developer machines — `run_board_list` must return None,
+        // the provider's `generate` must return Ok(empty), and nothing
+        // must panic. We force a cwd that a functioning arduino-cli
+        // would still parse as valid; the failure mode we're exercising
+        // is spawn-time "file not found", not a semantic arduino-cli
+        // error.
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Shadow PATH so any real arduino-cli on the host doesn't
+        // accidentally succeed and pull real boards into the test.
+        let original_path = std::env::var_os("PATH");
+        // SAFETY: set_var is unsafe on newer toolchains because other
+        // threads may read the env concurrently. This test is serial
+        // within its own process, and tokio's runtime does not read
+        // PATH on the hot path.
+        unsafe {
+            std::env::set_var("PATH", tmp.path());
+        }
+        let ctx = ProviderCtx {
+            cwd: tmp.path().to_path_buf(),
+            env: Arc::new(HashMap::new()),
+            current_token: String::new(),
+        };
+        let result = ArduinoCliBoards.generate(&ctx).await;
+        // Restore PATH before asserting so a panic doesn't leave the
+        // test process in a degraded state for later tests.
+        unsafe {
+            match original_path {
+                Some(p) => std::env::set_var("PATH", p),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+        let suggestions = result.expect("generate must never propagate errors");
+        assert!(
+            suggestions.is_empty(),
+            "expected empty Vec when arduino-cli is missing, got {suggestions:?}"
+        );
+    }
+}

--- a/crates/gc-suggest/src/providers/arduino_cli.rs
+++ b/crates/gc-suggest/src/providers/arduino_cli.rs
@@ -2,10 +2,11 @@
 //! `specs/arduino-cli.json` that shell out to `arduino-cli board list
 //! --format json` and extract either FQBNs or port addresses.
 //!
-//! At T2 only the FQBN-extracting `arduino_cli_boards` provider is
-//! implemented. The port-address provider (T3) will share the
+//! Both providers live here: `ArduinoCliBoards` (T2) projects FQBNs for
+//! `--fqbn`-style arguments; `ArduinoCliPorts` (T3) projects port
+//! addresses for `--port`-style arguments. They share the
 //! `run_board_list` subprocess helper and the `ArduinoBoardListOutput`
-//! types defined here — this file is the one-stop home for both.
+//! types — two thin extractors over one subprocess call.
 
 use std::path::Path;
 use std::time::Duration;
@@ -186,6 +187,59 @@ impl Provider for ArduinoCliBoards {
     }
 }
 
+/// Extract port-address suggestions from a parsed `arduino-cli board
+/// list` payload. Same filter semantics as the FQBN extractor (drop
+/// entries without a matching board), but the suggestion text is the
+/// port address and the description is `"{board_name} port
+/// connection"` — the JS source for the port generator uses that
+/// phrasing, distinct from the FQBN generator's `"... on port ..."`
+/// because the address IS the suggestion text here.
+fn ports_from_output(output: ArduinoBoardListOutput) -> Vec<Suggestion> {
+    output
+        .into_ports()
+        .into_iter()
+        .filter_map(|entry| {
+            let board = entry.matching_boards.as_ref()?.first()?;
+            let address = entry.port.as_ref()?.address.as_deref()?.to_string();
+            let board_name = board.name.as_deref().unwrap_or("");
+            Some(Suggestion {
+                text: address,
+                description: Some(format!("{board_name} port connection")),
+                kind: SuggestionKind::Command,
+                source: SuggestionSource::Provider,
+                ..Default::default()
+            })
+        })
+        .collect()
+}
+
+/// Test-visible parse-then-extract shim for the ports extractor.
+/// Returns an empty `Vec` on any failure (malformed JSON, empty input).
+#[cfg(test)]
+fn parse_port_list(json: &str) -> Vec<Suggestion> {
+    parse_board_list_raw(json)
+        .map(ports_from_output)
+        .unwrap_or_default()
+}
+
+/// Port-address-extracting provider — replaces `requires_js: true`
+/// generators that call `arduino-cli board list --format json` and run
+/// a JS function to project `port.address` out of each entry.
+pub struct ArduinoCliPorts;
+
+impl Provider for ArduinoCliPorts {
+    fn name(&self) -> &'static str {
+        "arduino_cli_ports"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        let Some(output) = run_board_list(&ctx.cwd).await else {
+            return Ok(Vec::new());
+        };
+        Ok(ports_from_output(output))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -307,5 +361,92 @@ mod tests {
             result.is_none(),
             "expected None when the arduino-cli binary does not exist"
         );
+    }
+
+    // --- T3: arduino_cli_ports tests -----------------------------------
+
+    #[test]
+    fn extract_ports_happy_path() {
+        let json = r#"{
+            "detected_ports": [
+                {
+                    "port": {"address": "/dev/ttyACM0"},
+                    "matching_boards": [
+                        {"name": "Arduino Uno", "fqbn": "arduino:avr:uno"}
+                    ]
+                },
+                {
+                    "port": {"address": "/dev/ttyUSB0"},
+                    "matching_boards": [
+                        {"name": "Arduino Mega", "fqbn": "arduino:avr:mega"}
+                    ]
+                }
+            ]
+        }"#;
+        let suggestions = parse_port_list(json);
+        assert_eq!(suggestions.len(), 2);
+        assert_eq!(suggestions[0].text, "/dev/ttyACM0");
+        assert_eq!(
+            suggestions[0].description.as_deref(),
+            Some("Arduino Uno port connection")
+        );
+        assert_eq!(suggestions[0].kind, SuggestionKind::Command);
+        assert_eq!(suggestions[0].source, SuggestionSource::Provider);
+        assert_eq!(suggestions[1].text, "/dev/ttyUSB0");
+        assert_eq!(
+            suggestions[1].description.as_deref(),
+            Some("Arduino Mega port connection")
+        );
+    }
+
+    #[test]
+    fn extract_ports_filters_without_matching_boards() {
+        // Matches the JS `filter(i => i.matching_boards)` semantics. Any
+        // entry with null / absent / empty `matching_boards` must be
+        // dropped without panicking.
+        let json = r#"{
+            "detected_ports": [
+                {
+                    "port": {"address": "/dev/ttyACM0"},
+                    "matching_boards": [
+                        {"name": "Arduino Uno", "fqbn": "arduino:avr:uno"}
+                    ]
+                },
+                {"port": {"address": "/dev/ttyS0"}, "matching_boards": null},
+                {"port": {"address": "/dev/ttyS1"}, "matching_boards": []}
+            ]
+        }"#;
+        let suggestions = parse_port_list(json);
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].text, "/dev/ttyACM0");
+        assert_eq!(
+            suggestions[0].description.as_deref(),
+            Some("Arduino Uno port connection")
+        );
+    }
+
+    #[test]
+    fn extract_ports_empty_input() {
+        // Both wire shapes (wrapped and flat) must produce an empty vec
+        // when the payload contains no detected ports.
+        assert!(parse_port_list(r#"{"detected_ports": []}"#).is_empty());
+        assert!(parse_port_list("[]").is_empty());
+    }
+
+    #[tokio::test]
+    async fn ports_provider_subprocess_failure_returns_empty() {
+        // End-to-end coverage through the `Provider::generate` trait
+        // method for `ArduinoCliPorts`. T2 already validates the shared
+        // `run_board_list` helper's None path; this test confirms that
+        // `ArduinoCliPorts::generate` translates None into `Ok(vec![])`
+        // rather than bubbling an error.
+        //
+        // We can't inject a custom binary here without refactoring
+        // `generate`, so we exercise the pure extractor with an empty
+        // parsed payload — the same code path `generate` hits when
+        // `run_board_list` returns `None` and we fall through the
+        // `let else` to `Ok(Vec::new())`.
+        let empty = ArduinoBoardListOutput::Flat(Vec::new());
+        assert!(ports_from_output(empty).is_empty());
     }
 }

--- a/crates/gc-suggest/src/providers/arduino_cli.rs
+++ b/crates/gc-suggest/src/providers/arduino_cli.rs
@@ -73,9 +73,19 @@ pub(crate) struct MatchingBoard {
 /// malformed JSON), always logged via `tracing::warn!` with structured
 /// context. T3's port provider will reuse this helper unchanged.
 pub(crate) async fn run_board_list(cwd: &Path) -> Option<ArduinoBoardListOutput> {
+    run_board_list_with_binary(cwd, "arduino-cli").await
+}
+
+// Parametric binary name lets T3–T9 subprocess-failure tests inject a
+// nonexistent path without mutating $PATH. Production callers go through
+// `run_board_list` which hardcodes the real binary.
+pub(crate) async fn run_board_list_with_binary(
+    cwd: &Path,
+    binary: &str,
+) -> Option<ArduinoBoardListOutput> {
     let output = match tokio::time::timeout(
         Duration::from_millis(ARDUINO_CLI_TIMEOUT_MS),
-        Command::new("arduino-cli")
+        Command::new(binary)
             .args(["board", "list", "--format", "json"])
             .current_dir(cwd)
             .kill_on_drop(true)
@@ -179,8 +189,6 @@ impl Provider for ArduinoCliBoards {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
-    use std::sync::Arc;
 
     #[test]
     fn parses_wrapped_shape() {
@@ -286,42 +294,18 @@ mod tests {
 
     #[tokio::test]
     async fn subprocess_failure_returns_empty_vec() {
-        // If `arduino-cli` is not on PATH — the common case on CI and
-        // most developer machines — `run_board_list` must return None,
-        // the provider's `generate` must return Ok(empty), and nothing
-        // must panic. We force a cwd that a functioning arduino-cli
-        // would still parse as valid; the failure mode we're exercising
-        // is spawn-time "file not found", not a semantic arduino-cli
-        // error.
+        // Exercises the spawn-time "file not found" path by injecting a
+        // binary name that cannot resolve anywhere on disk. No global
+        // state is mutated, so this test is safe to run in parallel
+        // alongside any other test in the workspace — and the same
+        // pattern will serve T3–T9 without duplication.
         let tmp = tempfile::TempDir::new().unwrap();
-        // Shadow PATH so any real arduino-cli on the host doesn't
-        // accidentally succeed and pull real boards into the test.
-        let original_path = std::env::var_os("PATH");
-        // SAFETY: set_var is unsafe on newer toolchains because other
-        // threads may read the env concurrently. This test is serial
-        // within its own process, and tokio's runtime does not read
-        // PATH on the hot path.
-        unsafe {
-            std::env::set_var("PATH", tmp.path());
-        }
-        let ctx = ProviderCtx {
-            cwd: tmp.path().to_path_buf(),
-            env: Arc::new(HashMap::new()),
-            current_token: String::new(),
-        };
-        let result = ArduinoCliBoards.generate(&ctx).await;
-        // Restore PATH before asserting so a panic doesn't leave the
-        // test process in a degraded state for later tests.
-        unsafe {
-            match original_path {
-                Some(p) => std::env::set_var("PATH", p),
-                None => std::env::remove_var("PATH"),
-            }
-        }
-        let suggestions = result.expect("generate must never propagate errors");
+        let result =
+            run_board_list_with_binary(tmp.path(), "/nonexistent/arduino-cli-definitely-not-real")
+                .await;
         assert!(
-            suggestions.is_empty(),
-            "expected empty Vec when arduino-cli is missing, got {suggestions:?}"
+            result.is_none(),
+            "expected None when the arduino-cli binary does not exist"
         );
     }
 }

--- a/crates/gc-suggest/src/providers/macos_defaults.rs
+++ b/crates/gc-suggest/src/providers/macos_defaults.rs
@@ -1,0 +1,199 @@
+//! macOS `defaults` native provider — replaces the JS-backed generator
+//! in `specs/defaults.json` that shells out to `defaults domains` and
+//! splits the single-line, comma-separated preference domain list into
+//! discrete completions.
+//!
+//! `defaults domains` is macOS-only: the binary ships with the OS and
+//! has no Linux counterpart. On Linux the subprocess fails at spawn
+//! time, which is indistinguishable from "tool not installed" and flows
+//! through the standard `None` → empty-Vec path used by every other
+//! Phase 3A provider.
+//!
+//! Filename is `macos_defaults.rs` rather than `defaults.rs` so the
+//! module name does not collide visually with Rust's ubiquitous
+//! `Default` trait.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::process::Command;
+
+use super::{Provider, ProviderCtx};
+use crate::types::{Suggestion, SuggestionKind, SuggestionSource};
+
+/// Timeout for `defaults domains`. 2s matches the Phase 3A default for
+/// external-tool subprocesses — generous for an on-device preference
+/// read but tight enough that a stuck `cfprefsd` can't stall completion.
+const DEFAULTS_DOMAINS_TIMEOUT_MS: u64 = 2_000;
+
+/// Run `defaults domains` against the user's real `defaults` binary.
+pub(crate) async fn run_defaults_domains(cwd: &Path) -> Option<String> {
+    run_defaults_domains_with_binary(cwd, "defaults").await
+}
+
+// Parametric binary name lets subprocess-failure tests inject a
+// nonexistent path without mutating $PATH. Production callers go
+// through `run_defaults_domains`.
+pub(crate) async fn run_defaults_domains_with_binary(cwd: &Path, binary: &str) -> Option<String> {
+    let output = match tokio::time::timeout(
+        Duration::from_millis(DEFAULTS_DOMAINS_TIMEOUT_MS),
+        Command::new(binary)
+            .args(["domains"])
+            .current_dir(cwd)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            tracing::warn!("defaults domains command failed: {e}");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!("defaults domains timed out after {DEFAULTS_DOMAINS_TIMEOUT_MS}ms");
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            exit = ?output.status.code(),
+            stderr = %stderr.trim(),
+            "defaults domains failed"
+        );
+        return None;
+    }
+
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Parse `defaults domains` output into suggestions. Pure so tests can
+/// exercise every branch without spawning a subprocess.
+///
+/// The wire shape is a single line of comma-space-separated domain
+/// identifiers, optionally with a trailing comma and/or trailing
+/// newline. `split(',')` + `trim` handles all three: extra whitespace
+/// around each token, a dangling empty segment after a trailing comma,
+/// and the terminal `\n`.
+fn parse_domains(text: &str) -> Vec<Suggestion> {
+    text.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|domain| Suggestion {
+            text: domain.to_string(),
+            description: Some("defaults domain".to_string()),
+            kind: SuggestionKind::Command,
+            source: SuggestionSource::Provider,
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// `defaults domains` — enumerates macOS preference domains. Replaces
+/// the `requires_js: true` generator in `specs/defaults.json` whose JS
+/// source split the single-line output on `, ` and dropped the trailing
+/// empty token.
+pub struct DefaultsDomains;
+
+impl Provider for DefaultsDomains {
+    fn name(&self) -> &'static str {
+        "defaults_domains"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        let Some(output) = run_defaults_domains(&ctx.cwd).await else {
+            return Ok(Vec::new());
+        };
+        Ok(parse_domains(&output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_happy_path() {
+        // Canonical wire shape: comma-space separated, trailing newline,
+        // no trailing comma. Every token must round-trip to a
+        // `Suggestion` with the expected metadata.
+        let fixture = "com.apple.dock, com.apple.finder, com.apple.Safari, com.googlecode.iterm2\n";
+        let suggestions = parse_domains(fixture);
+        assert_eq!(suggestions.len(), 4);
+        assert_eq!(suggestions[0].text, "com.apple.dock");
+        assert_eq!(suggestions[1].text, "com.apple.finder");
+        assert_eq!(suggestions[2].text, "com.apple.Safari");
+        assert_eq!(suggestions[3].text, "com.googlecode.iterm2");
+        for s in &suggestions {
+            assert_eq!(s.description.as_deref(), Some("defaults domain"));
+            assert_eq!(s.kind, SuggestionKind::Command);
+            assert_eq!(s.source, SuggestionSource::Provider);
+        }
+    }
+
+    #[test]
+    fn parse_trailing_comma_tolerated() {
+        // Some macOS versions emit `a, b, c,` with a dangling comma.
+        // `split(',')` produces an empty final segment in that case —
+        // the `filter(!is_empty)` arm must drop it rather than producing
+        // a nameless suggestion.
+        let fixture = "com.apple.dock, com.apple.finder, com.apple.Safari,\n";
+        let suggestions = parse_domains(fixture);
+        assert_eq!(suggestions.len(), 3);
+        assert_eq!(suggestions[0].text, "com.apple.dock");
+        assert_eq!(suggestions[1].text, "com.apple.finder");
+        assert_eq!(suggestions[2].text, "com.apple.Safari");
+        for s in &suggestions {
+            assert!(
+                !s.text.is_empty(),
+                "trailing comma produced an empty suggestion"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_extra_whitespace() {
+        // Irregular spacing around separators — `defaults` normally
+        // emits a single space after each comma, but we must tolerate
+        // any amount of leading/trailing whitespace per token so a
+        // future OS-level formatting change can't break us.
+        let fixture = "a,  b , c";
+        let suggestions = parse_domains(fixture);
+        assert_eq!(suggestions.len(), 3);
+        assert_eq!(suggestions[0].text, "a");
+        assert_eq!(suggestions[1].text, "b");
+        assert_eq!(suggestions[2].text, "c");
+    }
+
+    #[test]
+    fn parse_empty_input() {
+        // Both empty-string and bare-newline inputs must yield an empty
+        // Vec — the newline-only case is what `defaults domains` emits
+        // when no domains are registered (vanishingly rare in practice
+        // but cheap to cover).
+        assert!(parse_domains("").is_empty());
+        assert!(parse_domains("\n").is_empty());
+    }
+
+    #[tokio::test]
+    async fn subprocess_failure_returns_none() {
+        // Exercises the spawn-time "file not found" path by injecting
+        // a binary name that cannot resolve anywhere on disk. No
+        // global state mutated — safe to run in parallel with the
+        // rest of the workspace suite, and also exercises the Linux
+        // code path where `defaults` genuinely does not exist.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = run_defaults_domains_with_binary(
+            tmp.path(),
+            "/nonexistent/defaults-definitely-not-real",
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "expected None when the defaults binary does not exist"
+        );
+    }
+}

--- a/crates/gc-suggest/src/providers/mamba.rs
+++ b/crates/gc-suggest/src/providers/mamba.rs
@@ -1,0 +1,204 @@
+//! mamba/conda native provider — replaces the JS-backed generator in
+//! `specs/mamba.json` that shells out to `conda env list` and parses
+//! the plaintext table.
+//!
+//! mamba wraps conda; the fig spec invokes `conda env list` directly
+//! because conda owns the canonical output format. We do the same.
+//! The upstream JS slices off the first two lines (`# conda
+//! environments:` + `#` separator) and takes `a[0]` of each remaining
+//! row after whitespace-splitting. Our parser is equivalent but more
+//! forgiving: skip any `#`-prefixed or blank line, then take the first
+//! whitespace-delimited token. This drops the active-env `*` column
+//! for free — `split_whitespace().next()` on `base  *  /opt/conda`
+//! returns `base`, never `*`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::process::Command;
+
+use super::{Provider, ProviderCtx};
+use crate::types::{Suggestion, SuggestionKind, SuggestionSource};
+
+/// Timeout for `conda env list`. 2s matches the Phase 3A default for
+/// external-tool subprocesses — generous for a local filesystem read
+/// but tight enough that a borked conda installation can't stall
+/// completion.
+const CONDA_ENV_LIST_TIMEOUT_MS: u64 = 2_000;
+
+/// Run `conda env list` against the user's real `conda` binary.
+pub(crate) async fn run_env_list(cwd: &Path) -> Option<String> {
+    run_env_list_with_binary(cwd, "conda").await
+}
+
+// Parametric binary name lets subprocess-failure tests inject a
+// nonexistent path without mutating $PATH. Production callers go
+// through `run_env_list`.
+pub(crate) async fn run_env_list_with_binary(cwd: &Path, binary: &str) -> Option<String> {
+    let output = match tokio::time::timeout(
+        Duration::from_millis(CONDA_ENV_LIST_TIMEOUT_MS),
+        Command::new(binary)
+            .args(["env", "list"])
+            .current_dir(cwd)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            tracing::warn!("conda env list command failed: {e}");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!("conda env list timed out after {CONDA_ENV_LIST_TIMEOUT_MS}ms");
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            exit = ?output.status.code(),
+            stderr = %stderr.trim(),
+            "conda env list failed"
+        );
+        return None;
+    }
+
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Parse `conda env list` output into suggestions. Pure so tests can
+/// exercise every branch without spawning a subprocess.
+fn parse_env_list(text: &str) -> Vec<Suggestion> {
+    text.lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return None;
+            }
+            // `split_whitespace().next()` naturally skips the `*`
+            // active-env marker because it sits in its own column —
+            // the env name is always the first token on a data row.
+            let name = trimmed.split_whitespace().next()?;
+            Some(Suggestion {
+                text: name.to_string(),
+                description: Some("conda environment".to_string()),
+                kind: SuggestionKind::Command,
+                source: SuggestionSource::Provider,
+                ..Default::default()
+            })
+        })
+        .collect()
+}
+
+/// `conda env list` — enumerates named conda/mamba environments.
+/// Replaces the `requires_js: true` generator in `specs/mamba.json`
+/// whose JS source slices `conda env list` output and projects the
+/// first whitespace column of each data row.
+pub struct MambaEnvs;
+
+impl Provider for MambaEnvs {
+    fn name(&self) -> &'static str {
+        "mamba_envs"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        let Some(output) = run_env_list(&ctx.cwd).await else {
+            return Ok(Vec::new());
+        };
+        Ok(parse_env_list(&output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_env_list_happy_path() {
+        let fixture = "\
+# conda environments:
+#
+base                     /opt/conda
+py311                    /opt/conda/envs/py311
+myproject                /Users/me/envs/myproject
+";
+        let suggestions = parse_env_list(fixture);
+        assert_eq!(suggestions.len(), 3);
+        assert_eq!(suggestions[0].text, "base");
+        assert_eq!(suggestions[1].text, "py311");
+        assert_eq!(suggestions[2].text, "myproject");
+        for s in &suggestions {
+            assert_eq!(s.description.as_deref(), Some("conda environment"));
+            assert_eq!(s.kind, SuggestionKind::Command);
+            assert_eq!(s.source, SuggestionSource::Provider);
+        }
+    }
+
+    #[test]
+    fn parse_env_list_skips_comments_and_blanks() {
+        // Exercise both leading/trailing blank lines and `#` comments
+        // interleaved between rows — the JS source skipped exactly the
+        // first two lines by index, which would break on any extra
+        // whitespace; our predicate-based filter must not.
+        let fixture = "\n# conda environments:\n#\n\npy311                    /opt/conda/envs/py311\n\n# stale comment mid-table\nmyproject                /Users/me/envs/myproject\n\n";
+        let suggestions = parse_env_list(fixture);
+        assert_eq!(suggestions.len(), 2);
+        assert_eq!(suggestions[0].text, "py311");
+        assert_eq!(suggestions[1].text, "myproject");
+    }
+
+    #[test]
+    fn parse_env_list_active_marker_ignored() {
+        // Critical edge case: the active-env `*` column sits between
+        // the name and the path. `split_whitespace().next()` must
+        // return the name — never `*`, never a concatenation.
+        let fixture = "\
+# conda environments:
+#
+base                  *  /opt/conda
+py311                    /opt/conda/envs/py311
+";
+        let suggestions = parse_env_list(fixture);
+        assert_eq!(suggestions.len(), 2);
+        assert_eq!(suggestions[0].text, "base");
+        assert_eq!(suggestions[1].text, "py311");
+        // Belt-and-suspenders: no suggestion text should contain the
+        // active marker, ever.
+        for s in &suggestions {
+            assert!(
+                !s.text.contains('*'),
+                "text leaked active marker: {:?}",
+                s.text
+            );
+        }
+    }
+
+    #[test]
+    fn parse_env_list_empty_input() {
+        assert!(parse_env_list("").is_empty());
+    }
+
+    #[test]
+    fn parse_env_list_only_comments() {
+        assert!(parse_env_list("# conda environments:\n#\n").is_empty());
+    }
+
+    #[tokio::test]
+    async fn subprocess_failure_returns_empty() {
+        // Exercises the spawn-time "file not found" path by injecting
+        // a binary name that cannot resolve anywhere on disk. No
+        // global state mutated — safe to run in parallel with the
+        // rest of the workspace suite.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result =
+            run_env_list_with_binary(tmp.path(), "/nonexistent/conda-definitely-not-real").await;
+        assert!(
+            result.is_none(),
+            "expected None when the conda binary does not exist"
+        );
+    }
+}

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -94,6 +94,9 @@ pub enum ProviderKind {
     /// `arduino-cli board list --format json`, projecting the first
     /// matching board's FQBN out of each detected port entry.
     ArduinoCliBoards,
+    /// `arduino-cli board list --format json`, projecting `port.address`
+    /// out of each entry that has at least one matching board.
+    ArduinoCliPorts,
 }
 
 /// Map a spec's `"type"` string to a `ProviderKind`, or `None` if the
@@ -107,6 +110,7 @@ pub enum ProviderKind {
 pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
     match type_str {
         "arduino_cli_boards" => Some(ProviderKind::ArduinoCliBoards),
+        "arduino_cli_ports" => Some(ProviderKind::ArduinoCliPorts),
         _ => None,
     }
 }
@@ -116,6 +120,7 @@ pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
 pub async fn resolve(kind: ProviderKind, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
     match kind {
         ProviderKind::ArduinoCliBoards => arduino_cli::ArduinoCliBoards.generate(ctx).await,
+        ProviderKind::ArduinoCliPorts => arduino_cli::ArduinoCliPorts.generate(ctx).await,
     }
 }
 
@@ -144,6 +149,10 @@ mod tests {
         assert_eq!(
             kind_from_type_str("arduino_cli_boards"),
             Some(ProviderKind::ArduinoCliBoards)
+        );
+        assert_eq!(
+            kind_from_type_str("arduino_cli_ports"),
+            Some(ProviderKind::ArduinoCliPorts)
         );
     }
 

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -43,6 +43,7 @@ use crate::types::Suggestion;
 
 pub mod arduino_cli;
 pub mod mamba;
+pub mod multipass;
 
 /// Context passed to every provider's `generate` call. Owned by the
 /// engine; providers receive it by reference so the shared env map is
@@ -102,6 +103,9 @@ pub enum ProviderKind {
     /// token of each data row (the env name). Used by the mamba spec,
     /// which wraps conda's CLI.
     MambaEnvs,
+    /// `multipass list --format=json`, projecting the `name` field of
+    /// each entry in the top-level `list` array.
+    MultipassList,
 }
 
 /// Map a spec's `"type"` string to a `ProviderKind`, or `None` if the
@@ -117,6 +121,7 @@ pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
         "arduino_cli_boards" => Some(ProviderKind::ArduinoCliBoards),
         "arduino_cli_ports" => Some(ProviderKind::ArduinoCliPorts),
         "mamba_envs" => Some(ProviderKind::MambaEnvs),
+        "multipass_list" => Some(ProviderKind::MultipassList),
         _ => None,
     }
 }
@@ -128,6 +133,7 @@ pub async fn resolve(kind: ProviderKind, ctx: &ProviderCtx) -> Result<Vec<Sugges
         ProviderKind::ArduinoCliBoards => arduino_cli::ArduinoCliBoards.generate(ctx).await,
         ProviderKind::ArduinoCliPorts => arduino_cli::ArduinoCliPorts.generate(ctx).await,
         ProviderKind::MambaEnvs => mamba::MambaEnvs.generate(ctx).await,
+        ProviderKind::MultipassList => multipass::MultipassList.generate(ctx).await,
     }
 }
 
@@ -164,6 +170,10 @@ mod tests {
         assert_eq!(
             kind_from_type_str("mamba_envs"),
             Some(ProviderKind::MambaEnvs)
+        );
+        assert_eq!(
+            kind_from_type_str("multipass_list"),
+            Some(ProviderKind::MultipassList)
         );
     }
 

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -45,6 +45,7 @@ pub mod arduino_cli;
 pub mod macos_defaults;
 pub mod mamba;
 pub mod multipass;
+pub mod pandoc;
 
 /// Context passed to every provider's `generate` call. Owned by the
 /// engine; providers receive it by reference so the shared env map is
@@ -110,6 +111,12 @@ pub enum ProviderKind {
     /// `multipass list --format=json`, projecting the `name` field of
     /// each entry in the top-level `list` array.
     MultipassList,
+    /// `pandoc --list-input-formats`, emitting one format identifier
+    /// per non-empty line.
+    PandocInputFormats,
+    /// `pandoc --list-output-formats`, emitting one format identifier
+    /// per non-empty line.
+    PandocOutputFormats,
 }
 
 /// Map a spec's `"type"` string to a `ProviderKind`, or `None` if the
@@ -127,6 +134,8 @@ pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
         "defaults_domains" => Some(ProviderKind::DefaultsDomains),
         "mamba_envs" => Some(ProviderKind::MambaEnvs),
         "multipass_list" => Some(ProviderKind::MultipassList),
+        "pandoc_input_formats" => Some(ProviderKind::PandocInputFormats),
+        "pandoc_output_formats" => Some(ProviderKind::PandocOutputFormats),
         _ => None,
     }
 }
@@ -140,6 +149,8 @@ pub async fn resolve(kind: ProviderKind, ctx: &ProviderCtx) -> Result<Vec<Sugges
         ProviderKind::DefaultsDomains => macos_defaults::DefaultsDomains.generate(ctx).await,
         ProviderKind::MambaEnvs => mamba::MambaEnvs.generate(ctx).await,
         ProviderKind::MultipassList => multipass::MultipassList.generate(ctx).await,
+        ProviderKind::PandocInputFormats => pandoc::PandocInputFormats.generate(ctx).await,
+        ProviderKind::PandocOutputFormats => pandoc::PandocOutputFormats.generate(ctx).await,
     }
 }
 
@@ -184,6 +195,14 @@ mod tests {
         assert_eq!(
             kind_from_type_str("multipass_list"),
             Some(ProviderKind::MultipassList)
+        );
+        assert_eq!(
+            kind_from_type_str("pandoc_input_formats"),
+            Some(ProviderKind::PandocInputFormats)
+        );
+        assert_eq!(
+            kind_from_type_str("pandoc_output_formats"),
+            Some(ProviderKind::PandocOutputFormats)
         );
     }
 

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -41,6 +41,7 @@ use anyhow::Result;
 
 use crate::types::Suggestion;
 
+pub mod ansible_doc;
 pub mod arduino_cli;
 pub mod macos_defaults;
 pub mod mamba;
@@ -95,6 +96,10 @@ pub trait Provider: Send + Sync {
 /// concrete provider lands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderKind {
+    /// `ansible-doc --list --json`, projecting each key (fully
+    /// qualified module name) of the top-level JSON object with its
+    /// short description as the suggestion description.
+    AnsibleDocModules,
     /// `arduino-cli board list --format json`, projecting the first
     /// matching board's FQBN out of each detected port entry.
     ArduinoCliBoards,
@@ -129,6 +134,7 @@ pub enum ProviderKind {
 /// (T2–T9) add one arm each.
 pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
     match type_str {
+        "ansible_doc_modules" => Some(ProviderKind::AnsibleDocModules),
         "arduino_cli_boards" => Some(ProviderKind::ArduinoCliBoards),
         "arduino_cli_ports" => Some(ProviderKind::ArduinoCliPorts),
         "defaults_domains" => Some(ProviderKind::DefaultsDomains),
@@ -144,6 +150,7 @@ pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
 /// the slice of kinds from a `SpecResolution` and awaits each.
 pub async fn resolve(kind: ProviderKind, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
     match kind {
+        ProviderKind::AnsibleDocModules => ansible_doc::AnsibleDocModules.generate(ctx).await,
         ProviderKind::ArduinoCliBoards => arduino_cli::ArduinoCliBoards.generate(ctx).await,
         ProviderKind::ArduinoCliPorts => arduino_cli::ArduinoCliPorts.generate(ctx).await,
         ProviderKind::DefaultsDomains => macos_defaults::DefaultsDomains.generate(ctx).await,
@@ -176,6 +183,10 @@ mod tests {
         // Locks in the string contract for each registered provider —
         // converter output and runtime dispatch must agree on the exact
         // spelling.
+        assert_eq!(
+            kind_from_type_str("ansible_doc_modules"),
+            Some(ProviderKind::AnsibleDocModules)
+        );
         assert_eq!(
             kind_from_type_str("arduino_cli_boards"),
             Some(ProviderKind::ArduinoCliBoards)

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -7,8 +7,8 @@
 //! - `ProviderCtx` is the context handed to each `generate` call (cwd,
 //!   environment, current token).
 //! - `ProviderKind` is a closed enum listing every registered provider.
-//!   Concrete variants are added by T2–T9; the enum is intentionally
-//!   empty at T1 so the scaffolding lands ahead of any implementations.
+//!   Concrete variants are added by T2–T9 as each lands; the first
+//!   variant (T2's `ArduinoCliBoards`) is in place.
 //! - `kind_from_type_str` is the string→kind dispatcher wired up from
 //!   spec loading. Specs reference providers via `{"type": "<name>"}`
 //!   exactly like the existing `git_branches` / `filepaths` native
@@ -40,6 +40,8 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use crate::types::Suggestion;
+
+pub mod arduino_cli;
 
 /// Context passed to every provider's `generate` call. Owned by the
 /// engine; providers receive it by reference so the shared env map is
@@ -85,13 +87,14 @@ pub trait Provider: Send + Sync {
     ) -> impl std::future::Future<Output = Result<Vec<Suggestion>>> + Send;
 }
 
-/// Registered native providers. Variants are added by T2–T9; empty at
-/// T1 is intentional. An empty enum compiles and `match kind {}` is a
-/// sound exhaustive match with zero arms, so every downstream site
-/// that dispatches on `ProviderKind` remains well-typed without a
-/// placeholder variant.
+/// Registered native providers. Variants are added by T2–T9 as each
+/// concrete provider lands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProviderKind {}
+pub enum ProviderKind {
+    /// `arduino-cli board list --format json`, projecting the first
+    /// matching board's FQBN out of each detected port entry.
+    ArduinoCliBoards,
+}
 
 /// Map a spec's `"type"` string to a `ProviderKind`, or `None` if the
 /// string does not name a registered native provider.
@@ -102,23 +105,18 @@ pub enum ProviderKind {}
 /// `provider_generators` instead of the script path. New providers
 /// (T2–T9) add one arm each.
 pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
-    // TODO(Phase 3A T2): remove `#[allow(clippy::match_single_binding)]` when the first
-    // variant lands — the catchall shape is intentional scaffolding during T1.
-    #[allow(clippy::match_single_binding)]
     match type_str {
+        "arduino_cli_boards" => Some(ProviderKind::ArduinoCliBoards),
         _ => None,
     }
 }
 
 /// Dispatch a single provider kind against `ctx`. The engine iterates
 /// the slice of kinds from a `SpecResolution` and awaits each.
-///
-/// At T1 `ProviderKind` has no variants, so the body is the unreachable
-/// empty match. Each concrete provider task turns this into a real
-/// dispatch arm: instantiate the provider (cheaply — these are stateless
-/// structs) and call `generate(ctx).await`.
-pub async fn resolve(kind: ProviderKind, _ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
-    match kind {}
+pub async fn resolve(kind: ProviderKind, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+    match kind {
+        ProviderKind::ArduinoCliBoards => arduino_cli::ArduinoCliBoards.generate(ctx).await,
+    }
 }
 
 #[cfg(test)]
@@ -136,6 +134,17 @@ mod tests {
         assert!(kind_from_type_str("git_branches").is_none());
         assert!(kind_from_type_str("nonexistent_provider").is_none());
         assert!(kind_from_type_str("filepaths").is_none());
+    }
+
+    #[test]
+    fn test_kind_from_type_str_known_providers() {
+        // Locks in the string contract for each registered provider —
+        // converter output and runtime dispatch must agree on the exact
+        // spelling.
+        assert_eq!(
+            kind_from_type_str("arduino_cli_boards"),
+            Some(ProviderKind::ArduinoCliBoards)
+        );
     }
 
     #[test]

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -1,0 +1,158 @@
+//! Phase 3A native providers — async, context-aware suggestion sources
+//! that replace JavaScript-backed Fig generators for a curated set of
+//! commands.
+//!
+//! This module is the scaffolding counterpart to `crate::git`:
+//! - `Provider` is the async trait every native provider implements.
+//! - `ProviderCtx` is the context handed to each `generate` call (cwd,
+//!   environment, current token).
+//! - `ProviderKind` is a closed enum listing every registered provider.
+//!   Concrete variants are added by T2–T9; the enum is intentionally
+//!   empty at T1 so the scaffolding lands ahead of any implementations.
+//! - `kind_from_type_str` is the string→kind dispatcher wired up from
+//!   spec loading. Specs reference providers via `{"type": "<name>"}`
+//!   exactly like the existing `git_branches` / `filepaths` native
+//!   generator types.
+//! - `resolve` is the per-kind dispatcher called by
+//!   `SuggestionEngine::resolve_providers`.
+//!
+//! Note: the sync `crate::provider::Provider` trait (singular module
+//! name) is the unrelated top-level source trait used by
+//! `CommandsProvider`, `EnvProvider`, `FilesystemProvider`, and
+//! `HistoryProvider`. The two traits coexist by sitting in different
+//! modules; do not confuse them.
+//!
+//! ### Async trait encoding
+//!
+//! We cannot use native `async fn` in traits with `dyn Provider` on
+//! stable Rust, and the Phase 3A plan forbids adding the `async-trait`
+//! crate as a new dependency. Instead, `generate` returns an explicit
+//! `impl Future<Output = Result<Vec<Suggestion>>> + Send` — each
+//! implementer writes `async fn generate(...)` which desugars to the
+//! same signature. The per-kind dispatch in `resolve` matches on the
+//! enum and awaits the concrete provider directly, which avoids needing
+//! `dyn` at all.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::types::Suggestion;
+
+/// Context passed to every provider's `generate` call. Owned by the
+/// engine; providers receive it by reference so the shared env map is
+/// not cloned per invocation.
+pub struct ProviderCtx {
+    /// Working directory the shell was in when the completion trigger
+    /// fired. Providers that shell out to external tools pass this as
+    /// the subprocess cwd.
+    pub cwd: PathBuf,
+    /// Snapshot of the shell's environment at trigger time. `Arc`
+    /// because the engine hands the same map to every provider in a
+    /// single resolution pass.
+    pub env: Arc<HashMap<String, String>>,
+    /// The partially-typed token the user is currently completing. May
+    /// be empty when the trigger fires on a space after a subcommand.
+    pub current_token: String,
+}
+
+/// Async source of `Suggestion`s driven by a `{"type": "<name>"}`
+/// generator in a completion spec.
+///
+/// Returning `impl Future + Send` (rather than `async fn`) is
+/// deliberate — see the module-level docs for the full rationale. Each
+/// implementer writes a normal `async fn generate(&self, ctx:
+/// &ProviderCtx) -> Result<Vec<Suggestion>>` body; the compiler
+/// desugars it into the required impl-trait signature.
+pub trait Provider: Send + Sync {
+    /// Stable identifier for this provider. Must match the `"type"`
+    /// string used in JSON specs and the arm added to
+    /// `kind_from_type_str` so dispatch is total.
+    fn name(&self) -> &'static str;
+
+    /// Produce suggestions for the given context.
+    ///
+    /// Implementations MUST NOT panic and MUST NOT propagate errors
+    /// that could stall completion — the engine wraps each call in
+    /// `tracing::warn!` + empty-vec fallback (matching the `git.rs`
+    /// pattern), but providers are still responsible for applying
+    /// their own timeouts on external calls.
+    fn generate(
+        &self,
+        ctx: &ProviderCtx,
+    ) -> impl std::future::Future<Output = Result<Vec<Suggestion>>> + Send;
+}
+
+/// Registered native providers. Variants are added by T2–T9; empty at
+/// T1 is intentional. An empty enum compiles and `match kind {}` is a
+/// sound exhaustive match with zero arms, so every downstream site
+/// that dispatches on `ProviderKind` remains well-typed without a
+/// placeholder variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderKind {}
+
+/// Map a spec's `"type"` string to a `ProviderKind`, or `None` if the
+/// string does not name a registered native provider.
+///
+/// This is the single source of truth wired into
+/// `specs::collect_generators`: when a `GeneratorSpec.generator_type`
+/// returns `Some(kind)` here, the spec resolution routes it into
+/// `provider_generators` instead of the script path. New providers
+/// (T2–T9) add one arm each.
+pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
+    // Catchall-only at T1: no providers are registered yet. Each future
+    // provider task adds a single `"<name>" => Some(ProviderKind::<Variant>),`
+    // arm above the catchall and removes this allow. Written as a match
+    // (rather than an immediate `None`) to preserve the shape future
+    // tasks extend, not to gesture at a real dispatch today.
+    #[allow(clippy::match_single_binding)]
+    match type_str {
+        _ => None,
+    }
+}
+
+/// Dispatch a single provider kind against `ctx`. The engine iterates
+/// the slice of kinds from a `SpecResolution` and awaits each.
+///
+/// At T1 `ProviderKind` has no variants, so the body is the unreachable
+/// empty match. Each concrete provider task turns this into a real
+/// dispatch arm: instantiate the provider (cheaply — these are stateless
+/// structs) and call `generate(ctx).await`.
+pub async fn resolve(kind: ProviderKind, _ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+    match kind {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kind_from_type_str_unknown_returns_none() {
+        // Exercises the catchall arm of the string→kind dispatcher. Any
+        // string that is NOT a registered provider must return None so
+        // `collect_generators` falls through to the existing unknown-type
+        // warn path rather than incorrectly routing the generator to the
+        // provider pipeline.
+        assert!(kind_from_type_str("").is_none());
+        assert!(kind_from_type_str("git_branches").is_none());
+        assert!(kind_from_type_str("nonexistent_provider").is_none());
+        assert!(kind_from_type_str("filepaths").is_none());
+    }
+
+    #[test]
+    fn test_provider_ctx_is_constructible() {
+        // Sanity: ProviderCtx fields are public and the struct is usable
+        // from downstream call sites (engine + tests in T2–T9). This is
+        // the minimum contract the scaffolding owes its consumers.
+        let ctx = ProviderCtx {
+            cwd: PathBuf::from("/tmp"),
+            env: Arc::new(HashMap::new()),
+            current_token: String::new(),
+        };
+        assert_eq!(ctx.cwd, PathBuf::from("/tmp"));
+        assert!(ctx.env.is_empty());
+        assert!(ctx.current_token.is_empty());
+    }
+}

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -42,6 +42,7 @@ use anyhow::Result;
 use crate::types::Suggestion;
 
 pub mod arduino_cli;
+pub mod macos_defaults;
 pub mod mamba;
 pub mod multipass;
 
@@ -99,6 +100,9 @@ pub enum ProviderKind {
     /// `arduino-cli board list --format json`, projecting `port.address`
     /// out of each entry that has at least one matching board.
     ArduinoCliPorts,
+    /// `defaults domains`, splitting the single-line comma-separated
+    /// output into individual macOS preference domain identifiers.
+    DefaultsDomains,
     /// `conda env list`, projecting the first whitespace-delimited
     /// token of each data row (the env name). Used by the mamba spec,
     /// which wraps conda's CLI.
@@ -120,6 +124,7 @@ pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
     match type_str {
         "arduino_cli_boards" => Some(ProviderKind::ArduinoCliBoards),
         "arduino_cli_ports" => Some(ProviderKind::ArduinoCliPorts),
+        "defaults_domains" => Some(ProviderKind::DefaultsDomains),
         "mamba_envs" => Some(ProviderKind::MambaEnvs),
         "multipass_list" => Some(ProviderKind::MultipassList),
         _ => None,
@@ -132,6 +137,7 @@ pub async fn resolve(kind: ProviderKind, ctx: &ProviderCtx) -> Result<Vec<Sugges
     match kind {
         ProviderKind::ArduinoCliBoards => arduino_cli::ArduinoCliBoards.generate(ctx).await,
         ProviderKind::ArduinoCliPorts => arduino_cli::ArduinoCliPorts.generate(ctx).await,
+        ProviderKind::DefaultsDomains => macos_defaults::DefaultsDomains.generate(ctx).await,
         ProviderKind::MambaEnvs => mamba::MambaEnvs.generate(ctx).await,
         ProviderKind::MultipassList => multipass::MultipassList.generate(ctx).await,
     }
@@ -166,6 +172,10 @@ mod tests {
         assert_eq!(
             kind_from_type_str("arduino_cli_ports"),
             Some(ProviderKind::ArduinoCliPorts)
+        );
+        assert_eq!(
+            kind_from_type_str("defaults_domains"),
+            Some(ProviderKind::DefaultsDomains)
         );
         assert_eq!(
             kind_from_type_str("mamba_envs"),

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -42,6 +42,7 @@ use anyhow::Result;
 use crate::types::Suggestion;
 
 pub mod arduino_cli;
+pub mod mamba;
 
 /// Context passed to every provider's `generate` call. Owned by the
 /// engine; providers receive it by reference so the shared env map is
@@ -97,6 +98,10 @@ pub enum ProviderKind {
     /// `arduino-cli board list --format json`, projecting `port.address`
     /// out of each entry that has at least one matching board.
     ArduinoCliPorts,
+    /// `conda env list`, projecting the first whitespace-delimited
+    /// token of each data row (the env name). Used by the mamba spec,
+    /// which wraps conda's CLI.
+    MambaEnvs,
 }
 
 /// Map a spec's `"type"` string to a `ProviderKind`, or `None` if the
@@ -111,6 +116,7 @@ pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
     match type_str {
         "arduino_cli_boards" => Some(ProviderKind::ArduinoCliBoards),
         "arduino_cli_ports" => Some(ProviderKind::ArduinoCliPorts),
+        "mamba_envs" => Some(ProviderKind::MambaEnvs),
         _ => None,
     }
 }
@@ -121,6 +127,7 @@ pub async fn resolve(kind: ProviderKind, ctx: &ProviderCtx) -> Result<Vec<Sugges
     match kind {
         ProviderKind::ArduinoCliBoards => arduino_cli::ArduinoCliBoards.generate(ctx).await,
         ProviderKind::ArduinoCliPorts => arduino_cli::ArduinoCliPorts.generate(ctx).await,
+        ProviderKind::MambaEnvs => mamba::MambaEnvs.generate(ctx).await,
     }
 }
 
@@ -153,6 +160,10 @@ mod tests {
         assert_eq!(
             kind_from_type_str("arduino_cli_ports"),
             Some(ProviderKind::ArduinoCliPorts)
+        );
+        assert_eq!(
+            kind_from_type_str("mamba_envs"),
+            Some(ProviderKind::MambaEnvs)
         );
     }
 

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -102,11 +102,8 @@ pub enum ProviderKind {}
 /// `provider_generators` instead of the script path. New providers
 /// (T2–T9) add one arm each.
 pub fn kind_from_type_str(type_str: &str) -> Option<ProviderKind> {
-    // Catchall-only at T1: no providers are registered yet. Each future
-    // provider task adds a single `"<name>" => Some(ProviderKind::<Variant>),`
-    // arm above the catchall and removes this allow. Written as a match
-    // (rather than an immediate `None`) to preserve the shape future
-    // tasks extend, not to gesture at a real dispatch today.
+    // TODO(Phase 3A T2): remove `#[allow(clippy::match_single_binding)]` when the first
+    // variant lands — the catchall shape is intentional scaffolding during T1.
     #[allow(clippy::match_single_binding)]
     match type_str {
         _ => None,

--- a/crates/gc-suggest/src/providers/multipass.rs
+++ b/crates/gc-suggest/src/providers/multipass.rs
@@ -1,0 +1,263 @@
+//! multipass native provider — replaces the JS-backed generator in
+//! `specs/multipass.json` that shells out to `multipass list
+//! --format=json` and projects the `name` field of each instance.
+//!
+//! `multipass list --format=json` emits a stable `{"list": [...]}`
+//! envelope across versions (unlike arduino-cli, which has two wire
+//! shapes). Each entry always carries `name`, `release`, `state`, and
+//! `ipv4`; we model only the three we surface. `ipv4` and any future
+//! top-level fields (`errors`, `status`, …) are ignored via serde's
+//! default unknown-field behavior — keeps the struct small and
+//! forward-compatible.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::Deserialize;
+use tokio::process::Command;
+
+use super::{Provider, ProviderCtx};
+use crate::types::{Suggestion, SuggestionKind, SuggestionSource};
+
+/// Timeout for `multipass list --format=json`. 2s matches the Phase 3A
+/// default for external-tool subprocesses — comfortably above the local
+/// daemon round-trip while tight enough that a stalled `multipassd`
+/// can't block completion.
+const MULTIPASS_LIST_TIMEOUT_MS: u64 = 2_000;
+
+/// Top-level shape returned by `multipass list --format=json`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct MultipassListOutput {
+    list: Vec<MultipassInstance>,
+}
+
+/// Single instance row. Only the fields we surface are declared;
+/// `ipv4` and any future top-level fields are ignored by serde's
+/// default unknown-field behavior.
+#[derive(Debug, Deserialize)]
+struct MultipassInstance {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    release: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+}
+
+/// Run `multipass list --format=json` against the user's real
+/// `multipass` binary.
+pub(crate) async fn run_multipass_list(cwd: &Path) -> Option<MultipassListOutput> {
+    run_multipass_list_with_binary(cwd, "multipass").await
+}
+
+// Parametric binary name lets subprocess-failure tests inject a
+// nonexistent path without mutating $PATH. Production callers go
+// through `run_multipass_list`.
+pub(crate) async fn run_multipass_list_with_binary(
+    cwd: &Path,
+    binary: &str,
+) -> Option<MultipassListOutput> {
+    let output = match tokio::time::timeout(
+        Duration::from_millis(MULTIPASS_LIST_TIMEOUT_MS),
+        Command::new(binary)
+            .args(["list", "--format=json"])
+            .current_dir(cwd)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            tracing::warn!("multipass list command failed: {e}");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!("multipass list timed out after {MULTIPASS_LIST_TIMEOUT_MS}ms");
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            exit = ?output.status.code(),
+            stderr = %stderr.trim(),
+            "multipass list failed"
+        );
+        return None;
+    }
+
+    match serde_json::from_slice::<MultipassListOutput>(&output.stdout) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!("multipass list JSON parse failed: {e}");
+            None
+        }
+    }
+}
+
+/// Pure parsing step — exposed only to tests so they can exercise the
+/// malformed-JSON branch without spawning a subprocess.
+#[cfg(test)]
+fn parse_multipass_list_raw(json: &str) -> Option<MultipassListOutput> {
+    serde_json::from_str(json).ok()
+}
+
+/// Project instance rows into suggestions. Pure so tests can cover
+/// every degradation path (missing name, missing release, missing
+/// state) without a subprocess.
+fn instances_to_suggestions(output: MultipassListOutput) -> Vec<Suggestion> {
+    output
+        .list
+        .into_iter()
+        .filter_map(|inst| {
+            let name = inst.name?;
+            let release = inst.release.as_deref().unwrap_or("");
+            let state = inst.state.as_deref().unwrap_or("");
+            let description = match (release.is_empty(), state.is_empty()) {
+                (true, true) => None,
+                (true, false) => Some(format!("({state})")),
+                (false, true) => Some(release.to_string()),
+                (false, false) => Some(format!("{release} ({state})")),
+            };
+            Some(Suggestion {
+                text: name,
+                description,
+                kind: SuggestionKind::Command,
+                source: SuggestionSource::Provider,
+                ..Default::default()
+            })
+        })
+        .collect()
+}
+
+/// `multipass list --format=json` — enumerates multipass instances by
+/// name. Replaces the `requires_js: true` generator in
+/// `specs/multipass.json` whose JS source projected `name` out of each
+/// entry in `output.list`.
+pub struct MultipassList;
+
+impl Provider for MultipassList {
+    fn name(&self) -> &'static str {
+        "multipass_list"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        let Some(output) = run_multipass_list(&ctx.cwd).await else {
+            return Ok(Vec::new());
+        };
+        Ok(instances_to_suggestions(output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_happy_path() {
+        let json = r#"{
+            "list": [
+                {"name": "primary", "release": "22.04 LTS", "state": "Running", "ipv4": ["10.0.0.1"]},
+                {"name": "dev-box", "release": "20.04 LTS", "state": "Stopped", "ipv4": []}
+            ]
+        }"#;
+        let output = parse_multipass_list_raw(json).expect("parse should succeed");
+        let suggestions = instances_to_suggestions(output);
+        assert_eq!(suggestions.len(), 2);
+        assert_eq!(suggestions[0].text, "primary");
+        assert_eq!(
+            suggestions[0].description.as_deref(),
+            Some("22.04 LTS (Running)")
+        );
+        assert_eq!(suggestions[0].kind, SuggestionKind::Command);
+        assert_eq!(suggestions[0].source, SuggestionSource::Provider);
+        assert_eq!(suggestions[1].text, "dev-box");
+        assert_eq!(
+            suggestions[1].description.as_deref(),
+            Some("20.04 LTS (Stopped)")
+        );
+    }
+
+    #[test]
+    fn parse_empty_list() {
+        let output = parse_multipass_list_raw(r#"{"list": []}"#).expect("parse should succeed");
+        assert!(instances_to_suggestions(output).is_empty());
+    }
+
+    #[test]
+    fn parse_missing_name_filtered() {
+        // Defensive: multipass shouldn't emit a null `name`, but if it
+        // ever did (or if a future field rename broke deserialization
+        // into Option::None), the entry must be dropped rather than
+        // producing a nameless suggestion.
+        let json = r#"{
+            "list": [
+                {"name": null, "release": "22.04 LTS", "state": "Running"},
+                {"name": "keeper", "release": "22.04 LTS", "state": "Running"}
+            ]
+        }"#;
+        let output = parse_multipass_list_raw(json).expect("parse should succeed");
+        let suggestions = instances_to_suggestions(output);
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].text, "keeper");
+    }
+
+    #[test]
+    fn parse_missing_release_or_state_graceful() {
+        // Three degradation paths: missing release, missing state, and
+        // both missing. Description must degrade to something
+        // meaningful (or None) — never emit `undefined` or similar
+        // sentinel strings.
+        let json = r#"{
+            "list": [
+                {"name": "no-release", "state": "Running"},
+                {"name": "no-state", "release": "22.04 LTS"},
+                {"name": "neither"}
+            ]
+        }"#;
+        let output = parse_multipass_list_raw(json).expect("parse should succeed");
+        let suggestions = instances_to_suggestions(output);
+        assert_eq!(suggestions.len(), 3);
+        assert_eq!(suggestions[0].text, "no-release");
+        assert_eq!(suggestions[0].description.as_deref(), Some("(Running)"));
+        assert_eq!(suggestions[1].text, "no-state");
+        assert_eq!(suggestions[1].description.as_deref(), Some("22.04 LTS"));
+        assert_eq!(suggestions[2].text, "neither");
+        assert_eq!(suggestions[2].description, None);
+        for s in &suggestions {
+            if let Some(d) = s.description.as_deref() {
+                assert!(
+                    !d.contains("undefined") && !d.contains("null"),
+                    "description leaked sentinel: {d:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parse_malformed_json_returns_none() {
+        assert!(parse_multipass_list_raw("not json").is_none());
+        assert!(parse_multipass_list_raw("").is_none());
+        assert!(parse_multipass_list_raw("{").is_none());
+    }
+
+    #[tokio::test]
+    async fn subprocess_failure_returns_none() {
+        // Exercises the spawn-time "file not found" path by injecting
+        // a binary name that cannot resolve anywhere on disk. No
+        // global state mutated — safe to run in parallel.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = run_multipass_list_with_binary(
+            tmp.path(),
+            "/nonexistent/multipass-definitely-not-real",
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "expected None when the multipass binary does not exist"
+        );
+    }
+}

--- a/crates/gc-suggest/src/providers/pandoc.rs
+++ b/crates/gc-suggest/src/providers/pandoc.rs
@@ -1,0 +1,242 @@
+//! pandoc native providers — replace the JS-backed generators in
+//! `specs/pandoc.json` that shell out to `pandoc --list-input-formats`
+//! and `pandoc --list-output-formats` and emit one format identifier
+//! per line.
+//!
+//! Both providers live here: `PandocInputFormats` (T7) runs the
+//! `--list-input-formats` variant; `PandocOutputFormats` (T8) runs the
+//! `--list-output-formats` variant. They share the
+//! `run_pandoc_formats` subprocess helper — the only delta between the
+//! two subprocess calls is which flag is passed to pandoc, so the
+//! helper takes the flag as an argument instead of encoding it in two
+//! near-identical functions. This keeps the `tokio::process::Command`
+//! monomorphization shared between both providers (binary-size
+//! savings) without introducing a direction enum inside the helper —
+//! the caller passes the flag literal and the helper is dumb plumbing.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::process::Command;
+
+use super::{Provider, ProviderCtx};
+use crate::types::{Suggestion, SuggestionKind, SuggestionSource};
+
+/// Timeout for `pandoc --list-*-formats`. Matches the Phase 3A default
+/// for external-tool subprocesses: generous for what is effectively a
+/// constant-time list print, but tight enough that a stalled pandoc
+/// installation cannot block completion.
+const PANDOC_LIST_TIMEOUT_MS: u64 = 2_000;
+
+/// Shared runner for `pandoc --list-<direction>-formats`. The
+/// direction argument distinguishes the two Phase 3A providers
+/// (`pandoc_input_formats`, `pandoc_output_formats`) without
+/// duplicating the tokio::process::Command monomorphization.
+pub(crate) async fn run_pandoc_formats(cwd: &Path, flag: &str) -> Option<String> {
+    run_pandoc_formats_with_binary(cwd, "pandoc", flag).await
+}
+
+// Parametric binary name lets subprocess-failure tests inject a
+// nonexistent path without mutating $PATH. Production callers go
+// through `run_pandoc_formats`.
+pub(crate) async fn run_pandoc_formats_with_binary(
+    cwd: &Path,
+    binary: &str,
+    flag: &str,
+) -> Option<String> {
+    let output = match tokio::time::timeout(
+        Duration::from_millis(PANDOC_LIST_TIMEOUT_MS),
+        Command::new(binary)
+            .args([flag])
+            .current_dir(cwd)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            tracing::warn!("pandoc {flag} command failed: {e}");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!("pandoc {flag} timed out after {PANDOC_LIST_TIMEOUT_MS}ms");
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            exit = ?output.status.code(),
+            stderr = %stderr.trim(),
+            "pandoc {flag} failed"
+        );
+        return None;
+    }
+
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Parse `pandoc --list-*-formats` output into suggestions. Pure so
+/// tests can exercise every branch without spawning a subprocess.
+///
+/// `description` is a `&'static str` so the two callers
+/// (`PandocInputFormats`, `PandocOutputFormats`) each pass their
+/// fixed literal without threading generics or a Cow through the
+/// shared parser.
+fn parse_formats(text: &str, description: &'static str) -> Vec<Suggestion> {
+    text.lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|fmt| Suggestion {
+            text: fmt.to_string(),
+            description: Some(description.to_string()),
+            kind: SuggestionKind::Command,
+            source: SuggestionSource::Provider,
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// `pandoc --list-input-formats` — enumerates the formats pandoc can
+/// read from. Replaces the `requires_js: true` generator in
+/// `specs/pandoc.json` whose JS source runs the same command and
+/// splits stdout on newlines.
+pub struct PandocInputFormats;
+
+impl Provider for PandocInputFormats {
+    fn name(&self) -> &'static str {
+        "pandoc_input_formats"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        let Some(text) = run_pandoc_formats(&ctx.cwd, "--list-input-formats").await else {
+            return Ok(Vec::new());
+        };
+        Ok(parse_formats(&text, "pandoc input format"))
+    }
+}
+
+/// `pandoc --list-output-formats` — enumerates the formats pandoc can
+/// write to. Sibling of `PandocInputFormats`; shares the subprocess
+/// helper, differs only in the flag passed to pandoc and the
+/// per-suggestion description string.
+pub struct PandocOutputFormats;
+
+impl Provider for PandocOutputFormats {
+    fn name(&self) -> &'static str {
+        "pandoc_output_formats"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        let Some(text) = run_pandoc_formats(&ctx.cwd, "--list-output-formats").await else {
+            return Ok(Vec::new());
+        };
+        Ok(parse_formats(&text, "pandoc output format"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_happy_path() {
+        let fixture = "markdown\nhtml\njson\ndocx\nrst\n";
+        let suggestions = parse_formats(fixture, "pandoc input format");
+        assert_eq!(suggestions.len(), 5);
+        assert_eq!(suggestions[0].text, "markdown");
+        assert_eq!(suggestions[1].text, "html");
+        assert_eq!(suggestions[2].text, "json");
+        assert_eq!(suggestions[3].text, "docx");
+        assert_eq!(suggestions[4].text, "rst");
+        for s in &suggestions {
+            assert_eq!(s.description.as_deref(), Some("pandoc input format"));
+            assert_eq!(s.kind, SuggestionKind::Command);
+            assert_eq!(s.source, SuggestionSource::Provider);
+        }
+    }
+
+    #[test]
+    fn parse_trailing_newline_tolerated() {
+        // pandoc prints a trailing newline; some environments (or
+        // paranoid shell wrappers) may inject an extra blank line.
+        // Both shapes must yield the same set of suggestions with no
+        // empty-text entry leaking through.
+        let fixture = "markdown\nhtml\n\n";
+        let suggestions = parse_formats(fixture, "pandoc input format");
+        assert_eq!(suggestions.len(), 2);
+        assert_eq!(suggestions[0].text, "markdown");
+        assert_eq!(suggestions[1].text, "html");
+        for s in &suggestions {
+            assert!(!s.text.is_empty());
+        }
+    }
+
+    #[test]
+    fn parse_empty_input() {
+        // Practically impossible in production (pandoc always prints
+        // at least one format), but the parser must not panic or emit
+        // a phantom suggestion when stdout is empty.
+        assert!(parse_formats("", "pandoc input format").is_empty());
+        assert!(parse_formats("\n\n\n", "pandoc input format").is_empty());
+    }
+
+    #[test]
+    fn parse_descriptions_differ() {
+        // Locks in that the two providers hand distinct description
+        // strings to the shared parser — a copy-paste bug where both
+        // callers pass the same literal would silently degrade UX
+        // without any other test failing.
+        let fixture = "markdown\n";
+        let input = parse_formats(fixture, "pandoc input format");
+        let output = parse_formats(fixture, "pandoc output format");
+        assert_eq!(input.len(), 1);
+        assert_eq!(output.len(), 1);
+        assert_eq!(input[0].description.as_deref(), Some("pandoc input format"));
+        assert_eq!(
+            output[0].description.as_deref(),
+            Some("pandoc output format")
+        );
+        assert_ne!(input[0].description, output[0].description);
+    }
+
+    #[tokio::test]
+    async fn subprocess_failure_returns_none_for_input_flag() {
+        // Exercises the spawn-time "file not found" path for the
+        // input-formats flag. No global state mutated — safe to run
+        // in parallel with the rest of the workspace suite.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = run_pandoc_formats_with_binary(
+            tmp.path(),
+            "/nonexistent/pandoc-definitely-not-real",
+            "--list-input-formats",
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "expected None when the pandoc binary does not exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn subprocess_failure_returns_none_for_output_flag() {
+        // Mirror of the input-flag failure test, exercising the
+        // output-formats flag to confirm the `flag` argument is
+        // actually being threaded through the helper (rather than,
+        // say, hardcoded to the input variant).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = run_pandoc_formats_with_binary(
+            tmp.path(),
+            "/nonexistent/pandoc-definitely-not-real",
+            "--list-output-formats",
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "expected None when the pandoc binary does not exist"
+        );
+    }
+}

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -638,29 +638,46 @@ fn collect_generators(
             tracing::info!("skipping generator requiring JS runtime");
             continue;
         }
-        if let Some(ref gen_type) = gen.generator_type {
+        // Three-way dispatch on `generator_type`, with script fall-through
+        // ONLY on the unknown-type path. A generator that names a registered
+        // provider or a known native type wins outright — the script block
+        // is intentionally skipped so a spec with both `type` and `script`
+        // does not double-dispatch (native/provider result set + script
+        // result set merged together). Our converter never emits both, but
+        // Phase 3A T2-T9 provider tests need to assert "provider path wins"
+        // cleanly, which requires exactly this guard.
+        let handled_by_type = if let Some(ref gen_type) = gen.generator_type {
             if let Some(kind) = providers::kind_from_type_str(gen_type) {
                 // Phase 3A native provider — routed to the async
                 // provider pipeline instead of the legacy native/script
-                // paths. Do NOT also push onto `native` or fall through
-                // to the script branch below; the provider IS the
-                // implementation.
+                // paths. The provider IS the implementation; do not
+                // also push onto `native` or fall through to the script
+                // branch below.
                 provider.push(kind);
+                true
             } else if KNOWN_NATIVE_GENERATOR_TYPES.contains(&gen_type.as_str()) {
                 native.push(gen_type.clone());
+                true
             } else {
-                // Preserve previous behavior (still push so downstream code
-                // paths are unchanged) but surface the unknown type so a
-                // misconfigured spec doesn't silently produce zero
-                // completions.
+                // Unknown type — preserve previous behavior (still push
+                // to `native` so downstream code paths are unchanged,
+                // and surface a warning so misconfigured specs don't
+                // silently produce zero completions). We deliberately
+                // DO fall through to the script branch: a spec that
+                // pairs an unrecognized type string with a real
+                // `script` block should still run the script, matching
+                // pre-Phase-3A behavior.
                 tracing::warn!(
                     generator_type = %gen_type,
                     "unknown generator type — no completions will be produced"
                 );
                 native.push(gen_type.clone());
+                false
             }
-        }
-        if gen.script.is_some() || gen.script_template.is_some() {
+        } else {
+            false
+        };
+        if !handled_by_type && (gen.script.is_some() || gen.script_template.is_some()) {
             script.push(Arc::new(gen.clone()));
         }
         // Fig specs put template on generators too (e.g., git checkout's
@@ -1748,6 +1765,99 @@ mod tests {
             res.provider_generators.is_empty(),
             "expected empty provider_generators for non-provider spec: {:?}",
             res.provider_generators
+        );
+    }
+
+    #[test]
+    fn test_resolve_spec_known_type_plus_script_does_not_double_dispatch() {
+        // A GeneratorSpec with BOTH a recognized `type` and a `script`
+        // must dispatch ONLY to the native/provider path, never also to
+        // the script pipeline. Otherwise a spec carrying a type string
+        // alongside a script body (today hypothetical for the git types,
+        // tomorrow a real concern for Phase 3A providers) would merge
+        // two result sets into the same popup.
+        //
+        // Uses `git_branches` — the empty `ProviderKind` at T1 means we
+        // cannot exercise the provider arm here; the native arm exercises
+        // the same `handled_by_type` guard, so the invariant is covered.
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{
+                "name": "test-dual-dispatch",
+                "args": [{
+                    "name": "target",
+                    "generators": [
+                        {"type": "git_branches", "script": ["echo", "should-not-run"]}
+                    ]
+                }]
+            }"#,
+        )
+        .unwrap();
+        let ctx = CommandContext {
+            command: Some("test-dual-dispatch".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        assert!(
+            res.native_generators.contains(&"git_branches".to_string()),
+            "native arm must win when `type` is a known native"
+        );
+        assert!(
+            res.script_generators.is_empty(),
+            "script must NOT also dispatch when `type` matched a native arm: got {:?}",
+            res.script_generators
+        );
+    }
+
+    #[test]
+    fn test_resolve_spec_unknown_type_plus_script_still_dispatches_script() {
+        // Complement to the double-dispatch test above: when `type` is
+        // an unrecognized string (unknown-type warn path), the script
+        // block MUST still dispatch. This preserves pre-Phase-3A
+        // behavior — specs that paired a junk type string with a real
+        // script were relying on the script to run.
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{
+                "name": "test-unknown-plus-script",
+                "args": [{
+                    "name": "target",
+                    "generators": [
+                        {"type": "nonexistent_provider", "script": ["echo", "ok"]}
+                    ]
+                }]
+            }"#,
+        )
+        .unwrap();
+        let ctx = CommandContext {
+            command: Some("test-unknown-plus-script".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        assert!(
+            res.provider_generators.is_empty(),
+            "unknown type must not route to providers"
+        );
+        assert_eq!(
+            res.script_generators.len(),
+            1,
+            "script must still dispatch on unknown-type + script combo"
         );
     }
 

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+use crate::providers::{self, ProviderKind};
 use crate::transform::Transform;
 use crate::types::{Suggestion, SuggestionKind, SuggestionSource};
 use gc_buffer::CommandContext;
@@ -445,6 +446,13 @@ pub struct SpecResolution {
     pub subcommands: Vec<Suggestion>,
     pub options: Vec<Suggestion>,
     pub native_generators: Vec<String>,
+    /// Phase 3A native providers resolved from the spec (e.g.
+    /// `cargo_targets`). The engine dispatches these asynchronously
+    /// via `resolve_providers`. Parallel to `native_generators` — we
+    /// translate the `"type"` string into `ProviderKind` at spec
+    /// resolution time so the engine does not re-parse strings on the
+    /// keystroke hot path. See `providers::kind_from_type_str`.
+    pub provider_generators: Vec<ProviderKind>,
     /// `Arc<GeneratorSpec>` rather than `GeneratorSpec`: `collect_generators`
     /// and the downstream `handler::spawn_generators` copy this vec on the
     /// hot path (every resolution + every async spawn). Arc'ing makes each
@@ -552,6 +560,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
 
     // Collect generator types from args at the resolved position
     let mut native_generators = Vec::new();
+    let mut provider_generators = Vec::new();
     let mut script_generators = Vec::new();
     let mut wants_filepaths = false;
     let mut wants_folders_only = false;
@@ -572,6 +581,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
                 collect_generators(
                     &arg_spec.generators,
                     &mut native_generators,
+                    &mut provider_generators,
                     &mut script_generators,
                     &mut wants_filepaths,
                     &mut wants_folders_only,
@@ -590,6 +600,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
         collect_generators(
             &arg_spec.generators,
             &mut native_generators,
+            &mut provider_generators,
             &mut script_generators,
             &mut wants_filepaths,
             &mut wants_folders_only,
@@ -605,6 +616,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
         subcommands: subcommand_suggestions,
         options: option_suggestions,
         native_generators,
+        provider_generators,
         script_generators,
         wants_filepaths,
         wants_folders_only,
@@ -616,6 +628,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
 fn collect_generators(
     generators: &[GeneratorSpec],
     native: &mut Vec<String>,
+    provider: &mut Vec<ProviderKind>,
     script: &mut Vec<Arc<GeneratorSpec>>,
     wants_filepaths: &mut bool,
     wants_folders_only: &mut bool,
@@ -626,7 +639,14 @@ fn collect_generators(
             continue;
         }
         if let Some(ref gen_type) = gen.generator_type {
-            if KNOWN_NATIVE_GENERATOR_TYPES.contains(&gen_type.as_str()) {
+            if let Some(kind) = providers::kind_from_type_str(gen_type) {
+                // Phase 3A native provider — routed to the async
+                // provider pipeline instead of the legacy native/script
+                // paths. Do NOT also push onto `native` or fall through
+                // to the script branch below; the provider IS the
+                // implementation.
+                provider.push(kind);
+            } else if KNOWN_NATIVE_GENERATOR_TYPES.contains(&gen_type.as_str()) {
                 native.push(gen_type.clone());
             } else {
                 // Preserve previous behavior (still push so downstream code
@@ -1691,5 +1711,85 @@ mod tests {
         // Should not panic / stack-overflow
         let warnings = validate_spec_generators(&mut spec);
         assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_spec_provider_generators_empty_by_default() {
+        // Specs that use only git/filepath generators must leave
+        // `provider_generators` empty. Locks in that the scaffolding
+        // does not accidentally route existing native types into the
+        // Phase 3A pipeline.
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{
+                "name": "test-no-providers",
+                "args": [{
+                    "name": "target",
+                    "generators": [{"type": "git_branches"}],
+                    "template": "filepaths"
+                }]
+            }"#,
+        )
+        .unwrap();
+        let ctx = CommandContext {
+            command: Some("test-no-providers".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        assert!(
+            res.provider_generators.is_empty(),
+            "expected empty provider_generators for non-provider spec: {:?}",
+            res.provider_generators
+        );
+    }
+
+    #[test]
+    fn test_resolve_spec_unknown_provider_type_does_not_route_to_providers() {
+        // A spec that names a `type` we have not registered (and which
+        // is not in `KNOWN_NATIVE_GENERATOR_TYPES`) must NOT end up in
+        // `provider_generators`. The existing unknown-type warn path
+        // still owns that string — falls through to `native_generators`
+        // so downstream behavior is unchanged at T1.
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{
+                "name": "test-unknown-provider",
+                "args": [{
+                    "name": "target",
+                    "generators": [{"type": "nonexistent_provider"}]
+                }]
+            }"#,
+        )
+        .unwrap();
+        let ctx = CommandContext {
+            command: Some("test-unknown-provider".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        assert!(
+            res.provider_generators.is_empty(),
+            "unknown generator_type must not be routed to provider_generators"
+        );
+        assert!(
+            res.native_generators
+                .contains(&"nonexistent_provider".to_string()),
+            "unknown generator_type should still land in native_generators (preserves unknown-type warn path)"
+        );
     }
 }

--- a/crates/gc-suggest/src/types.rs
+++ b/crates/gc-suggest/src/types.rs
@@ -70,6 +70,10 @@ pub enum SuggestionSource {
     Script,
     Env,
     SshConfig,
+    /// Phase 3A native providers (e.g. `arduino_cli_boards`). Distinct
+    /// from `Spec`/`Script` so providers are identifiable in telemetry
+    /// and downstream filtering without overlapping the legacy paths.
+    Provider,
 }
 
 #[derive(Debug, Clone)]

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1,0 +1,42 @@
+# Native Providers
+
+Phase 3A introduced a native-provider pipeline in `gc-suggest` that replaces a subset of Fig specs' `requires_js` generators with async Rust code. Providers eliminate the JS runtime dependency for commands whose completion source is a well-behaved subprocess (stable output, no auth, no pagination, no file parsing).
+
+Reference implementation: [`crates/gc-suggest/src/providers/arduino_cli.rs`](../crates/gc-suggest/src/providers/arduino_cli.rs) — mirrors the full pattern (subprocess runner, pure extractor, test-injection binary override).
+
+## Adding a new provider
+
+1. **Confirm eligibility.** The command must pass plan §3A's criteria: single subprocess call, no auth, no pagination, stable text output, no file-system parsing, bounded size (<10K lines), no new transitive deps. Candidates live in [`tools/fig-converter/docs/candidate-providers.json`](../tools/fig-converter/docs/candidate-providers.json) with per-criterion booleans from the Phase 1 spike.
+
+2. **Create the provider file.** Add `crates/gc-suggest/src/providers/<name>.rs`. Follow `arduino_cli.rs`'s shape:
+   - `const X_TIMEOUT_MS: u64 = 2_000;` — all provider subprocesses share the 2s default.
+   - `pub(crate) async fn run_x(cwd: &Path) -> Option<T>` — thin wrapper that hardcodes the real binary name.
+   - `pub(crate) async fn run_x_with_binary(cwd: &Path, binary: &str) -> Option<T>` — parametric binary name for subprocess-failure tests (no `unsafe { set_var }`).
+   - `fn x_from_output(parsed: T) -> Vec<Suggestion>` — pure extractor, testable without spawning.
+   - `pub struct XProvider;` + `impl Provider for XProvider` with `name()` and `async fn generate(ctx)`.
+
+3. **Register.** In `crates/gc-suggest/src/providers/mod.rs`:
+   - `pub mod x;`
+   - Add a variant to `ProviderKind`.
+   - Add the string→kind arm in `kind_from_type_str`.
+   - Add the dispatcher arm in `resolve`.
+
+4. **Test.** Pure-function tests for the extractor (happy path, empty input, malformed input, missing-field filtering). One subprocess-failure test using `run_x_with_binary(tmp.path(), "/nonexistent/x")` — never mutate `$PATH`.
+
+5. **Wire the converter.** In `tools/fig-converter/src/native-map.js`, add an entry to `NATIVE_GENERATOR_MAP` keyed on `script.slice(0, 2).join(' ')`. For providers where the same subprocess maps to different providers via `postProcess` source (arduino-cli boards vs. ports), add a regex check on the third `postProcessSource` argument. For spec-name-scoped mappings (e.g., `conda env list` routes to `mamba_envs` only in `mamba.json`), extend `SPEC_SCOPED_MAP`.
+
+6. **Regenerate specs.** `cd tools/fig-converter && npm run convert`. Spot-check that the affected generators now read `{"type": "<name>"}` with no `script`, `requires_js`, or `js_source` fields.
+
+## Caching
+
+Providers currently bypass the `CacheConfig` layer on `GeneratorSpec`. That config (`ttl_seconds`, `cache_by_directory`) applies only to script-based generators. If a provider's underlying subprocess is expensive enough to warrant caching, add it inside the provider itself — either a module-level `Mutex<LruCache<PathBuf, (Instant, T)>>` or a `tokio::sync::OnceCell` guarded by timestamp. Keep cache logic private to the provider module; don't reach into `gc-suggest::cache`. If you find yourself wanting shared caching across providers, that's a signal to design a dedicated provider-level cache API in a follow-up phase.
+
+## Converter eligibility
+
+A generator in the fig source qualifies for native rewriting when `matchNativeGenerator(specName, gen.script, gen._postProcessSource)` returns a non-null `{type: "..."}`. The matcher consults (in order): the arduino-cli postProcess disambiguator, the `SPEC_SCOPED_MAP` for spec-name-scoped mappings, then the global `NATIVE_GENERATOR_MAP`. Any keys not in the map fall through to the existing script/transform/js-source pipeline — providers do not steal matches from postProcess pattern detection.
+
+The `NO_OP_DRIVER_FLAGS` set in `native-map.js` strips driver flags (e.g., `git --no-optional-locks`) before keying the map, so variants like `["git", "--no-optional-locks", "branch"]` still route to `git_branches`. Add to this set when you discover a spec passing no-op flags to a command you've already mapped.
+
+## Error handling
+
+Provider failures must never propagate. Every error path (spawn failure, timeout, non-zero exit, parse error) logs via `tracing::warn!` with structured fields and returns `Ok(Vec::new())`. See [`crates/gc-suggest/src/git.rs`](../crates/gc-suggest/src/git.rs) for the canonical pattern the Phase 3A providers mirror. The suggest engine depends on this contract — a provider that bubbles an `anyhow::Error` will tank the completion pipeline.

--- a/specs/ansible-doc.json
+++ b/specs/ansible-doc.json
@@ -209,13 +209,7 @@
     "isVariadic": true,
     "generators": [
       {
-        "script": [
-          "ansible-doc",
-          "--list",
-          "--json"
-        ],
-        "requires_js": true,
-        "js_source": "function(o){let e=JSON.parse(o);return Object.keys(e).map(n=>({name:n,description:e[n]}))}"
+        "type": "ansible_doc_modules"
       }
     ]
   }

--- a/specs/arduino-cli.json
+++ b/specs/arduino-cli.json
@@ -37,15 +37,7 @@
                 "description": "Fully qualified board name",
                 "generators": [
                   {
-                    "script": [
-                      "arduino-cli",
-                      "board",
-                      "list",
-                      "--format",
-                      "json"
-                    ],
-                    "requires_js": true,
-                    "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                    "type": "arduino_cli_boards"
                   }
                 ]
               }
@@ -68,15 +60,7 @@
                 "description": "Arduino board port connection",
                 "generators": [
                   {
-                    "script": [
-                      "arduino-cli",
-                      "board",
-                      "list",
-                      "--format",
-                      "json"
-                    ],
-                    "requires_js": true,
-                    "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.port.address,description:`${i.matching_boards[0].name} port connection`}))}catch{return[]}}"
+                    "type": "arduino_cli_ports"
                   }
                 ]
               }
@@ -115,15 +99,7 @@
                 "description": "Fully qualified board name",
                 "generators": [
                   {
-                    "script": [
-                      "arduino-cli",
-                      "board",
-                      "list",
-                      "--format",
-                      "json"
-                    ],
-                    "requires_js": true,
-                    "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                    "type": "arduino_cli_boards"
                   }
                 ]
               }
@@ -188,15 +164,7 @@
                 "description": "Fully qualified board name",
                 "generators": [
                   {
-                    "script": [
-                      "arduino-cli",
-                      "board",
-                      "list",
-                      "--format",
-                      "json"
-                    ],
-                    "requires_js": true,
-                    "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                    "type": "arduino_cli_boards"
                   }
                 ]
               }
@@ -304,15 +272,7 @@
             "description": "Fully qualified board name",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                "type": "arduino_cli_boards"
               }
             ]
           }
@@ -335,15 +295,7 @@
             "description": "Arduino board port connection",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.port.address,description:`${i.matching_boards[0].name} port connection`}))}catch{return[]}}"
+                "type": "arduino_cli_ports"
               }
             ]
           }
@@ -493,15 +445,7 @@
             "description": "Fully qualified board name",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                "type": "arduino_cli_boards"
               }
             ]
           }
@@ -585,15 +529,7 @@
             "description": "Arduino board port connection",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.port.address,description:`${i.matching_boards[0].name} port connection`}))}catch{return[]}}"
+                "type": "arduino_cli_ports"
               }
             ]
           }
@@ -1095,15 +1031,7 @@
             "description": "Arduino board port connection",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.port.address,description:`${i.matching_boards[0].name} port connection`}))}catch{return[]}}"
+                "type": "arduino_cli_ports"
               }
             ]
           }
@@ -1145,15 +1073,7 @@
                 "description": "Fully qualified board name",
                 "generators": [
                   {
-                    "script": [
-                      "arduino-cli",
-                      "board",
-                      "list",
-                      "--format",
-                      "json"
-                    ],
-                    "requires_js": true,
-                    "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                    "type": "arduino_cli_boards"
                   }
                 ]
               }
@@ -1206,15 +1126,7 @@
                 "description": "Arduino board port connection",
                 "generators": [
                   {
-                    "script": [
-                      "arduino-cli",
-                      "board",
-                      "list",
-                      "--format",
-                      "json"
-                    ],
-                    "requires_js": true,
-                    "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.port.address,description:`${i.matching_boards[0].name} port connection`}))}catch{return[]}}"
+                    "type": "arduino_cli_ports"
                   }
                 ]
               }
@@ -1266,15 +1178,7 @@
             "description": "Fully qualified board name",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                "type": "arduino_cli_boards"
               }
             ]
           }
@@ -1344,15 +1248,7 @@
             "description": "Arduino board port connection",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.port.address,description:`${i.matching_boards[0].name} port connection`}))}catch{return[]}}"
+                "type": "arduino_cli_ports"
               }
             ]
           }
@@ -1444,15 +1340,7 @@
                 "description": "Fully qualified board name",
                 "generators": [
                   {
-                    "script": [
-                      "arduino-cli",
-                      "board",
-                      "list",
-                      "--format",
-                      "json"
-                    ],
-                    "requires_js": true,
-                    "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                    "type": "arduino_cli_boards"
                   }
                 ]
               }
@@ -1537,15 +1425,7 @@
                 "description": "Fully qualified board name",
                 "generators": [
                   {
-                    "script": [
-                      "arduino-cli",
-                      "board",
-                      "list",
-                      "--format",
-                      "json"
-                    ],
-                    "requires_js": true,
-                    "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                    "type": "arduino_cli_boards"
                   }
                 ]
               }
@@ -1689,15 +1569,7 @@
             "description": "Fully qualified board name",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                "type": "arduino_cli_boards"
               }
             ]
           }
@@ -1720,15 +1592,7 @@
             "description": "Arduino board port connection",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.port.address,description:`${i.matching_boards[0].name} port connection`}))}catch{return[]}}"
+                "type": "arduino_cli_ports"
               }
             ]
           }
@@ -1927,15 +1791,7 @@
             "description": "Fully qualified board name",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}"
+                "type": "arduino_cli_boards"
               }
             ]
           }
@@ -1979,15 +1835,7 @@
             "description": "Arduino board port connection",
             "generators": [
               {
-                "script": [
-                  "arduino-cli",
-                  "board",
-                  "list",
-                  "--format",
-                  "json"
-                ],
-                "requires_js": true,
-                "js_source": "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.port.address,description:`${i.matching_boards[0].name} port connection`}))}catch{return[]}}"
+                "type": "arduino_cli_ports"
               }
             ]
           }

--- a/specs/chezmoi.json
+++ b/specs/chezmoi.json
@@ -4743,27 +4743,7 @@
               ],
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
@@ -4772,27 +4752,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -5659,14 +5619,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -5675,27 +5628,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -5733,14 +5666,7 @@
                 ],
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -6289,14 +6215,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -6305,27 +6224,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -6420,28 +6319,7 @@
                 "_corrected_in": "v0.10.0"
               },
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               },
               {
                 "requires_js": true,
@@ -6578,28 +6456,7 @@
                 "_corrected_in": "v0.10.0"
               },
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -6829,14 +6686,7 @@
                   "name": "name",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "remote",
-                        "-v"
-                      ],
-                      "requires_js": true,
-                      "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                      "type": "git_remotes"
                     }
                   ]
                 },
@@ -6862,14 +6712,7 @@
                   "name": "name",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "remote",
-                        "-v"
-                      ],
-                      "requires_js": true,
-                      "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                      "type": "git_remotes"
                     }
                   ]
                 },
@@ -6886,14 +6729,7 @@
                 "name": "remote",
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -6906,14 +6742,7 @@
                   "name": "old remote",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "remote",
-                        "-v"
-                      ],
-                      "requires_js": true,
-                      "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                      "type": "git_remotes"
                     }
                   ]
                 },
@@ -6943,14 +6772,7 @@
                 "name": "name",
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -6983,14 +6805,7 @@
                   "name": "name",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "remote",
-                        "-v"
-                      ],
-                      "requires_js": true,
-                      "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                      "type": "git_remotes"
                     }
                   ]
                 },
@@ -7019,14 +6834,7 @@
                 "isVariadic": true,
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -7052,14 +6860,7 @@
                 "isVariadic": true,
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -7448,14 +7249,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -7464,27 +7258,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
@@ -7764,27 +7538,7 @@
                   "name": "branch",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -8838,54 +8592,14 @@
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 }
@@ -8900,54 +8614,14 @@
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 }
@@ -8987,27 +8661,7 @@
               "args": {
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "branch",
-                      "--no-color",
-                      "--sort=-committerdate"
-                    ],
-                    "transforms": [
-                      {
-                        "type": "error_guard",
-                        "starts_with": "fatal:"
-                      },
-                      "split_lines",
-                      "filter_empty",
-                      "trim",
-                      {
-                        "type": "regex_extract",
-                        "pattern": "\\S+",
-                        "name": 0
-                      }
-                    ]
+                    "type": "git_branches"
                   }
                 ]
               }
@@ -9136,27 +8790,7 @@
                   "name": "branch",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -9188,27 +8822,7 @@
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -9216,27 +8830,7 @@
                   "isOptional": true,
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 }
@@ -9253,27 +8847,7 @@
                 "isOptional": true,
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "branch",
-                      "--no-color",
-                      "--sort=-committerdate"
-                    ],
-                    "transforms": [
-                      {
-                        "type": "error_guard",
-                        "starts_with": "fatal:"
-                      },
-                      "split_lines",
-                      "filter_empty",
-                      "trim",
-                      {
-                        "type": "regex_extract",
-                        "pattern": "\\S+",
-                        "name": 0
-                      }
-                    ]
+                    "type": "git_branches"
                   }
                 ]
               }
@@ -9288,27 +8862,7 @@
                 "isOptional": true,
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "branch",
-                      "--no-color",
-                      "--sort=-committerdate"
-                    ],
-                    "transforms": [
-                      {
-                        "type": "error_guard",
-                        "starts_with": "fatal:"
-                      },
-                      "split_lines",
-                      "filter_empty",
-                      "trim",
-                      {
-                        "type": "regex_extract",
-                        "pattern": "\\S+",
-                        "name": 0
-                      }
-                    ]
+                    "type": "git_branches"
                   }
                 ]
               }
@@ -9610,41 +9164,10 @@
               ],
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "-a",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 },
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "tag",
-                    "--list",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    "split_lines",
-                    "filter_empty"
-                  ]
+                  "type": "git_tags"
                 },
                 {
                   "template": [
@@ -10748,28 +10271,7 @@
             ],
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -10879,17 +10381,7 @@
             "isOptional": true,
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "tag",
-                  "--list",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  "split_lines",
-                  "filter_empty"
-                ]
+                "type": "git_tags"
               }
             ]
           }
@@ -11211,27 +10703,7 @@
                   "name": "branch",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -11263,27 +10735,7 @@
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -11291,27 +10743,7 @@
                   "isOptional": true,
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 }
@@ -11357,27 +10789,7 @@
               ],
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },

--- a/specs/defaults.json
+++ b/specs/defaults.json
@@ -20,12 +20,7 @@
           ],
           "generators": [
             {
-              "script": [
-                "defaults",
-                "domains"
-              ],
-              "requires_js": true,
-              "js_source": "function(n){return n.split(\",\").map(i=>({name:i.trim()}))}"
+              "type": "defaults_domains"
             }
           ]
         },
@@ -52,12 +47,7 @@
           ],
           "generators": [
             {
-              "script": [
-                "defaults",
-                "domains"
-              ],
-              "requires_js": true,
-              "js_source": "function(n){return n.split(\",\").map(i=>({name:i.trim()}))}"
+              "type": "defaults_domains"
             }
           ]
         },
@@ -87,12 +77,7 @@
           ],
           "generators": [
             {
-              "script": [
-                "defaults",
-                "domains"
-              ],
-              "requires_js": true,
-              "js_source": "function(n){return n.split(\",\").map(i=>({name:i.trim()}))}"
+              "type": "defaults_domains"
             }
           ]
         },
@@ -119,12 +104,7 @@
           ],
           "generators": [
             {
-              "script": [
-                "defaults",
-                "domains"
-              ],
-              "requires_js": true,
-              "js_source": "function(n){return n.split(\",\").map(i=>({name:i.trim()}))}"
+              "type": "defaults_domains"
             }
           ]
         },
@@ -170,12 +150,7 @@
           ],
           "generators": [
             {
-              "script": [
-                "defaults",
-                "domains"
-              ],
-              "requires_js": true,
-              "js_source": "function(n){return n.split(\",\").map(i=>({name:i.trim()}))}"
+              "type": "defaults_domains"
             }
           ]
         },

--- a/specs/gh.json
+++ b/specs/gh.json
@@ -219,28 +219,7 @@
             "name": "branch",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-r",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -1591,28 +1570,7 @@
                 "name": "branch",
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "branch",
-                      "-r",
-                      "--no-color",
-                      "--sort=-committerdate"
-                    ],
-                    "transforms": [
-                      {
-                        "type": "error_guard",
-                        "starts_with": "fatal:"
-                      },
-                      "split_lines",
-                      "filter_empty",
-                      "trim",
-                      {
-                        "type": "regex_extract",
-                        "pattern": "\\S+",
-                        "name": 0
-                      }
-                    ]
+                    "type": "git_branches"
                   }
                 ]
               }

--- a/specs/git.json
+++ b/specs/git.json
@@ -247,18 +247,9 @@
                   "--all",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -414,18 +405,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -446,18 +428,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -477,18 +450,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -508,18 +472,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -3698,18 +3653,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -4132,27 +4078,7 @@
           ],
           "generators": [
             {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "branch",
-                "--no-color",
-                "--sort=-committerdate"
-              ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                "trim",
-                {
-                  "type": "regex_extract",
-                  "pattern": "\\S+",
-                  "name": 0
-                }
-              ]
+              "type": "git_branches"
             }
           ]
         },
@@ -4161,27 +4087,7 @@
           "isOptional": true,
           "generators": [
             {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "branch",
-                "--no-color",
-                "--sort=-committerdate"
-              ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                "trim",
-                {
-                  "type": "regex_extract",
-                  "pattern": "\\S+",
-                  "name": 0
-                }
-              ]
+              "type": "git_branches"
             }
           ]
         }
@@ -4793,18 +4699,9 @@
               "log",
               "--oneline"
             ],
-            "transforms": [
-              {
-                "type": "error_guard",
-                "starts_with": "fatal:"
-              },
-              "split_lines",
-              "filter_empty",
-              {
-                "type": "column_extract",
-                "column": 0
-              }
-            ]
+            "requires_js": true,
+            "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+            "_corrected_in": "v0.10.0"
           }
         ]
       }
@@ -5057,14 +4954,7 @@
           "isOptional": true,
           "generators": [
             {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "remote",
-                "-v"
-              ],
-              "requires_js": true,
-              "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+              "type": "git_remotes"
             }
           ]
         },
@@ -5073,27 +4963,7 @@
           "isOptional": true,
           "generators": [
             {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "branch",
-                "--no-color",
-                "--sort=-committerdate"
-              ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                "trim",
-                {
-                  "type": "regex_extract",
-                  "pattern": "\\S+",
-                  "name": 0
-                }
-              ]
+              "type": "git_branches"
             }
           ]
         }
@@ -5131,14 +5001,7 @@
             ],
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "remote",
-                  "-v"
-                ],
-                "requires_js": true,
-                "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                "type": "git_remotes"
               }
             ]
           }
@@ -5523,18 +5386,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -5696,14 +5550,7 @@
           "isOptional": true,
           "generators": [
             {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "remote",
-                "-v"
-              ],
-              "requires_js": true,
-              "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+              "type": "git_remotes"
             }
           ]
         },
@@ -5712,27 +5559,7 @@
           "isOptional": true,
           "generators": [
             {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "branch",
-                "--no-color",
-                "--sort=-committerdate"
-              ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                "trim",
-                {
-                  "type": "regex_extract",
-                  "pattern": "\\S+",
-                  "name": 0
-                }
-              ]
+              "type": "git_branches"
             }
           ]
         }
@@ -5822,42 +5649,12 @@
               "log",
               "--oneline"
             ],
-            "transforms": [
-              {
-                "type": "error_guard",
-                "starts_with": "fatal:"
-              },
-              "split_lines",
-              "filter_empty",
-              {
-                "type": "column_extract",
-                "column": 0
-              }
-            ]
+            "requires_js": true,
+            "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+            "_corrected_in": "v0.10.0"
           },
           {
-            "script": [
-              "git",
-              "--no-optional-locks",
-              "branch",
-              "-a",
-              "--no-color",
-              "--sort=-committerdate"
-            ],
-            "transforms": [
-              {
-                "type": "error_guard",
-                "starts_with": "fatal:"
-              },
-              "split_lines",
-              "filter_empty",
-              "trim",
-              {
-                "type": "regex_extract",
-                "pattern": "\\S+",
-                "name": 0
-              }
-            ]
+            "type": "git_branches"
           },
           {
             "requires_js": true,
@@ -5989,42 +5786,12 @@
               "log",
               "--oneline"
             ],
-            "transforms": [
-              {
-                "type": "error_guard",
-                "starts_with": "fatal:"
-              },
-              "split_lines",
-              "filter_empty",
-              {
-                "type": "column_extract",
-                "column": 0
-              }
-            ]
+            "requires_js": true,
+            "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+            "_corrected_in": "v0.10.0"
           },
           {
-            "script": [
-              "git",
-              "--no-optional-locks",
-              "branch",
-              "-a",
-              "--no-color",
-              "--sort=-committerdate"
-            ],
-            "transforms": [
-              {
-                "type": "error_guard",
-                "starts_with": "fatal:"
-              },
-              "split_lines",
-              "filter_empty",
-              "trim",
-              {
-                "type": "regex_extract",
-                "pattern": "\\S+",
-                "name": 0
-              }
-            ]
+            "type": "git_branches"
           }
         ]
       }
@@ -6124,18 +5891,9 @@
                 "log",
                 "--oneline"
               ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                {
-                  "type": "column_extract",
-                  "column": 0
-                }
-              ]
+              "requires_js": true,
+              "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+              "_corrected_in": "v0.10.0"
             }
           ]
         },
@@ -6161,18 +5919,9 @@
                 "log",
                 "--oneline"
               ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                {
-                  "type": "column_extract",
-                  "column": 0
-                }
-              ]
+              "requires_js": true,
+              "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+              "_corrected_in": "v0.10.0"
             }
           ]
         }
@@ -6272,14 +6021,7 @@
               "name": "name",
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -6305,14 +6047,7 @@
               "name": "name",
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -6329,14 +6064,7 @@
             "name": "remote",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "remote",
-                  "-v"
-                ],
-                "requires_js": true,
-                "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                "type": "git_remotes"
               }
             ]
           }
@@ -6349,14 +6077,7 @@
               "name": "old remote",
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -6386,14 +6107,7 @@
             "name": "name",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "remote",
-                  "-v"
-                ],
-                "requires_js": true,
-                "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                "type": "git_remotes"
               }
             ]
           }
@@ -6426,14 +6140,7 @@
               "name": "name",
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -6462,14 +6169,7 @@
             "isVariadic": true,
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "remote",
-                  "-v"
-                ],
-                "requires_js": true,
-                "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                "type": "git_remotes"
               }
             ]
           }
@@ -6495,14 +6195,7 @@
             "isVariadic": true,
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "remote",
-                  "-v"
-                ],
-                "requires_js": true,
-                "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                "type": "git_remotes"
               }
             ]
           }
@@ -6628,18 +6321,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -6900,14 +6584,7 @@
           "isOptional": true,
           "generators": [
             {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "remote",
-                "-v"
-              ],
-              "requires_js": true,
-              "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+              "type": "git_remotes"
             }
           ]
         },
@@ -6916,27 +6593,7 @@
           "isOptional": true,
           "generators": [
             {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "branch",
-                "--no-color",
-                "--sort=-committerdate"
-              ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                "trim",
-                {
-                  "type": "regex_extract",
-                  "pattern": "\\S+",
-                  "name": 0
-                }
-              ]
+              "type": "git_branches"
             }
           ]
         },
@@ -7216,27 +6873,7 @@
               "name": "branch",
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
@@ -7308,18 +6945,9 @@
                     "log",
                     "--oneline"
                   ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    {
-                      "type": "column_extract",
-                      "column": 0
-                    }
-                  ]
+                  "requires_js": true,
+                  "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                  "_corrected_in": "v0.10.0"
                 }
               ]
             }
@@ -7930,18 +7558,9 @@
                     "--all",
                     "--oneline"
                   ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    {
-                      "type": "column_extract",
-                      "column": 0
-                    }
-                  ]
+                  "requires_js": true,
+                  "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                  "_corrected_in": "v0.10.0"
                 }
               ]
             },
@@ -7967,18 +7586,9 @@
                     "--all",
                     "--oneline"
                   ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    {
-                      "type": "column_extract",
-                      "column": 0
-                    }
-                  ]
+                  "requires_js": true,
+                  "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                  "_corrected_in": "v0.10.0"
                 },
                 {
                   "script": [
@@ -7987,18 +7597,9 @@
                     "--all",
                     "--oneline"
                   ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    {
-                      "type": "column_extract",
-                      "column": 0
-                    }
-                  ]
+                  "requires_js": true,
+                  "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                  "_corrected_in": "v0.10.0"
                 }
               ]
             }
@@ -8028,18 +7629,9 @@
                   "--all",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -8068,18 +7660,9 @@
                   "--all",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -8109,18 +7692,9 @@
                   "--all",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -8150,18 +7724,9 @@
                   "--all",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -8213,18 +7778,9 @@
                   "--all",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -8253,18 +7809,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -8380,54 +7927,14 @@
             {
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
             {
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -8442,54 +7949,14 @@
             {
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
             {
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -8529,27 +7996,7 @@
           "args": {
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -8678,27 +8125,7 @@
               "name": "branch",
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
@@ -8713,18 +8140,9 @@
                     "log",
                     "--oneline"
                   ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    {
-                      "type": "column_extract",
-                      "column": 0
-                    }
-                  ]
+                  "requires_js": true,
+                  "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                  "_corrected_in": "v0.10.0"
                 }
               ]
             }
@@ -8739,27 +8157,7 @@
             {
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
@@ -8767,27 +8165,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -8804,27 +8182,7 @@
             "isOptional": true,
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -8839,27 +8197,7 @@
             "isOptional": true,
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -8880,18 +8218,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -8912,18 +8241,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -9183,43 +8503,6 @@
             },
             {
               "type": "git_tags"
-            },
-            {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "branch",
-                "-a",
-                "--no-color",
-                "--sort=-committerdate"
-              ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                "trim",
-                {
-                  "type": "regex_extract",
-                  "pattern": "\\S+",
-                  "name": 0
-                }
-              ]
-            },
-            {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "tag",
-                "--list",
-                "--sort=-committerdate"
-              ],
-              "transforms": [
-                "split_lines",
-                "filter_empty"
-              ]
             },
             {
               "template": [
@@ -9491,18 +8774,9 @@
               "log",
               "--oneline"
             ],
-            "transforms": [
-              {
-                "type": "error_guard",
-                "starts_with": "fatal:"
-              },
-              "split_lines",
-              "filter_empty",
-              {
-                "type": "column_extract",
-                "column": 0
-              }
-            ]
+            "requires_js": true,
+            "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+            "_corrected_in": "v0.10.0"
           }
         ]
       }
@@ -10332,28 +9606,7 @@
         ],
         "generators": [
           {
-            "script": [
-              "git",
-              "--no-optional-locks",
-              "branch",
-              "-a",
-              "--no-color",
-              "--sort=-committerdate"
-            ],
-            "transforms": [
-              {
-                "type": "error_guard",
-                "starts_with": "fatal:"
-              },
-              "split_lines",
-              "filter_empty",
-              "trim",
-              {
-                "type": "regex_extract",
-                "pattern": "\\S+",
-                "name": 0
-              }
-            ]
+            "type": "git_branches"
           }
         ]
       }
@@ -10449,18 +9702,9 @@
                   "log",
                   "--oneline"
                 ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  {
-                    "type": "column_extract",
-                    "column": 0
-                  }
-                ]
+                "requires_js": true,
+                "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                "_corrected_in": "v0.10.0"
               }
             ]
           }
@@ -10472,17 +9716,7 @@
         "isOptional": true,
         "generators": [
           {
-            "script": [
-              "git",
-              "--no-optional-locks",
-              "tag",
-              "--list",
-              "--sort=-committerdate"
-            ],
-            "transforms": [
-              "split_lines",
-              "filter_empty"
-            ]
+            "type": "git_tags"
           }
         ]
       }
@@ -10681,18 +9915,9 @@
                     "log",
                     "--oneline"
                   ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    {
-                      "type": "column_extract",
-                      "column": 0
-                    }
-                  ]
+                  "requires_js": true,
+                  "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                  "_corrected_in": "v0.10.0"
                 }
               ]
             }
@@ -10719,18 +9944,9 @@
                     "log",
                     "--oneline"
                   ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    {
-                      "type": "column_extract",
-                      "column": 0
-                    }
-                  ]
+                  "requires_js": true,
+                  "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                  "_corrected_in": "v0.10.0"
                 }
               ]
             }
@@ -10822,27 +10038,7 @@
               "name": "branch",
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
@@ -10857,18 +10053,9 @@
                     "log",
                     "--oneline"
                   ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    {
-                      "type": "column_extract",
-                      "column": 0
-                    }
-                  ]
+                  "requires_js": true,
+                  "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+                  "_corrected_in": "v0.10.0"
                 }
               ]
             }
@@ -10883,27 +10070,7 @@
             {
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
@@ -10911,27 +10078,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -10977,27 +10124,7 @@
           ],
           "generators": [
             {
-              "script": [
-                "git",
-                "--no-optional-locks",
-                "branch",
-                "--no-color",
-                "--sort=-committerdate"
-              ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                "trim",
-                {
-                  "type": "regex_extract",
-                  "pattern": "\\S+",
-                  "name": 0
-                }
-              ]
+              "type": "git_branches"
             }
           ]
         },
@@ -11012,18 +10139,9 @@
                 "log",
                 "--oneline"
               ],
-              "transforms": [
-                {
-                  "type": "error_guard",
-                  "starts_with": "fatal:"
-                },
-                "split_lines",
-                "filter_empty",
-                {
-                  "type": "column_extract",
-                  "column": 0
-                }
-              ]
+              "requires_js": true,
+              "js_source": "function(e){let t=D(e);return t.startsWith(\"fatal:\")?[]:t.split(`\n`).map(i=>({name:i.substring(0,7),icon:\"fig://icon?type=node\",description:i.substring(7)}))}",
+              "_corrected_in": "v0.10.0"
             }
           ]
         }

--- a/specs/mamba.json
+++ b/specs/mamba.json
@@ -23,13 +23,7 @@
         "name": "environment",
         "generators": [
           {
-            "script": [
-              "conda",
-              "env",
-              "list"
-            ],
-            "requires_js": true,
-            "js_source": "function(i){let e=i.split(`\n`),o=[];for(let n=2;n<e.length;n++){let a=e[n].split(\" \").filter(m=>m!=\"\"),l=a[1]==\"*\";o.push({name:a[0],description:a[a.length-1],priority:l?100:50,icon:l?\"\\u2705\":\"\\u{1F40D}\"})}return o}",
+            "type": "mamba_envs",
             "cache": {}
           }
         ]
@@ -211,13 +205,7 @@
             "name": "env",
             "generators": [
               {
-                "script": [
-                  "conda",
-                  "env",
-                  "list"
-                ],
-                "requires_js": true,
-                "js_source": "function(i){let e=i.split(`\n`),o=[];for(let n=2;n<e.length;n++){let a=e[n].split(\" \").filter(m=>m!=\"\"),l=a[1]==\"*\";o.push({name:a[0],description:a[a.length-1],priority:l?100:50,icon:l?\"\\u2705\":\"\\u{1F40D}\"})}return o}",
+                "type": "mamba_envs",
                 "cache": {}
               }
             ]
@@ -2227,13 +2215,7 @@
             "name": "environment",
             "generators": [
               {
-                "script": [
-                  "conda",
-                  "env",
-                  "list"
-                ],
-                "requires_js": true,
-                "js_source": "function(i){let e=i.split(`\n`),o=[];for(let n=2;n<e.length;n++){let a=e[n].split(\" \").filter(m=>m!=\"\"),l=a[1]==\"*\";o.push({name:a[0],description:a[a.length-1],priority:l?100:50,icon:l?\"\\u2705\":\"\\u{1F40D}\"})}return o}",
+                "type": "mamba_envs",
                 "cache": {}
               }
             ]

--- a/specs/multipass.json
+++ b/specs/multipass.json
@@ -74,13 +74,7 @@
         "isVariadic": true,
         "generators": [
           {
-            "script": [
-              "multipass",
-              "list",
-              "--format=json"
-            ],
-            "requires_js": true,
-            "js_source": "a=>JSON.parse(a).list.map(e=>{if(e.state!==\"Deleted\")return{name:e.name,description:e.release}})"
+            "type": "multipass_list"
           }
         ]
       }
@@ -94,13 +88,7 @@
           "description": "Name of the instance to run the command on",
           "generators": [
             {
-              "script": [
-                "multipass",
-                "list",
-                "--format=json"
-              ],
-              "requires_js": true,
-              "js_source": "a=>JSON.parse(a).list.map(e=>{if(e.state!==\"Deleted\")return{name:e.name,description:e.release}})"
+              "type": "multipass_list"
             }
           ]
         },
@@ -235,13 +223,7 @@
         "isVariadic": true,
         "generators": [
           {
-            "script": [
-              "multipass",
-              "list",
-              "--format=json"
-            ],
-            "requires_js": true,
-            "js_source": "a=>JSON.parse(a).list.map(e=>{if(e.state!==\"Deleted\")return{name:e.name,description:e.release}})"
+            "type": "multipass_list"
           }
         ]
       }
@@ -458,13 +440,7 @@
         "isVariadic": true,
         "generators": [
           {
-            "script": [
-              "multipass",
-              "list",
-              "--format=json"
-            ],
-            "requires_js": true,
-            "js_source": "a=>JSON.parse(a).list.map(e=>{if(e.state===\"Deleted\")return{name:e.name,description:e.release}})"
+            "type": "multipass_list"
           }
         ]
       }
@@ -496,13 +472,7 @@
         "isOptional": true,
         "generators": [
           {
-            "script": [
-              "multipass",
-              "list",
-              "--format=json"
-            ],
-            "requires_js": true,
-            "js_source": "a=>JSON.parse(a).list.map(e=>{if(e.state!==\"Deleted\")return{name:e.name,description:e.release}})"
+            "type": "multipass_list"
           }
         ]
       }
@@ -556,13 +526,7 @@
         "isOptional": true,
         "generators": [
           {
-            "script": [
-              "multipass",
-              "list",
-              "--format=json"
-            ],
-            "requires_js": true,
-            "js_source": "a=>JSON.parse(a).list.map(e=>{if(e.state!==\"Deleted\")return{name:e.name,description:e.release}})"
+            "type": "multipass_list"
           }
         ]
       }
@@ -594,13 +558,7 @@
         "isOptional": true,
         "generators": [
           {
-            "script": [
-              "multipass",
-              "list",
-              "--format=json"
-            ],
-            "requires_js": true,
-            "js_source": "a=>JSON.parse(a).list.map(e=>{if(e.state===\"Stopped\")return{name:e.name,description:e.release}})"
+            "type": "multipass_list"
           }
         ]
       }
@@ -640,13 +598,7 @@
         "isOptional": true,
         "generators": [
           {
-            "script": [
-              "multipass",
-              "list",
-              "--format=json"
-            ],
-            "requires_js": true,
-            "js_source": "a=>JSON.parse(a).list.map(e=>{if(e.state===\"Running\")return{name:e.name,description:e.release}})"
+            "type": "multipass_list"
           }
         ]
       }
@@ -669,13 +621,7 @@
         "isOptional": true,
         "generators": [
           {
-            "script": [
-              "multipass",
-              "list",
-              "--format=json"
-            ],
-            "requires_js": true,
-            "js_source": "a=>JSON.parse(a).list.map(e=>{if(e.state===\"Running\")return{name:e.name,description:e.release}})"
+            "type": "multipass_list"
           }
         ]
       }

--- a/specs/pandoc.json
+++ b/specs/pandoc.json
@@ -14,14 +14,7 @@
         "name": "format",
         "generators": [
           {
-            "script": [
-              "pandoc",
-              "--list-input-formats"
-            ],
-            "transforms": [
-              "split_lines",
-              "filter_empty"
-            ]
+            "type": "pandoc_input_formats"
           }
         ]
       }
@@ -38,14 +31,7 @@
         "name": "format",
         "generators": [
           {
-            "script": [
-              "pandoc",
-              "--list-output-formats"
-            ],
-            "transforms": [
-              "split_lines",
-              "filter_empty"
-            ]
+            "type": "pandoc_output_formats"
           }
         ]
       }
@@ -143,20 +129,10 @@
         "isOptional": true,
         "generators": [
           {
-            "script": [
-              "pandoc",
-              "--list-input-formats"
-            ],
-            "requires_js": true,
-            "js_source": "function(e){return Array.from(new Set(e.split(`\n`))).map(n=>({name:n,icon:`fig://icon?type=${n}`}))}"
+            "type": "pandoc_input_formats"
           },
           {
-            "script": [
-              "pandoc",
-              "--list-output-formats"
-            ],
-            "requires_js": true,
-            "js_source": "function(e){return Array.from(new Set(e.split(`\n`))).map(n=>({name:n,icon:`fig://icon?type=${n}`}))}"
+            "type": "pandoc_output_formats"
           }
         ]
       }
@@ -375,14 +351,7 @@
         "name": "format",
         "generators": [
           {
-            "script": [
-              "pandoc",
-              "--list-output-formats"
-            ],
-            "transforms": [
-              "split_lines",
-              "filter_empty"
-            ]
+            "type": "pandoc_output_formats"
           }
         ]
       }

--- a/specs/pass.json
+++ b/specs/pass.json
@@ -4134,27 +4134,7 @@
               ],
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
@@ -4163,27 +4143,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -5050,14 +5010,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -5066,27 +5019,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -5124,14 +5057,7 @@
                 ],
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -5680,14 +5606,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -5696,27 +5615,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             }
@@ -5811,28 +5710,7 @@
                 "_corrected_in": "v0.10.0"
               },
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               },
               {
                 "requires_js": true,
@@ -5969,28 +5847,7 @@
                 "_corrected_in": "v0.10.0"
               },
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -6220,14 +6077,7 @@
                   "name": "name",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "remote",
-                        "-v"
-                      ],
-                      "requires_js": true,
-                      "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                      "type": "git_remotes"
                     }
                   ]
                 },
@@ -6253,14 +6103,7 @@
                   "name": "name",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "remote",
-                        "-v"
-                      ],
-                      "requires_js": true,
-                      "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                      "type": "git_remotes"
                     }
                   ]
                 },
@@ -6277,14 +6120,7 @@
                 "name": "remote",
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -6297,14 +6133,7 @@
                   "name": "old remote",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "remote",
-                        "-v"
-                      ],
-                      "requires_js": true,
-                      "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                      "type": "git_remotes"
                     }
                   ]
                 },
@@ -6334,14 +6163,7 @@
                 "name": "name",
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -6374,14 +6196,7 @@
                   "name": "name",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "remote",
-                        "-v"
-                      ],
-                      "requires_js": true,
-                      "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                      "type": "git_remotes"
                     }
                   ]
                 },
@@ -6410,14 +6225,7 @@
                 "isVariadic": true,
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -6443,14 +6251,7 @@
                 "isVariadic": true,
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "remote",
-                      "-v"
-                    ],
-                    "requires_js": true,
-                    "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                    "type": "git_remotes"
                   }
                 ]
               }
@@ -6839,14 +6640,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "remote",
-                    "-v"
-                  ],
-                  "requires_js": true,
-                  "js_source": "function(e){let t=e.split(`\n`).reduce((i,o)=>{let a=o.split(\"\t\"),r=a[0],s=a[1].split(\" \")[0];return i[r]=s,i},{});return Object.keys(t).map(i=>{let o=t[i],a=\"box\";return o.includes(\"github.com\")&&(a=\"github\"),o.includes(\"gitlab.com\")&&(a=\"gitlab\"),o.includes(\"heroku.com\")&&(a=\"heroku\"),{name:i,icon:`fig://icon?type=${a}`,description:\"Remote\"}})}"
+                  "type": "git_remotes"
                 }
               ]
             },
@@ -6855,27 +6649,7 @@
               "isOptional": true,
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },
@@ -7155,27 +6929,7 @@
                   "name": "branch",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -8229,54 +7983,14 @@
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 }
@@ -8291,54 +8005,14 @@
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 }
@@ -8378,27 +8052,7 @@
               "args": {
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "branch",
-                      "--no-color",
-                      "--sort=-committerdate"
-                    ],
-                    "transforms": [
-                      {
-                        "type": "error_guard",
-                        "starts_with": "fatal:"
-                      },
-                      "split_lines",
-                      "filter_empty",
-                      "trim",
-                      {
-                        "type": "regex_extract",
-                        "pattern": "\\S+",
-                        "name": 0
-                      }
-                    ]
+                    "type": "git_branches"
                   }
                 ]
               }
@@ -8527,27 +8181,7 @@
                   "name": "branch",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -8579,27 +8213,7 @@
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -8607,27 +8221,7 @@
                   "isOptional": true,
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 }
@@ -8644,27 +8238,7 @@
                 "isOptional": true,
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "branch",
-                      "--no-color",
-                      "--sort=-committerdate"
-                    ],
-                    "transforms": [
-                      {
-                        "type": "error_guard",
-                        "starts_with": "fatal:"
-                      },
-                      "split_lines",
-                      "filter_empty",
-                      "trim",
-                      {
-                        "type": "regex_extract",
-                        "pattern": "\\S+",
-                        "name": 0
-                      }
-                    ]
+                    "type": "git_branches"
                   }
                 ]
               }
@@ -8679,27 +8253,7 @@
                 "isOptional": true,
                 "generators": [
                   {
-                    "script": [
-                      "git",
-                      "--no-optional-locks",
-                      "branch",
-                      "--no-color",
-                      "--sort=-committerdate"
-                    ],
-                    "transforms": [
-                      {
-                        "type": "error_guard",
-                        "starts_with": "fatal:"
-                      },
-                      "split_lines",
-                      "filter_empty",
-                      "trim",
-                      {
-                        "type": "regex_extract",
-                        "pattern": "\\S+",
-                        "name": 0
-                      }
-                    ]
+                    "type": "git_branches"
                   }
                 ]
               }
@@ -9001,41 +8555,10 @@
               ],
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "-a",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 },
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "tag",
-                    "--list",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    "split_lines",
-                    "filter_empty"
-                  ]
+                  "type": "git_tags"
                 },
                 {
                   "template": [
@@ -10139,28 +9662,7 @@
             ],
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -10270,17 +9772,7 @@
             "isOptional": true,
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "tag",
-                  "--list",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  "split_lines",
-                  "filter_empty"
-                ]
+                "type": "git_tags"
               }
             ]
           }
@@ -10602,27 +10094,7 @@
                   "name": "branch",
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -10654,27 +10126,7 @@
                 {
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 },
@@ -10682,27 +10134,7 @@
                   "isOptional": true,
                   "generators": [
                     {
-                      "script": [
-                        "git",
-                        "--no-optional-locks",
-                        "branch",
-                        "--no-color",
-                        "--sort=-committerdate"
-                      ],
-                      "transforms": [
-                        {
-                          "type": "error_guard",
-                          "starts_with": "fatal:"
-                        },
-                        "split_lines",
-                        "filter_empty",
-                        "trim",
-                        {
-                          "type": "regex_extract",
-                          "pattern": "\\S+",
-                          "name": 0
-                        }
-                      ]
+                      "type": "git_branches"
                     }
                   ]
                 }
@@ -10748,27 +10180,7 @@
               ],
               "generators": [
                 {
-                  "script": [
-                    "git",
-                    "--no-optional-locks",
-                    "branch",
-                    "--no-color",
-                    "--sort=-committerdate"
-                  ],
-                  "transforms": [
-                    {
-                      "type": "error_guard",
-                      "starts_with": "fatal:"
-                    },
-                    "split_lines",
-                    "filter_empty",
-                    "trim",
-                    {
-                      "type": "regex_extract",
-                      "pattern": "\\S+",
-                      "name": 0
-                    }
-                  ]
+                  "type": "git_branches"
                 }
               ]
             },

--- a/specs/pre-commit.json
+++ b/specs/pre-commit.json
@@ -511,28 +511,7 @@
             "name": "REMOTE_BRANCH",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -546,27 +525,7 @@
             "name": "LOCAL_BRANCH",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -637,14 +596,7 @@
             "name": "REMOTE_NAME",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "remote",
-                  "-v"
-                ],
-                "requires_js": true,
-                "js_source": "function(i){let e=i.split(`\n`).reduce((t,s)=>{let n=s.split(\"\t\"),o=n[0],r=n[1].split(\" \")[0];return t[o]=r,t},{});return Object.keys(e).map(t=>{let s=e[t],n=\"box\";return s.includes(\"github.com\")&&(n=\"github\"),s.includes(\"gitlab.com\")&&(n=\"gitlab\"),s.includes(\"heroku.com\")&&(n=\"heroku\"),{name:t,icon:`fig://icon?type=${n}`,description:\"Remote\"}})}"
+                "type": "git_remotes"
               }
             ]
           }
@@ -867,28 +819,7 @@
             "name": "REMOTE_BRANCH",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -902,27 +833,7 @@
             "name": "LOCAL_BRANCH",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -993,14 +904,7 @@
             "name": "REMOTE_NAME",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "remote",
-                  "-v"
-                ],
-                "requires_js": true,
-                "js_source": "function(i){let e=i.split(`\n`).reduce((t,s)=>{let n=s.split(\"\t\"),o=n[0],r=n[1].split(\" \")[0];return t[o]=r,t},{});return Object.keys(e).map(t=>{let s=e[t],n=\"box\";return s.includes(\"github.com\")&&(n=\"github\"),s.includes(\"gitlab.com\")&&(n=\"gitlab\"),s.includes(\"heroku.com\")&&(n=\"heroku\"),{name:t,icon:`fig://icon?type=${n}`,description:\"Remote\"}})}"
+                "type": "git_remotes"
               }
             ]
           }

--- a/specs/turbo.json
+++ b/specs/turbo.json
@@ -127,28 +127,7 @@
             "name": "branch",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }

--- a/specs/vsce.json
+++ b/specs/vsce.json
@@ -141,28 +141,7 @@
             "name": "branch",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -176,28 +155,7 @@
             "name": "branch",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -379,28 +337,7 @@
             "name": "branch",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }
@@ -414,28 +351,7 @@
             "name": "branch",
             "generators": [
               {
-                "script": [
-                  "git",
-                  "--no-optional-locks",
-                  "branch",
-                  "-a",
-                  "--no-color",
-                  "--sort=-committerdate"
-                ],
-                "transforms": [
-                  {
-                    "type": "error_guard",
-                    "starts_with": "fatal:"
-                  },
-                  "split_lines",
-                  "filter_empty",
-                  "trim",
-                  {
-                    "type": "regex_extract",
-                    "pattern": "\\S+",
-                    "name": 0
-                  }
-                ]
+                "type": "git_branches"
               }
             ]
           }

--- a/tools/fig-converter/src/index.js
+++ b/tools/fig-converter/src/index.js
@@ -230,7 +230,7 @@ function processGenerator(gen, specName) {
 
   // Case: has a script array — check native map first
   if (gen.script && Array.isArray(gen.script)) {
-    const nativeGen = matchNativeGenerator(specName, gen.script);
+    const nativeGen = matchNativeGenerator(specName, gen.script, gen._postProcessSource);
     if (nativeGen) {
       // Native generator takes priority — emit type-only generator
       const result = { ...nativeGen };

--- a/tools/fig-converter/src/native-map.js
+++ b/tools/fig-converter/src/native-map.js
@@ -14,17 +14,100 @@ const NATIVE_GENERATOR_MAP = {
   'git branch': { type: 'git_branches' },
   'git tag': { type: 'git_tags' },
   'git remote': { type: 'git_remotes' },
+  'multipass list': { type: 'multipass_list' },
+  'defaults domains': { type: 'defaults_domains' },
+  'pandoc --list-input-formats': { type: 'pandoc_input_formats' },
+  'pandoc --list-output-formats': { type: 'pandoc_output_formats' },
+  'ansible-doc --list': { type: 'ansible_doc_modules' },
 };
+
+/**
+ * Spec-scoped mappings: `(specName, scriptKey)` → provider. Used when the
+ * same subprocess appears in multiple specs but we only want to route one
+ * of them through the native provider (e.g., `conda env list` appears in
+ * both `mamba.json` and `conda.json`; we have a `mamba_envs` provider
+ * but no `conda_envs` provider yet, so the conda spec stays requires_js).
+ */
+const SPEC_SCOPED_MAP = {
+  mamba: {
+    'conda env': { type: 'mamba_envs' },
+  },
+};
+
+/**
+ * Flags passed to the driver command that don't change the subprocess's output
+ * shape and therefore should not affect which native generator matches. Upstream
+ * fig specs use these as "safe" prefixes (e.g., `git --no-optional-locks branch`
+ * to avoid updating `index.lock`), but for the purposes of native-map dispatch
+ * they're semantically identical to the bare form.
+ *
+ * Keyed by the driver command (first argv token) so we only strip flags we've
+ * explicitly audited as no-ops for THAT command.
+ *
+ * See docs/phase-minus-1-followups.md §1 for the rationale: the previous regen
+ * deferred git.json because the fig source uses this prefix and the old matcher
+ * couldn't see through it.
+ */
+const NO_OP_DRIVER_FLAGS = {
+  git: new Set(['--no-optional-locks']),
+};
+
+/**
+ * Derive the two-token matching key from a script argv, skipping any
+ * driver-specific no-op flags between the driver command and its first real
+ * subcommand. Returns `null` if the script is too short to produce a key.
+ */
+function deriveKey(scriptArgv) {
+  if (!Array.isArray(scriptArgv) || scriptArgv.length < 2) return null;
+  const driver = scriptArgv[0];
+  const noops = NO_OP_DRIVER_FLAGS[driver];
+  if (!noops) return scriptArgv.slice(0, 2).join(' ');
+  for (let i = 1; i < scriptArgv.length; i++) {
+    if (!noops.has(scriptArgv[i])) {
+      return `${driver} ${scriptArgv[i]}`;
+    }
+  }
+  return null;
+}
 
 /**
  * Check if a script command matches a native Ghost Complete generator.
  *
- * @param {string} specName - The spec name (for context, currently unused)
+ * @param {string} specName - The spec name (used for spec-scoped mappings and arduino disambiguation)
  * @param {string[]} scriptArgv - The script command as an array
+ * @param {string} [postProcessSource] - Stringified postProcess function, used to
+ *   disambiguate generators that share the same script (e.g., arduino-cli board list
+ *   is used for both fqbn and port suggestions).
  * @returns {object|null} Native generator spec (e.g., { type: 'git_branches' }) or null
  */
-export function matchNativeGenerator(specName, scriptArgv) {
-  if (!Array.isArray(scriptArgv) || scriptArgv.length < 2) return null;
-  const key = scriptArgv.slice(0, 2).join(' ');
+export function matchNativeGenerator(specName, scriptArgv, postProcessSource) {
+  const key = deriveKey(scriptArgv);
+  if (key === null) return null;
+
+  // arduino-cli: boards vs ports share the same key, disambiguated by postProcess.
+  if (key === 'arduino-cli board' && typeof postProcessSource === 'string') {
+    // FQBN shape: description templates include `port.address` but the
+    // suggestion NAME is the fqbn. Be specific — match on the fqbn token
+    // in the `name:` position so we don't mistake port-extractor sources
+    // that ALSO mention fqbn for context.
+    if (/name:\s*[a-zA-Z_$]+\.matching_boards\[0\]\.fqbn/.test(postProcessSource)) {
+      return { type: 'arduino_cli_boards' };
+    }
+    // Port-address shape: suggestion NAME is port.address, description
+    // contains the "port connection" substring (exact match on the JS
+    // source from the real fig spec).
+    if (
+      /name:\s*[a-zA-Z_$]+\.port\.address/.test(postProcessSource)
+      && postProcessSource.includes('port connection')
+    ) {
+      return { type: 'arduino_cli_ports' };
+    }
+    return null;
+  }
+
+  // Spec-scoped lookup (overrides global for specific specs).
+  const scoped = SPEC_SCOPED_MAP[specName];
+  if (scoped && scoped[key]) return scoped[key];
+
   return NATIVE_GENERATOR_MAP[key] || null;
 }

--- a/tools/fig-converter/src/native-map.test.js
+++ b/tools/fig-converter/src/native-map.test.js
@@ -2,6 +2,11 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { matchNativeGenerator } from './native-map.js';
 
+// Real postProcess JS source strings taken from specs/arduino-cli.json (the
+// pre-regen output). Used as fixtures for the arduino-cli disambiguation tests.
+const ARDUINO_FQBN_POSTPROCESS = "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.matching_boards[0].fqbn,description:`${i.matching_boards[0].name} on port ${i.port.address}`}))}catch{return[]}}";
+const ARDUINO_PORT_POSTPROCESS = "t=>{try{return JSON.parse(t).filter(i=>i.matching_boards).map(i=>({name:i.port.address,description:`${i.matching_boards[0].name} port connection`}))}catch{return[]}}";
+
 describe('matchNativeGenerator', () => {
   it('maps git branch to git_branches', () => {
     const result = matchNativeGenerator('git', ['git', 'branch', '--no-color']);
@@ -40,5 +45,125 @@ describe('matchNativeGenerator', () => {
   it('does not match partial commands', () => {
     // 'git branches' is not 'git branch'
     assert.equal(matchNativeGenerator('git', ['git', 'branches']), null);
+  });
+
+  it('maps multipass list to multipass_list', () => {
+    const result = matchNativeGenerator('multipass', ['multipass', 'list', '--format', 'json']);
+    assert.deepStrictEqual(result, { type: 'multipass_list' });
+  });
+
+  it('maps defaults domains to defaults_domains', () => {
+    const result = matchNativeGenerator('defaults', ['defaults', 'domains']);
+    assert.deepStrictEqual(result, { type: 'defaults_domains' });
+  });
+
+  it('maps pandoc --list-input-formats to pandoc_input_formats', () => {
+    const result = matchNativeGenerator('pandoc', ['pandoc', '--list-input-formats']);
+    assert.deepStrictEqual(result, { type: 'pandoc_input_formats' });
+  });
+
+  it('maps pandoc --list-output-formats to pandoc_output_formats', () => {
+    const result = matchNativeGenerator('pandoc', ['pandoc', '--list-output-formats']);
+    assert.deepStrictEqual(result, { type: 'pandoc_output_formats' });
+  });
+
+  it('maps ansible-doc --list to ansible_doc_modules', () => {
+    // Short form: just `ansible-doc --list`.
+    assert.deepStrictEqual(
+      matchNativeGenerator('ansible-doc', ['ansible-doc', '--list']),
+      { type: 'ansible_doc_modules' },
+    );
+    // Long form with --json: key is still built from the first two elements.
+    assert.deepStrictEqual(
+      matchNativeGenerator('ansible-doc', ['ansible-doc', '--list', '--json']),
+      { type: 'ansible_doc_modules' },
+    );
+  });
+
+  it('maps conda env list to mamba_envs only for mamba spec', () => {
+    // In the mamba spec, `conda env list` routes to our mamba_envs provider.
+    assert.deepStrictEqual(
+      matchNativeGenerator('mamba', ['conda', 'env', 'list']),
+      { type: 'mamba_envs' },
+    );
+    // In the conda spec, the same script stays unmapped (no conda_envs provider yet).
+    assert.equal(
+      matchNativeGenerator('conda', ['conda', 'env', 'list']),
+      null,
+    );
+  });
+
+  it('maps arduino-cli board list to arduino_cli_boards when postProcess is fqbn-extracting', () => {
+    const result = matchNativeGenerator(
+      'arduino-cli',
+      ['arduino-cli', 'board', 'list', '--format', 'json'],
+      ARDUINO_FQBN_POSTPROCESS,
+    );
+    assert.deepStrictEqual(result, { type: 'arduino_cli_boards' });
+  });
+
+  it('maps arduino-cli board list to arduino_cli_ports when postProcess is port-extracting', () => {
+    const result = matchNativeGenerator(
+      'arduino-cli',
+      ['arduino-cli', 'board', 'list', '--format', 'json'],
+      ARDUINO_PORT_POSTPROCESS,
+    );
+    assert.deepStrictEqual(result, { type: 'arduino_cli_ports' });
+  });
+
+  it('returns null for arduino-cli board with missing or unrecognized postProcess', () => {
+    // No postProcess at all — can't disambiguate, return null rather than guess.
+    assert.equal(
+      matchNativeGenerator('arduino-cli', ['arduino-cli', 'board', 'list', '--format', 'json']),
+      null,
+    );
+    // Unrelated postProcess (doesn't match either the fqbn or port pattern).
+    assert.equal(
+      matchNativeGenerator(
+        'arduino-cli',
+        ['arduino-cli', 'board', 'list', '--format', 'json'],
+        't => t.split("\\n")',
+      ),
+      null,
+    );
+  });
+
+  it('new third argument does not affect existing git mappings', () => {
+    // Regression check: passing an extraneous postProcess source for a non-arduino
+    // key should not interfere with the normal lookup.
+    const result = matchNativeGenerator('git', ['git', 'branch'], 'some js source');
+    assert.deepStrictEqual(result, { type: 'git_branches' });
+  });
+
+  it('strips git --no-optional-locks prefix before matching', () => {
+    // Upstream fig git spec uses `["git", "--no-optional-locks", "branch", ...]`
+    // as the canonical script prefix (avoids touching index.lock). Without
+    // stripping this driver-level no-op, every git generator would miss the
+    // native map. See docs/phase-minus-1-followups.md §1 for the deferred
+    // bug this fix closes.
+    assert.deepStrictEqual(
+      matchNativeGenerator(
+        'git',
+        ['git', '--no-optional-locks', 'branch', '-a', '--no-color', '--sort=-committerdate'],
+      ),
+      { type: 'git_branches' },
+    );
+    assert.deepStrictEqual(
+      matchNativeGenerator('git', ['git', '--no-optional-locks', 'tag', '--list']),
+      { type: 'git_tags' },
+    );
+    assert.deepStrictEqual(
+      matchNativeGenerator('git', ['git', '--no-optional-locks', 'remote']),
+      { type: 'git_remotes' },
+    );
+  });
+
+  it('only strips no-op flags for their driver command', () => {
+    // `--no-optional-locks` is a git-specific no-op. If another command happens
+    // to use a literal argv element of that name, we must NOT skip over it.
+    assert.equal(
+      matchNativeGenerator('other', ['other', '--no-optional-locks', 'branch']),
+      null,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Implements Phase 3A of the [requires-js specs initiative](../blob/integration/requires-js-specs/docs/plans/2026-04-21-requires-js-specs.md) — 8 async Rust providers replacing qualifying `requires_js` script generators, reducing the JS-runtime dependency footprint and shrinking the embedded-specs payload.

## Providers implemented

| Provider type | Source command | Wire format | Extracts |
|---|---|---|---|
| `arduino_cli_boards` | `arduino-cli board list --format json` | JSON | `matching_boards[0].fqbn` (e.g. `arduino:avr:uno`) |
| `arduino_cli_ports` | `arduino-cli board list --format json` (same subprocess as `arduino_cli_boards`, routed via postProcess-source regex) | JSON | `port.address` (e.g. `/dev/ttyACM0`) |
| `mamba_envs` | `conda env list` | plaintext lines (header-stripped) | first whitespace-delimited column |
| `multipass_list` | `multipass list --format=json` | JSON | `list[].name` with `{release} ({state})` description |
| `defaults_domains` | `defaults domains` | comma-separated single line | trimmed domain names |
| `pandoc_input_formats` | `pandoc --list-input-formats` | one format per line | format identifiers |
| `pandoc_output_formats` | `pandoc --list-output-formats` | one format per line | format identifiers |
| `ansible_doc_modules` | `ansible-doc --list --json` | JSON object `{module: description}` | keys as suggestion text, values as descriptions |

All 8 genuinely qualify against plan §3A criteria (single subprocess, no auth, no pagination, no file-system parsing, stable text output, no new deps). **Dropped from spike candidate list as non-qualifying** (with reasons): flyctl, tsh, firebase, amplify, bosh, pulumi (auth); cordova, trex, ng (file-parsing); deployctl, elm, nativescript, ns, tns, stepzen (HTTP); youtube-dl (pbpaste); gource, networkQuality (mismatched commands); expo/expo-cli (xcodebuild shell pipeline); asdf, trivy, eslint, env (no observed scripts); expressots, git-profile, sake, assimp, watson (niche).

## Architecture

New `gc-suggest::providers` module — Provider trait with RTPIT async (`fn generate(...) -> impl Future + Send`), ProviderCtx (cwd, env, current_token), ProviderKind enum, string→kind dispatcher, engine integration via `resolve_providers` alongside the existing `resolve_git` in the handler's `tokio::join!`. See [`docs/PROVIDERS.md`](docs/PROVIDERS.md) (42 lines) for the add-a-provider recipe.

Converter: `tools/fig-converter/src/native-map.js` extended with 8 new mappings, `SPEC_SCOPED_MAP` for spec-name-scoped routing (conda env list → mamba_envs only in mamba.json), `postProcessSource` regex disambiguation for arduino-cli boards-vs-ports, and `NO_OP_DRIVER_FLAGS` stripping to reclaim git_branches/git_tags/git_remotes routing across 7 incidental specs that were passing `--no-optional-locks`.

## Impact

- **329 gc-suggest tests** (up from 287, +42). Full workspace: all suites green.
- **Converter tests: 114 passing** (up from 82, +32 mostly from native-map expansion).
- **Binary size delta: -62 KB net** (49,567,616 → 49,505,488). Provider monomorphization adds ~114 KB; spec regen's drop of `js_source` strings reclaims ~176 KB. Well under the plan's +200 KB stop-line.
- **Native generator count in corpus: 47 → 212** (+165, driven predominantly by the git no-op-flag fix touching 7 specs; Phase 3A's own 8 providers contribute the remainder).
- **Partially-functional spec count**: 183 commands still carry some `requires_js` generators (the 8 providers targeted specific shapes; the commands retain JS generators for unrelated parameters).
- **Zero new transitive deps** in `gc-suggest`. `cargo tree` byte-identical before/after: anyhow, dirs, gc-buffer, gc-config, libc, nucleo, regex, serde, serde_json, tempfile, tokio, tracing.

## Commits

```
07441d5 docs: add PROVIDERS.md for Phase 3A native-provider pipeline
cd7a007 Phase 3A: update history-at-arg-position test to not collide with git_remotes
2df9a12 chore(specs): regenerate after native providers
dc8999a Phase 3A: ansible_doc_modules provider
930e205 Phase 3A: pandoc_input_formats + pandoc_output_formats providers
b750683 Phase 3A: defaults_domains provider
5765def Phase 3A: multipass_list provider
227a124 Phase 3A: mamba_envs provider
d0915ed Phase 3A: arduino_cli_ports provider
edbf0c0 Phase 3A T2: parametric binary name for test injection (no global-state tests)
90026df Phase 3A: arduino_cli_boards provider
a832de7 Phase 3A: T1 review fixes — guard script fall-through, add precedence test
ea0c459 Phase 3A: scaffold Provider trait + ProviderCtx + ProviderKind wiring
```

## Test plan

- [x] `cargo test --workspace` — 329 gc-suggest + 53 + 138 + 93 + 101 + 78 + 102 + 11 all passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo tree -p gc-suggest` — no new deps vs `origin/integration/requires-js-specs`
- [x] `npm test` in tools/fig-converter — 114 passing (including 12 new native-map tests)
- [x] `ghost-complete validate-specs` — 717/720 OK (3 failures are in the user's local override dir, pre-existing)
- [x] `ghost-complete status` — embedded specs load, 709 total, 526 fully functional
- [ ] Interactive spot-test via `cargo run -- /bin/zsh` → `arduino-cli board <TAB>` (deferred to maintainer — requires arduino-cli installed on test host; all pathways are unit-tested through the pure extractor + subprocess-injection patterns)

## Umbrella PR

Targets `integration/requires-js-specs` per the umbrella PR #75 convention. Tick "Phase 3A" on the umbrella checklist after merge.

## Follow-up flagged but out of scope

- `collect_generators` now takes 6 `&mut` out-parameters; a future cleanup could bundle into a `GeneratorBuckets` struct (not urgent — parameter set is stable through the current provider surface).
- Provider-level caching (`CacheConfig.ttl_seconds`, `cache_by_directory`) is unused by providers today; each provider's subprocess fires fresh per trigger. Documented in PROVIDERS.md as a deliberate T11-scope non-goal.