### PR TITLE
feat: print post-install next-steps summary

### DIFF
--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -172,10 +172,6 @@ fn print_shell_blocks(init_path: &Path, script_path: &Path) {
     println!("    \x1b[36m{indented_shell}\x1b[0m\n");
 }
 
-/// Render the post-install next-steps summary.
-///
-/// Caller's responsibility to skip in dry-run — `install_to` short-circuits
-/// before either call-site reaches this helper, so no internal guard.
 fn post_install_summary(config_dir: &Path, wrote_zshrc: bool) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
@@ -208,7 +204,7 @@ fn post_install_summary(config_dir: &Path, wrote_zshrc: bool) -> String {
     .unwrap();
     writeln!(
         out,
-        "  3. Try it:                \x1b[1mcd /tmp && git \x1b[0m\x1b[2m<space>\x1b[0m"
+        "  3. Try it:                \x1b[1mcd /tmp && git \x1b[0m\x1b[2m[space]\x1b[0m"
     )
     .unwrap();
     writeln!(
@@ -232,7 +228,7 @@ fn post_install_summary(config_dir: &Path, wrote_zshrc: bool) -> String {
     .unwrap();
     writeln!(
         out,
-        "  Specs:   {}/  ({} specs)",
+        "  Specs:   {}/  ({} completion specs)",
         sanitize_path(&config_dir.join("specs")),
         EMBEDDED_SPECS.len()
     )
@@ -1159,7 +1155,11 @@ mod tests {
 
     #[test]
     fn test_post_install_summary_contains_all_sections() {
-        let summary = post_install_summary(Path::new("/tmp/cfg"), true);
+        // Use a distinctive directory so we can also assert the helper
+        // interpolates `config_dir` into the rendered paths rather than
+        // hardcoding them.
+        let config_dir = Path::new("/tmp/gc-test-xyz");
+        let summary = post_install_summary(config_dir, true);
         for token in [
             "ghost-complete installed successfully",
             "doctor",
@@ -1169,12 +1169,19 @@ mod tests {
             "config.toml",
             "specs",
             "source ~/.zshrc",
+            "/tmp/gc-test-xyz/config.toml",
+            "/tmp/gc-test-xyz/specs",
         ] {
             assert!(
                 summary.contains(token),
                 "missing token: {token}\n--- summary ---\n{summary}"
             );
         }
+        let count_token = format!("({} completion specs)", EMBEDDED_SPECS.len());
+        assert!(
+            summary.contains(&count_token),
+            "missing spec count `{count_token}`\n--- summary ---\n{summary}"
+        );
     }
 
     #[test]

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -176,18 +176,26 @@ fn post_install_summary(config_dir: &Path, wrote_zshrc: bool) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
 
-    writeln!(
-        out,
-        "\x1b[32m\u{2713}\x1b[0m  ghost-complete installed successfully!"
-    )
-    .unwrap();
+    if wrote_zshrc {
+        writeln!(
+            out,
+            "\x1b[32m\u{2713}\x1b[0m  ghost-complete installed successfully!"
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            out,
+            "\x1b[33m\u{26a0}\x1b[0m  ghost-complete partially installed (manual .zshrc step required)"
+        )
+        .unwrap();
+    }
     writeln!(out).unwrap();
 
     writeln!(out, "\x1b[1mNext steps:\x1b[0m").unwrap();
     if wrote_zshrc {
         writeln!(
             out,
-            "  1. Restart your shell:    \x1b[1msource ~/.zshrc\x1b[0m"
+            "  1. Reload your shell:     \x1b[1msource ~/.zshrc\x1b[0m"
         )
         .unwrap();
     } else {
@@ -204,7 +212,7 @@ fn post_install_summary(config_dir: &Path, wrote_zshrc: bool) -> String {
     .unwrap();
     writeln!(
         out,
-        "  3. Try it:                \x1b[1mcd /tmp && git \x1b[0m\x1b[2m[space]\x1b[0m"
+        "  3. Try it:                \x1b[1mcd /tmp && git\x1b[0m\x1b[2m  (then type a space)\x1b[0m"
     )
     .unwrap();
     writeln!(
@@ -1192,6 +1200,17 @@ mod tests {
             !summary.contains("source ~/.zshrc"),
             "manual-fallback summary must not instruct user to source a file \
              they didn't write to:\n{summary}"
+        );
+        // Headline must reflect the partial-install state — a green-check
+        // "installed successfully" headline would contradict the prior
+        // permission-denied warning the user just saw on screen.
+        assert!(
+            summary.contains("partially installed"),
+            "manual-fallback headline must signal the degraded state:\n{summary}"
+        );
+        assert!(
+            !summary.contains("installed successfully"),
+            "manual-fallback summary must not claim success:\n{summary}"
         );
     }
 

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -172,6 +172,82 @@ fn print_shell_blocks(init_path: &Path, script_path: &Path) {
     println!("    \x1b[36m{indented_shell}\x1b[0m\n");
 }
 
+/// Render the post-install next-steps summary.
+///
+/// Caller's responsibility to skip in dry-run — `install_to` short-circuits
+/// before either call-site reaches this helper, so no internal guard.
+fn post_install_summary(config_dir: &Path, wrote_zshrc: bool) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+
+    writeln!(
+        out,
+        "\x1b[32m\u{2713}\x1b[0m  ghost-complete installed successfully!"
+    )
+    .unwrap();
+    writeln!(out).unwrap();
+
+    writeln!(out, "\x1b[1mNext steps:\x1b[0m").unwrap();
+    if wrote_zshrc {
+        writeln!(
+            out,
+            "  1. Restart your shell:    \x1b[1msource ~/.zshrc\x1b[0m"
+        )
+        .unwrap();
+    } else {
+        writeln!(
+            out,
+            "  1. Restart your shell after pasting the blocks above."
+        )
+        .unwrap();
+    }
+    writeln!(
+        out,
+        "  2. Verify the install:    \x1b[1mghost-complete doctor\x1b[0m"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  3. Try it:                \x1b[1mcd /tmp && git \x1b[0m\x1b[2m<space>\x1b[0m"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  4. Manual trigger:        \x1b[1mCtrl+/\x1b[0m  (if the popup doesn't appear)"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  5. Customize:             \x1b[1mghost-complete config edit\x1b[0m"
+    )
+    .unwrap();
+    writeln!(out).unwrap();
+
+    writeln!(out, "\x1b[1mFiles installed:\x1b[0m").unwrap();
+    writeln!(
+        out,
+        "  Config:  {}",
+        sanitize_path(&config_dir.join("config.toml"))
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  Specs:   {}/  ({} specs)",
+        sanitize_path(&config_dir.join("specs")),
+        EMBEDDED_SPECS.len()
+    )
+    .unwrap();
+    writeln!(out).unwrap();
+
+    writeln!(
+        out,
+        "Docs: https://github.com/StanMarek/ghost-complete#readme"
+    )
+    .unwrap();
+
+    out
+}
+
 fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()> {
     // 1. Write zsh shell scripts
     let shell_dir = config_dir.join("shell");
@@ -316,8 +392,7 @@ fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()>
     match fs::write(zshrc_path, &new_zshrc) {
         Ok(()) => {
             println!("  Updated {}", sanitize_path(zshrc_path));
-            println!("\nghost-complete installed successfully!");
-            println!("Restart your shell or run: source ~/.zshrc");
+            print!("\n{}", post_install_summary(config_dir, true));
         }
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
             println!(
@@ -328,6 +403,7 @@ fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()>
             println!(
                 "  \x1b[32m\u{2713}\x1b[0m  Installation complete (manual shell configuration required)."
             );
+            print!("\n{}", post_install_summary(config_dir, false));
         }
         Err(e) => {
             return Err(anyhow::anyhow!(
@@ -1079,5 +1155,55 @@ mod tests {
         // Specs and config should still be there (retained)
         assert!(config.join("specs").exists());
         assert!(config.join("config.toml").exists());
+    }
+
+    #[test]
+    fn test_post_install_summary_contains_all_sections() {
+        let summary = post_install_summary(Path::new("/tmp/cfg"), true);
+        for token in [
+            "ghost-complete installed successfully",
+            "doctor",
+            "Ctrl+/",
+            "config edit",
+            "git",
+            "config.toml",
+            "specs",
+            "source ~/.zshrc",
+        ] {
+            assert!(
+                summary.contains(token),
+                "missing token: {token}\n--- summary ---\n{summary}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_post_install_summary_manual_fallback_omits_source_zshrc() {
+        let summary = post_install_summary(Path::new("/tmp/cfg"), false);
+        assert!(summary.contains("after pasting the blocks above"));
+        assert!(
+            !summary.contains("source ~/.zshrc"),
+            "manual-fallback summary must not instruct user to source a file \
+             they didn't write to:\n{summary}"
+        );
+    }
+
+    #[test]
+    fn test_post_install_summary_uses_sanitized_paths() {
+        // Pin the sanitization invariant. We can't blanket-assert
+        // `!contains('\x1b')` because the helper intentionally emits ANSI
+        // sigils (green check, bolds, dim placeholder); instead pin both
+        // directions — the path's raw sequence is gone, the sanitised form
+        // is present.
+        let hostile = Path::new("/tmp/\x1b[31mevil");
+        let summary = post_install_summary(hostile, true);
+        assert!(
+            summary.contains("/tmp/[31mevil"),
+            "expected sanitised hostile path in summary: {summary:?}"
+        );
+        assert!(
+            !summary.contains("\x1b[31m"),
+            "raw ESC sequence from hostile path leaked: {summary:?}"
+        );
     }
 }

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -404,9 +404,6 @@ fn install_to(zshrc_path: &Path, config_dir: &Path, dry_run: bool) -> Result<()>
                 sanitize_path(zshrc_path)
             );
             print_shell_blocks(&init_path, &script_path);
-            println!(
-                "  \x1b[32m\u{2713}\x1b[0m  Installation complete (manual shell configuration required)."
-            );
             print!("\n{}", post_install_summary(config_dir, false));
         }
         Err(e) => {


### PR DESCRIPTION
## Summary
- Replaces the two-line install tail with a structured next-steps summary: green-check header, five numbered copy-pasteable next steps (`source ~/.zshrc`, `ghost-complete doctor`, demo command, `Ctrl+/` reminder, `ghost-complete config edit`), a "Files installed:" section listing the resolved `config.toml` and `specs/` paths (with spec count from `EMBEDDED_SPECS.len()`), and a docs URL.
- Step 1 branches on whether `.zshrc` was actually written: the manual-fallback path (PermissionDenied) prints "Restart your shell after pasting the blocks above." instead of `source ~/.zshrc`, since the user hasn't written anything to source.
- Dry-run and `uninstall` paths untouched.
- Both rendered config-derived paths run through `sanitize_path`, preserving the existing control-byte stripping invariant the rest of `install.rs` relies on.

Implements `docs/plans/ux-1-install-summary/{SPEC,PLAN}.md`.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p ghost-complete --all-targets -- -D warnings` clean
- [x] `cargo test -p ghost-complete` — 132 unit + 11 smoke tests passing (3 new: token coverage, manual-fallback wording, sanitization invariant)
- [x] Manual smoke: `HOME=$(mktemp -d) cargo run -- install` — summary renders with `source ~/.zshrc`, 709 specs reported
- [x] Manual smoke: `HOME=$(mktemp -d) cargo run -- install --dry-run` — summary absent (early-return at top of `install_to`)
- [x] Manual smoke: `HOME=$(mktemp -d)`, pre-create read-only `.zshrc`, rerun install — summary appears with "after pasting the blocks above" wording, no `source ~/.zshrc`
- [x] `cargo run -- uninstall` — output unchanged

## Implementation notes
- New helper `post_install_summary(config_dir: &Path, wrote_zshrc: bool) -> String` builds the summary as a `String` rather than threading `&mut dyn io::Write` through `install_to`, so unit tests can assert content without plumbing.
- Test C was adapted from the plan: the original assertion `!summary.contains('\x1b')` would falsely fail because the helper deliberately emits ANSI sigils (green check, bolds, dim placeholder). Instead the test pins both directions — the path's raw `\x1b[31m` sequence is gone, the sanitised `[31mevil` form is present.
- Zero new dependencies. No public API changes (`install_to` / `uninstall_from` signatures unchanged).