### PR TITLE
fix: reset popup scroll state synchronously on new prompt (#83)

### DIFF
--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -161,6 +161,7 @@ impl Perform for TerminalState {
                         // the proxy can query the real terminal for the actual
                         // cursor position and correct any VT tracking drift.
                         self.request_cursor_sync();
+                        self.mark_prompt_started();
                         self.set_prompt_row(self.cursor_row());
                         self.set_in_prompt(true);
                         tracing::debug!(
@@ -196,6 +197,7 @@ impl Perform for TerminalState {
                 match params[1] {
                     b"A" => {
                         self.request_cursor_sync();
+                        self.mark_prompt_started();
                         self.set_prompt_row(self.cursor_row());
                         self.set_in_prompt(true);
                         tracing::debug!(
@@ -627,6 +629,14 @@ mod tests {
     }
 
     #[test]
+    fn test_osc133_prompt_a_sets_prompt_started() {
+        let mut p = make_parser();
+        assert!(!p.state_mut().take_prompt_started());
+        p.process_bytes(b"\x1b]133;A\x07");
+        assert!(p.state_mut().take_prompt_started());
+    }
+
+    #[test]
     fn test_osc133_prompt_c() {
         let mut p = make_parser();
         p.process_bytes(b"\x1b]133;A\x07"); // start prompt
@@ -645,6 +655,14 @@ mod tests {
         assert_eq!(p.state().prompt_row(), Some(2));
         assert!(p.state().in_prompt());
         assert!(p.state_mut().take_cursor_sync_requested());
+    }
+
+    #[test]
+    fn test_osc7771_prompt_a_sets_prompt_started() {
+        let mut p = make_parser();
+        assert!(!p.state_mut().take_prompt_started());
+        p.process_bytes(b"\x1b]7771;A\x07");
+        assert!(p.state_mut().take_prompt_started());
     }
 
     #[test]

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -46,11 +46,11 @@ pub struct TerminalState {
     cwd_dirty: bool,
     cursor_sync_requested: bool,
     cpr_synced: bool,
-    /// Set to true on every detected new-prompt boundary (OSC 133;A or OSC
-    /// 7771;A) so the handler can synchronously reset render state that's
-    /// scoped to a single prompt context (e.g., scroll_deficit). Unlike
-    /// cpr_synced this does NOT depend on a terminal roundtrip — it fires
-    /// the moment the parser sees the prompt-start sequence.
+    /// Sentinel set on each detected new-prompt boundary (OSC 133;A or OSC
+    /// 7771;A). Drives synchronous per-prompt render-state reset (e.g.
+    /// scroll_deficit) — independent of cpr_synced, which depends on a
+    /// terminal CPR roundtrip and may land later or not at all on terminals
+    /// without robust CPR support.
     prompt_started: bool,
     /// FIFO queue of pending CPR requests in send-order.
     ///

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -46,6 +46,12 @@ pub struct TerminalState {
     cwd_dirty: bool,
     cursor_sync_requested: bool,
     cpr_synced: bool,
+    /// Set to true on every detected new-prompt boundary (OSC 133;A or OSC
+    /// 7771;A) so the handler can synchronously reset render state that's
+    /// scoped to a single prompt context (e.g., scroll_deficit). Unlike
+    /// cpr_synced this does NOT depend on a terminal roundtrip — it fires
+    /// the moment the parser sees the prompt-start sequence.
+    prompt_started: bool,
     /// FIFO queue of pending CPR requests in send-order.
     ///
     /// Terminals respond to `CSI 6n` requests in the same order they
@@ -77,6 +83,7 @@ impl TerminalState {
             cwd_dirty: false,
             cursor_sync_requested: false,
             cpr_synced: false,
+            prompt_started: false,
             cpr_queue: VecDeque::new(),
             next_cpr_id: 0,
         }
@@ -169,6 +176,15 @@ impl TerminalState {
         let synced = self.cpr_synced;
         self.cpr_synced = false;
         synced
+    }
+
+    /// Returns true if a new prompt was detected since the last check, and
+    /// clears the flag atomically. Drives synchronous reset of per-prompt
+    /// render state in the handler — independent of the async CPR sync.
+    pub fn take_prompt_started(&mut self) -> bool {
+        let started = self.prompt_started;
+        self.prompt_started = false;
+        started
     }
 
     /// Push a CPR request onto the back of the queue. Returns a token
@@ -345,6 +361,10 @@ impl TerminalState {
 
     pub(crate) fn set_prompt_row(&mut self, row: u16) {
         self.prompt_row = Some(row);
+    }
+
+    pub(crate) fn mark_prompt_started(&mut self) {
+        self.prompt_started = true;
     }
 
     pub(crate) fn set_in_prompt(&mut self, in_prompt: bool) {
@@ -590,5 +610,19 @@ mod tests {
         assert_eq!(dropped, 1);
         assert_eq!(state.cpr_queue_len(), 1);
         assert_eq!(state.claim_next_cpr(), Some(CprOwner::Shell));
+    }
+
+    #[test]
+    fn prompt_started_flag_default_false() {
+        let mut state = TerminalState::new(24, 80);
+        assert!(!state.take_prompt_started());
+    }
+
+    #[test]
+    fn prompt_started_set_then_drained() {
+        let mut state = TerminalState::new(24, 80);
+        state.mark_prompt_started();
+        assert!(state.take_prompt_started());
+        assert!(!state.take_prompt_started(), "drain must clear");
     }
 }

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -187,8 +187,10 @@ pub struct InputHandler {
     dynamic_ctx: Option<DynamicCtxSnapshot>,
     terminal_profile: TerminalProfile,
     /// Accumulated viewport scroll from popup rendering. Persists across
-    /// dismiss/re-trigger cycles because viewport scroll is permanent.
-    /// Reset when a CPR sync corrects the parser's cursor position (new prompt).
+    /// re-render cycles within a single prompt context because viewport
+    /// scroll is permanent. Reset synchronously when a new prompt boundary
+    /// is detected (OSC 133;A / OSC 7771;A via take_prompt_started), on
+    /// dismiss, on resize, and as a CPR-sync fallback (take_cpr_synced).
     scroll_deficit: u16,
     /// Fingerprint (buffer hash + cursor offset) of the last trigger that
     /// produced a visible popup. Used as an idempotency guard in
@@ -399,12 +401,14 @@ impl InputHandler {
         // Configurable actions checked first via if-chain
         if key == &self.keybindings.navigate_up {
             self.overlay.move_up();
+            self.drain_prompt_started_reset(parser);
             self.render(parser, stdout);
             return Vec::new();
         }
         if key == &self.keybindings.navigate_down {
             self.overlay
                 .move_down(self.suggestions.len(), self.max_visible);
+            self.drain_prompt_started_reset(parser);
             self.render(parser, stdout);
             return Vec::new();
         }
@@ -556,6 +560,7 @@ impl InputHandler {
                 self.suggestions = result.suggestions;
                 self.overlay.reset();
                 self.visible = true;
+                self.drain_prompt_started_reset(parser);
                 self.render_at(stdout, cr, cc, sr, sc);
             }
             _ => {
@@ -609,10 +614,19 @@ impl InputHandler {
         let (buffer, cursor, cwd, cursor_row, cursor_col, screen_rows, screen_cols) =
             match parser.lock() {
                 Ok(mut p) => {
-                    // CPR sync means the parser's cursor_row now reflects reality,
-                    // so any accumulated scroll deficit from prior renders is stale.
-                    if p.state_mut().take_cpr_synced() {
+                    // Drain both per-prompt boundary flags. `prompt_started`
+                    // (OSC 133;A / OSC 7771;A) fires synchronously; CPR sync
+                    // is the async fallback for terminals that confirm the
+                    // cursor jump later. `last_layout` resets only on
+                    // prompt_started — a CPR sync within the same prompt
+                    // context shouldn't blow away a valid layout.
+                    let prompt_started = p.state_mut().take_prompt_started();
+                    let cpr_synced = p.state_mut().take_cpr_synced();
+                    if prompt_started || cpr_synced {
                         self.scroll_deficit = 0;
+                        if prompt_started {
+                            self.last_layout = None;
+                        }
                     }
                     let state = p.state();
                     let buffer = state.command_buffer().unwrap_or("").to_string();
@@ -797,6 +811,7 @@ impl InputHandler {
         parser: &Arc<Mutex<TerminalParser>>,
         stdout: &mut dyn Write,
     ) -> bool {
+        self.drain_prompt_started_reset(parser);
         let rx = match self.dynamic_rx.as_mut() {
             Some(rx) => rx,
             None => return false,
@@ -985,7 +1000,30 @@ impl InputHandler {
         }
     }
 
+    /// Synchronous prompt-boundary reset. Called at every render entry point
+    /// so a re-render that fires before the async CPR roundtrip lands still
+    /// sees a clean per-prompt render context. Complements the async CPR
+    /// fallback in [`InputHandler::trigger`] — both must drain so neither
+    /// flag carries forward stale state. Mirrors render's poison handling.
+    fn drain_prompt_started_reset(&mut self, parser: &Arc<Mutex<TerminalParser>>) {
+        match parser.lock() {
+            Ok(mut p) => {
+                if p.state_mut().take_prompt_started() {
+                    self.scroll_deficit = 0;
+                    self.last_layout = None;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "parser mutex poisoned in drain_prompt_started_reset: {e} — \
+                     skipping prompt-boundary reset"
+                );
+            }
+        }
+    }
+
     fn render(&mut self, parser: &Arc<Mutex<TerminalParser>>, stdout: &mut dyn Write) {
+        self.drain_prompt_started_reset(parser);
         // Poison handling mirrors Task B in proxy.rs: if the parser mutex
         // is poisoned (another task panicked while holding it), log and
         // skip this render rather than propagating the panic. The popup
@@ -1069,6 +1107,7 @@ impl InputHandler {
         // ESC-then-retrigger on the same buffer) runs a fresh suggest_sync
         // instead of short-circuiting.
         self.last_trigger_fingerprint = None;
+        self.scroll_deficit = 0;
     }
 
     /// Compute the accept bytes for the currently-selected suggestion using
@@ -2543,6 +2582,187 @@ mod tests {
                 snapshot.command.as_deref(),
                 Some("old-cmd"),
                 "trigger() must clear or replace stale dynamic_ctx"
+            );
+        }
+    }
+
+    // --- Per-prompt synchronous reset (issue #83) ---
+
+    /// Drive the parser through an OSC 133;A sequence so `prompt_started`
+    /// is set without needing crate-private access to `mark_prompt_started`.
+    fn feed_prompt_start(parser: &Arc<Mutex<gc_parser::TerminalParser>>) {
+        let mut p = parser.lock().unwrap();
+        p.process_bytes(b"\x1b]133;A\x1b\\");
+    }
+
+    #[test]
+    fn test_render_resets_scroll_deficit_on_prompt_started() {
+        // Regression for issue #83: after Ctrl+C, a new prompt boundary
+        // (OSC 133;A) must synchronously reset scroll_deficit AND
+        // last_layout BEFORE render reads cursor state, otherwise the
+        // popup paints anchored on top of the new prompt.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "item".to_string(),
+            ..Default::default()
+        }]);
+        handler.scroll_deficit = 5;
+        assert!(handler.last_layout.is_some(), "setup invariant");
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        feed_prompt_start(&parser);
+
+        let mut buf = Vec::new();
+        handler.render(&parser, &mut buf);
+
+        // After render, scroll_deficit reflects the FRESH layout's deficit
+        // (which itself starts from 0 because we drained first). last_layout
+        // is repopulated by render_at, but the drain-then-paint ordering is
+        // what matters: confirm the parser flag was consumed.
+        let drained = parser.lock().unwrap().state_mut().take_prompt_started();
+        assert!(
+            !drained,
+            "render must drain prompt_started so a follow-up drain returns false"
+        );
+        // The pre-render layout was cleared, then a new layout was painted —
+        // so last_layout is Some, but it's the FRESH one (height matching the
+        // single suggestion), not the stale 1-row mock layout from the test
+        // builder. Easier to assert: confirm the stale scroll_deficit (5) was
+        // overwritten by the layout's own deficit, which can't carry the 5.
+        assert_ne!(
+            handler.scroll_deficit, 5,
+            "stale scroll_deficit must not persist across prompt boundary"
+        );
+    }
+
+    #[test]
+    fn test_dismiss_resets_scroll_deficit() {
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "item".to_string(),
+            ..Default::default()
+        }]);
+        handler.scroll_deficit = 7;
+
+        let mut buf = Vec::new();
+        handler.dismiss(&mut buf);
+
+        assert_eq!(
+            handler.scroll_deficit, 0,
+            "dismiss must reset scroll_deficit"
+        );
+        assert!(
+            handler.last_layout.is_none(),
+            "dismiss must clear last_layout"
+        );
+    }
+
+    #[test]
+    fn test_try_merge_dynamic_resets_scroll_deficit_on_prompt_started() {
+        // The merge path is also a render entry — it must drain the flag so
+        // a popup that was visible from a prior prompt and then merges new
+        // dynamic results across a Ctrl+C boundary doesn't paint with stale
+        // scroll_deficit.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "static".to_string(),
+            ..Default::default()
+        }]);
+        handler.scroll_deficit = 9;
+
+        // Wire up a closed channel so try_merge_dynamic takes the
+        // Disconnected branch (which still re-renders when visible).
+        let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
+        drop(tx);
+        handler.dynamic_rx = Some(rx);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        feed_prompt_start(&parser);
+
+        let mut buf = Vec::new();
+        handler.try_merge_dynamic(&parser, &mut buf);
+
+        let drained = parser.lock().unwrap().state_mut().take_prompt_started();
+        assert!(
+            !drained,
+            "try_merge_dynamic must drain prompt_started on entry"
+        );
+        assert_ne!(
+            handler.scroll_deficit, 9,
+            "stale scroll_deficit must not survive prompt boundary in merge path"
+        );
+    }
+
+    #[test]
+    fn test_trigger_resets_last_layout_on_prompt_started_only() {
+        // cpr_synced alone clears scroll_deficit but preserves last_layout —
+        // a sync within the same prompt context shouldn't blow it away.
+        // prompt_started clears BOTH. Use empty buffer so trigger() takes
+        // the early-return path after the drain, isolating the drain's
+        // effect from any downstream render_at side effects.
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+
+        let stale_layout = PopupLayout {
+            start_row: 1,
+            start_col: 0,
+            width: 10,
+            height: 1,
+            scroll_deficit: 0,
+        };
+
+        // Case 1: cpr_synced alone → scroll_deficit cleared, last_layout kept.
+        {
+            let mut handler = make_handler();
+            handler.scroll_deficit = 4;
+            handler.last_layout = Some(stale_layout.clone());
+            assert!(
+                !parser.lock().unwrap().state_mut().take_prompt_started(),
+                "setup: prompt_started must be false"
+            );
+            parser
+                .lock()
+                .unwrap()
+                .state_mut()
+                .set_cursor_from_report(2, 1);
+
+            let mut stdout = Vec::new();
+            handler.trigger(&parser, &mut stdout);
+
+            assert_eq!(
+                handler.scroll_deficit, 0,
+                "cpr_synced must clear scroll_deficit"
+            );
+            assert!(
+                handler.last_layout.is_some(),
+                "cpr_synced WITHOUT prompt_started must preserve last_layout"
+            );
+            let kept = handler.last_layout.as_ref().unwrap();
+            assert_eq!(
+                (kept.start_row, kept.start_col, kept.width, kept.height),
+                (
+                    stale_layout.start_row,
+                    stale_layout.start_col,
+                    stale_layout.width,
+                    stale_layout.height
+                ),
+                "cpr_synced must preserve the stale layout's geometry"
+            );
+        }
+
+        // Case 2: prompt_started=true → both cleared.
+        {
+            let mut handler = make_handler();
+            handler.scroll_deficit = 4;
+            handler.last_layout = Some(stale_layout.clone());
+            feed_prompt_start(&parser);
+
+            let mut stdout = Vec::new();
+            handler.trigger(&parser, &mut stdout);
+
+            assert_eq!(
+                handler.scroll_deficit, 0,
+                "prompt_started must clear scroll_deficit"
+            );
+            assert!(
+                handler.last_layout.is_none(),
+                "prompt_started must clear last_layout"
             );
         }
     }

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -188,9 +188,10 @@ pub struct InputHandler {
     terminal_profile: TerminalProfile,
     /// Accumulated viewport scroll from popup rendering. Persists across
     /// re-render cycles within a single prompt context because viewport
-    /// scroll is permanent. Reset synchronously when a new prompt boundary
-    /// is detected (OSC 133;A / OSC 7771;A via take_prompt_started), on
-    /// dismiss, on resize, and as a CPR-sync fallback (take_cpr_synced).
+    /// scroll is permanent. Reset synchronously on a new prompt boundary
+    /// (OSC 133;A / OSC 7771;A via take_prompt_started), on dismiss, on
+    /// resize, and via take_cpr_synced as the async fallback for terminals
+    /// where the boundary is observed only after the CPR roundtrip.
     scroll_deficit: u16,
     /// Fingerprint (buffer hash + cursor offset) of the last trigger that
     /// produced a visible popup. Used as an idempotency guard in
@@ -401,14 +402,12 @@ impl InputHandler {
         // Configurable actions checked first via if-chain
         if key == &self.keybindings.navigate_up {
             self.overlay.move_up();
-            self.drain_prompt_started_reset(parser);
             self.render(parser, stdout);
             return Vec::new();
         }
         if key == &self.keybindings.navigate_down {
             self.overlay
                 .move_down(self.suggestions.len(), self.max_visible);
-            self.drain_prompt_started_reset(parser);
             self.render(parser, stdout);
             return Vec::new();
         }
@@ -1000,11 +999,13 @@ impl InputHandler {
         }
     }
 
-    /// Synchronous prompt-boundary reset. Called at every render entry point
-    /// so a re-render that fires before the async CPR roundtrip lands still
-    /// sees a clean per-prompt render context. Complements the async CPR
-    /// fallback in [`InputHandler::trigger`] — both must drain so neither
-    /// flag carries forward stale state. Mirrors render's poison handling.
+    /// Drain `prompt_started` under a parser lock and clear per-prompt render
+    /// state (`scroll_deficit`, `last_layout`). Called by render entry points
+    /// (`render`, `accept_with_chaining`, `try_merge_dynamic`) that go through
+    /// `render_at` without draining first. [`InputHandler::trigger`] does its
+    /// own inline drain because it reads `cpr_synced` in the same critical
+    /// section. On a poisoned parser mutex this leaves `prompt_started` set
+    /// on the parser; recovery is upstream. Mirrors render's poison handling.
     fn drain_prompt_started_reset(&mut self, parser: &Arc<Mutex<TerminalParser>>) {
         match parser.lock() {
             Ok(mut p) => {
@@ -2586,7 +2587,7 @@ mod tests {
         }
     }
 
-    // --- Per-prompt synchronous reset (issue #83) ---
+    // --- Per-prompt synchronous reset ---
 
     /// Drive the parser through an OSC 133;A sequence so `prompt_started`
     /// is set without needing crate-private access to `mark_prompt_started`.
@@ -2596,11 +2597,11 @@ mod tests {
     }
 
     #[test]
-    fn test_render_resets_scroll_deficit_on_prompt_started() {
-        // Regression for issue #83: after Ctrl+C, a new prompt boundary
-        // (OSC 133;A) must synchronously reset scroll_deficit AND
-        // last_layout BEFORE render reads cursor state, otherwise the
-        // popup paints anchored on top of the new prompt.
+    fn test_drain_prompt_started_reset_with_flag_clears_state() {
+        // After a new prompt boundary (Ctrl+C, fresh prompt) the helper must
+        // synchronously zero scroll_deficit AND drop last_layout so the next
+        // render anchors clear_popup on the new prompt row instead of the
+        // stale geometry of the prior prompt.
         let mut handler = make_visible_handler(vec![Suggestion {
             text: "item".to_string(),
             ..Default::default()
@@ -2611,26 +2612,43 @@ mod tests {
         let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
         feed_prompt_start(&parser);
 
-        let mut buf = Vec::new();
-        handler.render(&parser, &mut buf);
+        handler.drain_prompt_started_reset(&parser);
 
-        // After render, scroll_deficit reflects the FRESH layout's deficit
-        // (which itself starts from 0 because we drained first). last_layout
-        // is repopulated by render_at, but the drain-then-paint ordering is
-        // what matters: confirm the parser flag was consumed.
-        let drained = parser.lock().unwrap().state_mut().take_prompt_started();
-        assert!(
-            !drained,
-            "render must drain prompt_started so a follow-up drain returns false"
+        assert_eq!(
+            handler.scroll_deficit, 0,
+            "drain must reset scroll_deficit when prompt_started is set"
         );
-        // The pre-render layout was cleared, then a new layout was painted —
-        // so last_layout is Some, but it's the FRESH one (height matching the
-        // single suggestion), not the stale 1-row mock layout from the test
-        // builder. Easier to assert: confirm the stale scroll_deficit (5) was
-        // overwritten by the layout's own deficit, which can't carry the 5.
-        assert_ne!(
-            handler.scroll_deficit, 5,
-            "stale scroll_deficit must not persist across prompt boundary"
+        assert!(
+            handler.last_layout.is_none(),
+            "drain must clear last_layout when prompt_started is set"
+        );
+        let still_set = parser.lock().unwrap().state_mut().take_prompt_started();
+        assert!(!still_set, "drain must consume the prompt_started flag");
+    }
+
+    #[test]
+    fn test_drain_prompt_started_reset_no_flag_preserves_state() {
+        // Without a fresh prompt boundary, the drain must be a no-op: it
+        // must not clobber a valid scroll_deficit or layout that the prior
+        // render committed.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "item".to_string(),
+            ..Default::default()
+        }]);
+        handler.scroll_deficit = 7;
+        assert!(handler.last_layout.is_some(), "setup invariant");
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+
+        handler.drain_prompt_started_reset(&parser);
+
+        assert_eq!(
+            handler.scroll_deficit, 7,
+            "drain must preserve scroll_deficit when prompt_started is unset"
+        );
+        assert!(
+            handler.last_layout.is_some(),
+            "drain must preserve last_layout when prompt_started is unset"
         );
     }
 
@@ -2656,19 +2674,16 @@ mod tests {
     }
 
     #[test]
-    fn test_try_merge_dynamic_resets_scroll_deficit_on_prompt_started() {
-        // The merge path is also a render entry — it must drain the flag so
-        // a popup that was visible from a prior prompt and then merges new
-        // dynamic results across a Ctrl+C boundary doesn't paint with stale
-        // scroll_deficit.
+    fn test_try_merge_dynamic_drains_prompt_started_on_entry() {
+        // The merge path is a render entry — it must drain the flag so a
+        // popup that was visible from a prior prompt and then merges new
+        // dynamic results across a Ctrl+C boundary doesn't paint with
+        // stale per-prompt state.
         let mut handler = make_visible_handler(vec![Suggestion {
             text: "static".to_string(),
             ..Default::default()
         }]);
-        handler.scroll_deficit = 9;
 
-        // Wire up a closed channel so try_merge_dynamic takes the
-        // Disconnected branch (which still re-renders when visible).
         let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
         drop(tx);
         handler.dynamic_rx = Some(rx);
@@ -2679,14 +2694,10 @@ mod tests {
         let mut buf = Vec::new();
         handler.try_merge_dynamic(&parser, &mut buf);
 
-        let drained = parser.lock().unwrap().state_mut().take_prompt_started();
+        let still_set = parser.lock().unwrap().state_mut().take_prompt_started();
         assert!(
-            !drained,
-            "try_merge_dynamic must drain prompt_started on entry"
-        );
-        assert_ne!(
-            handler.scroll_deficit, 9,
-            "stale scroll_deficit must not survive prompt boundary in merge path"
+            !still_set,
+            "try_merge_dynamic must consume prompt_started on entry"
         );
     }
 
@@ -2765,5 +2776,67 @@ mod tests {
                 "prompt_started must clear last_layout"
             );
         }
+
+        // Case 3: BOTH flags set within the same trigger() — both must drain
+        // and the prompt_started branch (which clears last_layout) must win.
+        {
+            let mut handler = make_handler();
+            handler.scroll_deficit = 4;
+            handler.last_layout = Some(stale_layout.clone());
+            feed_prompt_start(&parser);
+            parser
+                .lock()
+                .unwrap()
+                .state_mut()
+                .set_cursor_from_report(2, 1);
+
+            let mut stdout = Vec::new();
+            handler.trigger(&parser, &mut stdout);
+
+            assert_eq!(
+                handler.scroll_deficit, 0,
+                "both flags must clear scroll_deficit"
+            );
+            assert!(
+                handler.last_layout.is_none(),
+                "prompt_started branch must clear last_layout even with cpr_synced also set"
+            );
+            assert!(
+                !parser.lock().unwrap().state_mut().take_prompt_started(),
+                "trigger must consume prompt_started"
+            );
+            assert!(
+                !parser.lock().unwrap().state_mut().take_cpr_synced(),
+                "trigger must consume cpr_synced"
+            );
+        }
+    }
+
+    #[test]
+    fn test_handle_resize_does_not_consume_prompt_started() {
+        // handle_resize dismisses the popup and zeroes scroll_deficit on its
+        // own — it does NOT touch prompt_started, so a fresh prompt boundary
+        // observed after resize is still drained at the next render entry.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "item".to_string(),
+            ..Default::default()
+        }]);
+        handler.scroll_deficit = 5;
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        feed_prompt_start(&parser);
+
+        let mut buf = Vec::new();
+        handler.handle_resize(&parser, &mut buf);
+
+        assert!(!handler.visible, "resize must dismiss the popup");
+        assert_eq!(
+            handler.scroll_deficit, 0,
+            "resize must reset scroll_deficit independently"
+        );
+        assert!(
+            parser.lock().unwrap().state_mut().take_prompt_started(),
+            "resize must NOT consume prompt_started — next render owns the drain"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #83 — completion popup occasionally renders **on top of the prompt** after Ctrl+C on Terminal.app and Ghostty.

## Root cause

`InputHandler::scroll_deficit` (`crates/gc-pty/src/handler.rs:189`) was only reset via the async CPR roundtrip drained inside `trigger()` (handler.rs:614). After Ctrl+C, the shell prints `^C\n` + new prompt + `OSC 7771;A` + `OSC 7770("")` in one batched read. Task B writes `CSI 6n` and immediately calls `trigger()` with `buffer_dirty=true` — but the terminal's CPR response is still in flight on stdin. `take_cpr_synced()` returns `false`, `scroll_deficit` stays at its pre-Ctrl+C value, and `dismiss()` (handler.rs:1050) didn't reset it either.

If the user types within that window, `final_cursor_row = real_row − scroll_deficit` produces `start_row = real_row` — the popup anchor lands on the new prompt row. With `scroll_deficit=1` you get exactly the symptom from the issue: `(b<popup>Book-Air GitHub % su` with the popup overlaid at column 2.

Both terminals are affected because the race lives in the proxy/handler — not in DECSET 2026 vs pre-render-buffer.

## Fix

Add a **synchronous** prompt-boundary signal independent of CPR. Drain it at every render entry so a re-render that fires before the CPR roundtrip lands still sees a clean per-prompt state.

- `gc-parser/src/state.rs` — new `prompt_started: bool` field on `TerminalState`. Public `take_prompt_started()` mirrors `take_cpr_synced` (atomic drain). `pub(crate) mark_prompt_started()` setter.
- `gc-parser/src/performer.rs` — call `mark_prompt_started()` inside both OSC 133;A and OSC 7771;A handlers, alongside the existing `request_cursor_sync` / `set_prompt_row` calls.
- `gc-pty/src/handler.rs`:
  - New `drain_prompt_started_reset` helper called at the start of `render`, `try_merge_dynamic`, navigation in `process_key_visible`, and `accept_with_chaining`. On true: `scroll_deficit = 0` and `last_layout = None`.
  - `trigger()` drains both flags. `prompt_started` resets both fields; `cpr_synced` (fallback) only resets `scroll_deficit` because a CPR sync within the same prompt context shouldn't blow away a valid layout.
  - `dismiss()` now resets `scroll_deficit = 0`.
  - Doc-comment on `scroll_deficit` updated to reflect all reset paths.

CPR-sync reset retained as defense-in-depth.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace` — **942 passed, 0 failed**
- [x] 8 new tests (4 parser, 4 handler) covering the regression:
  - `prompt_started_flag_default_false`
  - `prompt_started_set_then_drained`
  - `test_osc133_prompt_a_sets_prompt_started`
  - `test_osc7771_prompt_a_sets_prompt_started`
  - `test_render_resets_scroll_deficit_on_prompt_started`
  - `test_dismiss_resets_scroll_deficit`
  - `test_try_merge_dynamic_resets_scroll_deficit_on_prompt_started`
  - `test_trigger_resets_last_layout_on_prompt_started_only`
- [ ] Manual repro: 24-row Terminal.app, run a command that surfaces history, hit Ctrl+C while popup is visible, type immediately. Confirm popup no longer overlays the new prompt.
- [ ] Same on Ghostty.