### PR TITLE
feat(parser+shell): OSC 7772 percent-encoded buffer framing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +581,7 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "criterion",
+ "proptest",
  "tracing",
  "unicode-width",
  "vte",
@@ -622,13 +644,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1165,6 +1199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1227,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,9 +1262,53 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "ratatui"
@@ -1366,6 +1478,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1813,6 +1937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,6 +1997,15 @@ checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
  "memchr",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/gc-parser/Cargo.toml
+++ b/crates/gc-parser/Cargo.toml
@@ -15,6 +15,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
+proptest = "1"
 
 [[bench]]
 name = "parser_bench"

--- a/crates/gc-parser/benches/parser_bench.rs
+++ b/crates/gc-parser/benches/parser_bench.rs
@@ -1,7 +1,45 @@
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use gc_parser::TerminalParser;
 
 const BUFFER_SIZE: usize = 64 * 1024; // 64 KB
+
+const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+/// Mirror `_gc_urlencode_buffer` (zsh) byte-for-byte. Bench numbers
+/// describe the production path because the production path uses the
+/// same encoding alphabet.
+fn osc7772_encode(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len() * 3);
+    for &b in input {
+        let safe = matches!(b,
+            b'a'..=b'z'
+                | b'A'..=b'Z'
+                | b'0'..=b'9'
+                | b'.' | b'_' | b'~' | b'/' | b'-' | b' '
+        );
+        if safe {
+            out.push(b);
+        } else {
+            out.push(b'%');
+            out.push(HEX[(b >> 4) as usize]);
+            out.push(HEX[(b & 0x0F) as usize]);
+        }
+    }
+    out
+}
+
+fn build_osc7772_envelope(buffer: &[u8]) -> Vec<u8> {
+    let cursor = std::str::from_utf8(buffer)
+        .map(|s| s.chars().count())
+        .unwrap_or(buffer.len());
+    let mut env = Vec::with_capacity(buffer.len() * 3 + 16);
+    env.extend_from_slice(b"\x1b]7772;");
+    env.extend_from_slice(cursor.to_string().as_bytes());
+    env.push(b';');
+    env.extend_from_slice(&osc7772_encode(buffer));
+    env.push(0x07);
+    env
+}
 
 fn make_plain_text(size: usize) -> Vec<u8> {
     let line = b"drwxr-xr-x  5 user staff  160 Mar 12 10:00 dirname\n";
@@ -70,5 +108,33 @@ fn parser_benchmarks(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, parser_benchmarks);
+fn osc7772_decode_benchmarks(c: &mut Criterion) {
+    // Mixed alphabet: half the bytes are safe ASCII (pass-through), half
+    // require percent-encoding. Realistic for shells that contain a
+    // sprinkling of `;`, `|`, `&`, etc. Use a deterministic pattern so
+    // bench runs are comparable across machines and revisions.
+    let pattern: &[u8] = b"echo a; ls -la | grep -v test && cd /tmp ";
+    let make_buffer = |size: usize| -> Vec<u8> {
+        pattern.iter().cycle().take(size).copied().collect()
+    };
+
+    let mut group = c.benchmark_group("osc7772_decode");
+    for &size in &[100usize, 1024, 8 * 1024] {
+        let envelope = build_osc7772_envelope(&make_buffer(size));
+        group.throughput(Throughput::Bytes(envelope.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &envelope,
+            |b, env| {
+                b.iter(|| {
+                    let mut parser = TerminalParser::new(24, 80);
+                    parser.process_bytes(env);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, parser_benchmarks, osc7772_decode_benchmarks);
 criterion_main!(benches);

--- a/crates/gc-parser/benches/parser_bench.rs
+++ b/crates/gc-parser/benches/parser_bench.rs
@@ -114,24 +114,19 @@ fn osc7772_decode_benchmarks(c: &mut Criterion) {
     // sprinkling of `;`, `|`, `&`, etc. Use a deterministic pattern so
     // bench runs are comparable across machines and revisions.
     let pattern: &[u8] = b"echo a; ls -la | grep -v test && cd /tmp ";
-    let make_buffer = |size: usize| -> Vec<u8> {
-        pattern.iter().cycle().take(size).copied().collect()
-    };
+    let make_buffer =
+        |size: usize| -> Vec<u8> { pattern.iter().cycle().take(size).copied().collect() };
 
     let mut group = c.benchmark_group("osc7772_decode");
     for &size in &[100usize, 1024, 8 * 1024] {
         let envelope = build_osc7772_envelope(&make_buffer(size));
         group.throughput(Throughput::Bytes(envelope.len() as u64));
-        group.bench_with_input(
-            BenchmarkId::from_parameter(size),
-            &envelope,
-            |b, env| {
-                b.iter(|| {
-                    let mut parser = TerminalParser::new(24, 80);
-                    parser.process_bytes(env);
-                });
-            },
-        );
+        group.bench_with_input(BenchmarkId::from_parameter(size), &envelope, |b, env| {
+            b.iter(|| {
+                let mut parser = TerminalParser::new(24, 80);
+                parser.process_bytes(env);
+            });
+        });
     }
     group.finish();
 }

--- a/crates/gc-parser/benches/parser_bench.rs
+++ b/crates/gc-parser/benches/parser_bench.rs
@@ -109,10 +109,11 @@ fn parser_benchmarks(c: &mut Criterion) {
 }
 
 fn osc7772_decode_benchmarks(c: &mut Criterion) {
-    // Mixed alphabet: half the bytes are safe ASCII (pass-through), half
-    // require percent-encoding. Realistic for shells that contain a
-    // sprinkling of `;`, `|`, `&`, etc. Use a deterministic pattern so
-    // bench runs are comparable across machines and revisions.
+    // Realistic shell-line alphabet: mostly safe ASCII (pass-through) with
+    // a sprinkling of `;`, `|`, `&` that get percent-encoded. Roughly 10%
+    // of bytes are encoded, matching typical interactive $BUFFER content.
+    // Deterministic pattern so bench runs are comparable across machines
+    // and revisions.
     let pattern: &[u8] = b"echo a; ls -la | grep -v test && cd /tmp ";
     let make_buffer =
         |size: usize| -> Vec<u8> { pattern.iter().cycle().take(size).copied().collect() };

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -248,9 +248,7 @@ impl Perform for TerminalState {
                 let decoded = match percent_decode_buffer(params[2]) {
                     Some(bytes) => bytes,
                     None => {
-                        tracing::warn!(
-                            "OSC 7772 — malformed percent escape in payload, skipping"
-                        );
+                        tracing::warn!("OSC 7772 — malformed percent escape in payload, skipping");
                         return;
                     }
                 };
@@ -1055,10 +1053,7 @@ mod tests {
 
     #[test]
     fn percent_decode_buffer_no_encoding() {
-        assert_eq!(
-            percent_decode_buffer(b"abc xyz"),
-            Some(b"abc xyz".to_vec())
-        );
+        assert_eq!(percent_decode_buffer(b"abc xyz"), Some(b"abc xyz".to_vec()));
     }
 
     #[test]

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -1072,4 +1072,176 @@ mod tests {
         p.process_bytes(b"\x1b[?6n");
         assert_eq!(p.state().cpr_queue_len(), 0);
     }
+
+    // -- OSC 7772 buffer reporting (secure framing) --
+    //
+    // These tests own the canonical encoding contract. `encode_for_test`
+    // is the spec the production zsh emitter MUST match byte-for-byte.
+    // The decoder under test (`percent_decode_buffer`) MUST invert it
+    // exactly. Any divergence between encoder allow-list and decoder
+    // semantics shows up here first.
+
+    /// Encode a byte slice for OSC 7772 transport. The allow-list mirrors
+    /// `_gc_urlencode_buffer` in `shell/ghost-complete.zsh`:
+    ///   unreserved bytes:  `[A-Za-z0-9._~/-]` and ` ` (literal space)
+    ///   everything else  → `%XX` (uppercase hex)
+    /// In particular `;`, `\x07`, `\x1B`, `%`, `\\`, `\x00`, control bytes,
+    /// `0x7F`, and `0x80`–`0xFF` are all encoded.
+    fn encode_for_test(input: &[u8]) -> Vec<u8> {
+        const HEX: &[u8; 16] = b"0123456789ABCDEF";
+        let mut out = Vec::with_capacity(input.len());
+        for &b in input {
+            let safe = matches!(b,
+                b'a'..=b'z'
+                    | b'A'..=b'Z'
+                    | b'0'..=b'9'
+                    | b'.' | b'_' | b'~' | b'/' | b'-' | b' '
+            );
+            if safe {
+                out.push(b);
+            } else {
+                out.push(b'%');
+                out.push(HEX[(b >> 4) as usize]);
+                out.push(HEX[(b & 0x0F) as usize]);
+            }
+        }
+        out
+    }
+
+    /// Wrap an already-encoded payload in the OSC 7772 envelope.
+    fn build_osc7772(buffer: &[u8], cursor_chars: usize) -> Vec<u8> {
+        let mut env = Vec::with_capacity(buffer.len() * 3 + 16);
+        env.extend_from_slice(b"\x1b]7772;");
+        env.extend_from_slice(cursor_chars.to_string().as_bytes());
+        env.push(b';');
+        env.extend_from_slice(&encode_for_test(buffer));
+        env.push(0x07);
+        env
+    }
+
+    fn assert_roundtrips(buffer: &str) {
+        let mut p = make_parser();
+        let cursor = buffer.chars().count();
+        p.process_bytes(&build_osc7772(buffer.as_bytes(), cursor));
+        assert_eq!(p.state().command_buffer(), Some(buffer));
+        assert_eq!(p.state().buffer_cursor(), cursor);
+    }
+
+    #[test]
+    fn osc7772_roundtrips_semicolon() {
+        assert_roundtrips("if true; then");
+    }
+
+    #[test]
+    fn osc7772_roundtrips_bel() {
+        assert_roundtrips("x\x07y");
+    }
+
+    #[test]
+    fn osc7772_roundtrips_esc() {
+        assert_roundtrips("\x1b[31m");
+    }
+
+    #[test]
+    fn osc7772_roundtrips_nul() {
+        assert_roundtrips("a\x00b");
+    }
+
+    #[test]
+    fn osc7772_roundtrips_embedded_st() {
+        assert_roundtrips("foo\x1b\\bar");
+    }
+
+    #[test]
+    fn osc7772_roundtrips_long_8k() {
+        // Deterministic 8 KiB ASCII pattern that exercises every byte the
+        // emitter must encode (`;`, `%`, `\\`, control bytes) plus the
+        // allowed unreserved alphabet. `cycle()` keeps the test offline
+        // and reproducible without pulling a PRNG dependency.
+        let pattern: &[u8] = b"a;b\\c%d e/f.g_h~i-j0 1\x07 \x1b2.3_4-5/6~7 8 9";
+        let buf: Vec<u8> = pattern.iter().cycle().take(8192).copied().collect();
+        let s = std::str::from_utf8(&buf).expect("ASCII fixture is valid UTF-8");
+        assert_roundtrips(s);
+    }
+
+    #[test]
+    fn osc7772_roundtrips_utf8_cjk() {
+        assert_roundtrips("日本語");
+    }
+
+    #[test]
+    fn osc7772_roundtrips_empty() {
+        let mut p = make_parser();
+        p.process_bytes(&build_osc7772(b"", 0));
+        assert_eq!(p.state().command_buffer(), Some(""));
+        assert_eq!(p.state().buffer_cursor(), 0);
+    }
+
+    #[test]
+    fn osc7772_roundtrips_already_encoded_alphabet() {
+        // The user typed the literal characters `abc%20def`. The encoder
+        // must encode `%` as `%25` so the decoder yields back `abc%20def`,
+        // not `abc def`. This pins "the decoder runs exactly once."
+        assert_roundtrips("abc%20def");
+    }
+
+    #[test]
+    fn osc7772_rejects_invalid_percent_escape() {
+        let mut p = make_parser();
+        // Establish a known-good prior buffer state.
+        p.process_bytes(&build_osc7772(b"prior", 5));
+        assert_eq!(p.state().command_buffer(), Some("prior"));
+        // `%zz` has invalid hex digits — the whole frame must be rejected.
+        p.process_bytes(b"\x1b]7772;3;ab%zz\x07");
+        assert_eq!(
+            p.state().command_buffer(),
+            Some("prior"),
+            "invalid percent escape must leave state untouched"
+        );
+        assert_eq!(p.state().buffer_cursor(), 5);
+    }
+
+    #[test]
+    fn osc7772_rejects_truncated_percent() {
+        let mut p = make_parser();
+        p.process_bytes(&build_osc7772(b"prior", 5));
+        p.process_bytes(b"\x1b]7772;2;ab%\x07");
+        assert_eq!(p.state().command_buffer(), Some("prior"));
+        assert_eq!(p.state().buffer_cursor(), 5);
+    }
+
+    #[test]
+    fn osc7772_rejects_invalid_utf8_after_decode() {
+        let mut p = make_parser();
+        p.process_bytes(&build_osc7772(b"prior", 5));
+        // Bytes 0xFF 0xFE 0x80 are decoded successfully but are not valid
+        // UTF-8. Mirror the legacy 7770 path: silently drop, no replace
+        // characters, no buffer mutation.
+        p.process_bytes(b"\x1b]7772;3;%FF%FE%80\x07");
+        assert_eq!(p.state().command_buffer(), Some("prior"));
+        assert_eq!(p.state().buffer_cursor(), 5);
+    }
+
+    #[test]
+    fn osc7772_security_no_nested_osc7_dispatch() {
+        // Defense in depth: a buffer whose decoded value LOOKS like an
+        // OSC 7 (`\e]7;file:///etc/passwd\a`) must NOT update CWD. The
+        // decoded bytes go straight into `set_command_buffer`; they never
+        // re-enter the VTE state machine.
+        let mut p = make_parser();
+        assert_eq!(p.state().cwd(), None);
+        let smuggled = b"\x1b]7;file:///etc/passwd\x07";
+        let cursor = std::str::from_utf8(smuggled).unwrap().chars().count();
+        p.process_bytes(&build_osc7772(smuggled, cursor));
+        assert_eq!(
+            p.state().cwd(),
+            None,
+            "OSC 7772 payload must not re-enter the VTE state machine"
+        );
+        // The buffer itself reconstructs byte-for-byte.
+        assert_eq!(
+            p.state().command_buffer(),
+            Some(std::str::from_utf8(smuggled).unwrap())
+        );
+    }
 }

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -1280,12 +1280,12 @@ mod tests {
         assert_roundtrips("if true; then");
     }
 
-    // The canonical bug witness from the SPEC. Pre-OSC-7772 framing
-    // truncated this buffer at the first `;`, surfacing as wrong
-    // completion candidates the moment a user typed any composite
-    // statement. Asserting whole-buffer reconstruction here keeps that
-    // regression visible — if this ever fails, the encoder/decoder
-    // contract has drifted and `cargo test` is the loud failure.
+    // Pre-OSC-7772 framing truncated this buffer at the first `;`,
+    // surfacing as wrong completion candidates the moment a user typed
+    // any composite statement (see ADR 0003 §Context). Asserting
+    // whole-buffer reconstruction here keeps that regression visible —
+    // if this ever fails, the encoder/decoder contract has drifted and
+    // `cargo test` is the loud failure.
     #[test]
     fn osc7772_regression_pin_canonical_bug_witness() {
         assert_roundtrips("if true; then echo a; fi");

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -266,10 +266,29 @@ impl Perform for TerminalState {
                 tracing::debug!(cursor, "OSC 7772 — buffer update");
                 self.set_command_buffer(buffer, cursor);
             }
-            // OSC 7770 — Ghost Complete buffer report
+            // OSC 7770 — Ghost Complete buffer report (LEGACY raw framing).
+            //
+            // DEPRECATED: this path is structurally unsafe. vte splits OSC
+            // params on `;`, so a buffer like `if true; then` is silently
+            // truncated at the first semicolon, and embedded `\a` / `\e]`
+            // bytes can prematurely terminate the OSC envelope or smuggle
+            // a nested OSC into the parser. New shell integrations emit
+            // OSC 7772 (percent-encoded) instead. See ADR 0003.
+            //
+            // Behaviour is intentionally unchanged from prior releases:
+            // first hit per process logs a one-shot `warn!`, subsequent
+            // hits drop to `trace!`. Slated for removal at v(N+2).
             b"7770" => {
                 if params.len() < 3 {
                     return;
+                }
+                if self.check_and_set_legacy_osc7770_warned() {
+                    tracing::warn!(
+                        "OSC 7770 (legacy raw framing) received — upgrade your shell \
+                         integration. See docs/adr/0003-osc7772-buffer-framing.md."
+                    );
+                } else {
+                    tracing::trace!("OSC 7770 (legacy) — buffer update");
                 }
                 let cursor = match std::str::from_utf8(params[1])
                     .ok()
@@ -290,7 +309,6 @@ impl Perform for TerminalState {
                         return;
                     }
                 };
-                tracing::debug!(cursor, "OSC 7770 — buffer update");
                 self.set_command_buffer(buffer, cursor);
             }
             // OSC 7 — current working directory

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -987,6 +987,28 @@ mod tests {
 
     // -- OSC 7770 UTF-8 rejection --
 
+    // Legacy framing — bug-by-design; see ADR 0003.
+    //
+    // The pre-OSC-7772 emitter interpolated `$BUFFER` raw into the OSC
+    // payload, and vte splits OSC parameters on `;`. So a buffer like
+    // `if true; then` becomes a 4-param OSC: `params[2] = "if true"`,
+    // `params[3] = " then"`. The 7770 dispatch arm only reads `params[2]`,
+    // silently truncating the buffer at the first semicolon. This test
+    // pins the broken behaviour so changes to the legacy path stay
+    // observable until 7770 is removed in v(N+2).
+    #[test]
+    fn osc7770_legacy_truncates_on_semicolon_documented() {
+        let mut p = make_parser();
+        p.process_bytes(b"\x1b]7770;14;if true; then\x07");
+        assert_eq!(
+            p.state().command_buffer(),
+            Some("if true"),
+            "legacy OSC 7770 truncates at first ';' — see ADR 0003"
+        );
+        // Cursor was 14 (end of full buffer); clamped to truncated length 7.
+        assert_eq!(p.state().buffer_cursor(), 7);
+    }
+
     #[test]
     fn test_osc7770_invalid_utf8_rejected() {
         let mut p = make_parser();

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -1125,15 +1125,17 @@ mod tests {
 
     // -- OSC 7770 UTF-8 rejection --
 
-    // Legacy framing — bug-by-design; see ADR 0003.
+    // LEGACY: this test pins the OSC 7770 truncation bug deliberately —
+    // the parser still accepts the 7770 framing for one deprecation cycle
+    // even though it is structurally broken. Slated for `#[ignore]` at
+    // v(N+1) and deletion at v(N+2), once stale shells have been pushed
+    // to the OSC 7772 framing. See ADR 0003 and `osc7772_regression_pin_*`
+    // below for the positive case the new framing fixes.
     //
-    // The pre-OSC-7772 emitter interpolated `$BUFFER` raw into the OSC
-    // payload, and vte splits OSC parameters on `;`. So a buffer like
-    // `if true; then` becomes a 4-param OSC: `params[2] = "if true"`,
-    // `params[3] = " then"`. The 7770 dispatch arm only reads `params[2]`,
-    // silently truncating the buffer at the first semicolon. This test
-    // pins the broken behaviour so changes to the legacy path stay
-    // observable until 7770 is removed in v(N+2).
+    // vte splits OSC parameters on `;`, so a buffer like `if true; then`
+    // becomes a 4-param OSC: `params[2] = "if true"`, `params[3] = " then"`.
+    // The 7770 dispatch arm only reads `params[2]`, silently truncating
+    // the buffer at the first semicolon.
     #[test]
     fn osc7770_legacy_truncates_on_semicolon_documented() {
         let mut p = make_parser();
@@ -1268,6 +1270,17 @@ mod tests {
     #[test]
     fn osc7772_roundtrips_semicolon() {
         assert_roundtrips("if true; then");
+    }
+
+    // The canonical bug witness from the SPEC. Pre-OSC-7772 framing
+    // truncated this buffer at the first `;`, surfacing as wrong
+    // completion candidates the moment a user typed any composite
+    // statement. Asserting whole-buffer reconstruction here keeps that
+    // regression visible — if this ever fails, the encoder/decoder
+    // contract has drifted and `cargo test` is the loud failure.
+    #[test]
+    fn osc7772_regression_pin_canonical_bug_witness() {
+        assert_roundtrips("if true; then echo a; fi");
     }
 
     #[test]

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -227,10 +227,14 @@ impl Perform for TerminalState {
             //   params[2] = percent-encoded UTF-8 buffer
             //
             // Anything malformed (bad cursor int, bad escape, non-UTF-8
-            // payload) drops the frame silently and leaves prior state
-            // untouched.
+            // payload) drops the frame (logs a `tracing::warn!`; prior
+            // buffer state untouched).
             b"7772" => {
                 if params.len() < 3 {
+                    tracing::debug!(
+                        params_len = params.len(),
+                        "OSC 7772 — missing payload param, dropping frame"
+                    );
                     return;
                 }
                 let cursor = match std::str::from_utf8(params[1])
@@ -273,13 +277,11 @@ impl Perform for TerminalState {
             // a nested OSC into the parser. New shell integrations emit
             // OSC 7772 (percent-encoded) instead. See ADR 0003.
             //
-            // Behaviour is intentionally unchanged from prior releases:
-            // first hit per process logs a one-shot `warn!`, subsequent
-            // hits drop to `trace!`. Slated for removal at v(N+2).
+            // Decoding/state-update logic is unchanged; only logging now
+            // flags the legacy framing (one-shot `warn!` on first hit per
+            // parser instance, `trace!` thereafter). Slated for removal at
+            // v0.12.0.
             b"7770" => {
-                if params.len() < 3 {
-                    return;
-                }
                 if self.check_and_set_legacy_osc7770_warned() {
                     tracing::warn!(
                         "OSC 7770 (legacy raw framing) received — upgrade your shell \
@@ -287,6 +289,10 @@ impl Perform for TerminalState {
                     );
                 } else {
                     tracing::trace!("OSC 7770 (legacy) — buffer update");
+                }
+                if params.len() < 3 {
+                    tracing::debug!("OSC 7770 — short params, dropping");
+                    return;
                 }
                 let cursor = match std::str::from_utf8(params[1])
                     .ok()
@@ -1123,7 +1129,7 @@ mod tests {
     // LEGACY: this test pins the OSC 7770 truncation bug deliberately —
     // the parser still accepts the 7770 framing for one deprecation cycle
     // even though it is structurally broken. Slated for `#[ignore]` at
-    // v(N+1) and deletion at v(N+2), once stale shells have been pushed
+    // v0.11.0 and deletion at v0.12.0, once stale shells have been pushed
     // to the OSC 7772 framing. See ADR 0003 and `osc7772_regression_pin_*`
     // below for the positive case the new framing fixes.
     //
@@ -1140,7 +1146,8 @@ mod tests {
             Some("if true"),
             "legacy OSC 7770 truncates at first ';' — see ADR 0003"
         );
-        // Cursor was 14 (end of full buffer); clamped to truncated length 7.
+        // Cursor was 14 (one past the end of the full 13-char buffer);
+        // clamped to the truncated buffer length 7.
         assert_eq!(p.state().buffer_cursor(), 7);
     }
 
@@ -1389,5 +1396,70 @@ mod tests {
             p.state().command_buffer(),
             Some(std::str::from_utf8(smuggled).unwrap())
         );
+    }
+
+    #[test]
+    fn osc7772_does_not_disturb_terminal_cursor() {
+        let mut p = make_parser();
+        p.process_bytes(b"hello");
+        let before = p.state().cursor_position();
+        p.process_bytes(&build_osc7772(b"if true; then", 13));
+        p.process_bytes(b" world");
+        assert_eq!(p.state().cursor_position(), (before.0, before.1 + 6));
+        assert_eq!(p.state().command_buffer(), Some("if true; then"));
+    }
+
+    #[test]
+    fn osc7772_rejects_non_numeric_cursor() {
+        let mut p = make_parser();
+        p.process_bytes(&build_osc7772(b"prior", 5));
+        p.process_bytes(b"\x1b]7772;notanumber;abc\x07");
+        assert_eq!(p.state().command_buffer(), Some("prior"));
+        assert_eq!(p.state().buffer_cursor(), 5);
+    }
+
+    #[test]
+    fn osc7772_rejects_negative_cursor() {
+        let mut p = make_parser();
+        p.process_bytes(&build_osc7772(b"prior", 5));
+        p.process_bytes(b"\x1b]7772;-1;abc\x07");
+        assert_eq!(p.state().command_buffer(), Some("prior"));
+    }
+
+    #[test]
+    fn osc7772_rejects_missing_params() {
+        let mut p = make_parser();
+        p.process_bytes(&build_osc7772(b"prior", 5));
+        p.process_bytes(b"\x1b]7772;5\x07");
+        assert_eq!(p.state().command_buffer(), Some("prior"));
+        p.process_bytes(b"\x1b]7772\x07");
+        assert_eq!(p.state().command_buffer(), Some("prior"));
+    }
+
+    #[test]
+    fn osc7772_cursor_clamped_to_buffer_length() {
+        let mut p = make_parser();
+        p.process_bytes(&build_osc7772(b"abc", 9999));
+        assert_eq!(p.state().command_buffer(), Some("abc"));
+        assert_eq!(p.state().buffer_cursor(), 3);
+    }
+
+    #[test]
+    fn osc7772_cursor_zero_valid() {
+        let mut p = make_parser();
+        p.process_bytes(&build_osc7772(b"hello", 0));
+        assert_eq!(p.state().buffer_cursor(), 0);
+    }
+
+    #[test]
+    fn osc7770_legacy_dispatch_continues_after_warn_flag_flips() {
+        // Three legacy frames in a row: the one-shot warn flag flips on
+        // the first, but state updates must continue for every dispatch.
+        let mut p = make_parser();
+        p.process_bytes(b"\x1b]7770;1;a\x07");
+        p.process_bytes(b"\x1b]7770;2;ab\x07");
+        p.process_bytes(b"\x1b]7770;3;abc\x07");
+        assert_eq!(p.state().command_buffer(), Some("abc"));
+        assert_eq!(p.state().buffer_cursor(), 3);
     }
 }

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -351,6 +351,40 @@ fn percent_decode_path(input: &str) -> PathBuf {
     PathBuf::from(std::ffi::OsStr::from_bytes(&bytes))
 }
 
+/// Percent-decode an OSC 7772 buffer payload.
+///
+/// Returns `None` on:
+///   - invalid hex digit in `%XX`
+///   - truncated `%` at end of input
+///
+/// This is intentionally STRICTER than [`percent_decode_path`]: a buffer
+/// payload should round-trip exactly, so any malformed escape is a
+/// transport error and the whole frame is dropped. The OSC 7 path
+/// (filesystem URIs) instead preserves malformed bytes literally because
+/// "best-effort partial CWD" is a sensible degradation, but for command
+/// buffers the only safe action is to ignore the report.
+//
+// `dead_code` is allowed during this commit only — Task 4 wires the
+// OSC 7772 dispatch arm to call this helper and the attribute is
+// removed there.
+#[allow(dead_code)]
+fn percent_decode_buffer(input: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(input.len());
+    let mut iter = input.iter().copied();
+    while let Some(b) = iter.next() {
+        if b == b'%' {
+            let hi = iter.next()?;
+            let lo = iter.next()?;
+            let h = hex_val(hi)?;
+            let l = hex_val(lo)?;
+            out.push((h << 4) | l);
+        } else {
+            out.push(b);
+        }
+    }
+    Some(out)
+}
+
 fn hex_val(b: u8) -> Option<u8> {
     match b {
         b'0'..=b'9' => Some(b - b'0'),
@@ -947,6 +981,47 @@ mod tests {
             percent_decode_path("/100%25done"),
             PathBuf::from("/100%done")
         );
+    }
+
+    // -- percent_decode_buffer (strict: rejects malformed escapes) --
+
+    #[test]
+    fn percent_decode_buffer_empty() {
+        assert_eq!(percent_decode_buffer(b""), Some(Vec::new()));
+    }
+
+    #[test]
+    fn percent_decode_buffer_no_encoding() {
+        assert_eq!(
+            percent_decode_buffer(b"abc xyz"),
+            Some(b"abc xyz".to_vec())
+        );
+    }
+
+    #[test]
+    fn percent_decode_buffer_single_escape() {
+        assert_eq!(percent_decode_buffer(b"%20"), Some(b" ".to_vec()));
+    }
+
+    #[test]
+    fn percent_decode_buffer_mixed() {
+        // `if true; then` with `;` encoded.
+        assert_eq!(
+            percent_decode_buffer(b"if true%3B then"),
+            Some(b"if true; then".to_vec())
+        );
+    }
+
+    #[test]
+    fn percent_decode_buffer_invalid_hex_rejected() {
+        assert_eq!(percent_decode_buffer(b"ab%zz"), None);
+        assert_eq!(percent_decode_buffer(b"ab%2g"), None);
+    }
+
+    #[test]
+    fn percent_decode_buffer_truncated_rejected() {
+        assert_eq!(percent_decode_buffer(b"ab%"), None);
+        assert_eq!(percent_decode_buffer(b"ab%2"), None);
     }
 
     // -- OSC 7770 buffer cursor clamping --

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -216,6 +216,56 @@ impl Perform for TerminalState {
                     }
                 }
             }
+            // OSC 7772 — Ghost Complete buffer report (percent-encoded, secure framing).
+            //
+            // See `docs/adr/0003-osc7772-buffer-framing.md`. Replaces the
+            // raw 7770 framing whose `;`/`\a`/`\e` bytes silently
+            // truncated buffers and could smuggle nested OSC sequences.
+            //
+            //   params[0] = "7772"
+            //   params[1] = cursor position (decimal char count)
+            //   params[2] = percent-encoded UTF-8 buffer
+            //
+            // Anything malformed (bad cursor int, bad escape, non-UTF-8
+            // payload) drops the frame silently and leaves prior state
+            // untouched.
+            b"7772" => {
+                if params.len() < 3 {
+                    return;
+                }
+                let cursor = match std::str::from_utf8(params[1])
+                    .ok()
+                    .and_then(|s| s.parse::<usize>().ok())
+                {
+                    Some(c) => c,
+                    None => {
+                        tracing::warn!(
+                            "OSC 7772 — invalid cursor position, skipping buffer update"
+                        );
+                        return;
+                    }
+                };
+                let decoded = match percent_decode_buffer(params[2]) {
+                    Some(bytes) => bytes,
+                    None => {
+                        tracing::warn!(
+                            "OSC 7772 — malformed percent escape in payload, skipping"
+                        );
+                        return;
+                    }
+                };
+                let buffer = match String::from_utf8(decoded) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        tracing::warn!(
+                            "OSC 7772 — invalid UTF-8 after decode, skipping buffer update"
+                        );
+                        return;
+                    }
+                };
+                tracing::debug!(cursor, "OSC 7772 — buffer update");
+                self.set_command_buffer(buffer, cursor);
+            }
             // OSC 7770 — Ghost Complete buffer report
             b"7770" => {
                 if params.len() < 3 {
@@ -363,11 +413,6 @@ fn percent_decode_path(input: &str) -> PathBuf {
 /// (filesystem URIs) instead preserves malformed bytes literally because
 /// "best-effort partial CWD" is a sensible degradation, but for command
 /// buffers the only safe action is to ignore the report.
-//
-// `dead_code` is allowed during this commit only — Task 4 wires the
-// OSC 7772 dispatch arm to call this helper and the attribute is
-// removed there.
-#[allow(dead_code)]
 fn percent_decode_buffer(input: &[u8]) -> Option<Vec<u8>> {
     let mut out = Vec::with_capacity(input.len());
     let mut iter = input.iter().copied();

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -231,7 +231,12 @@ impl Perform for TerminalState {
             // buffer state untouched).
             b"7772" => {
                 if params.len() < 3 {
-                    tracing::debug!(
+                    // The production zsh emitter always emits 3 params (even
+                    // for an empty buffer); short params indicate a buggy
+                    // emitter or hostile input. Sibling rejection arms below
+                    // (cursor-parse, percent-decode, UTF-8) all `warn!`, so
+                    // RUST_LOG=warn operators see broken-shell conditions.
+                    tracing::warn!(
                         params_len = params.len(),
                         "OSC 7772 — missing payload param, dropping frame"
                     );
@@ -1124,14 +1129,15 @@ mod tests {
         assert_eq!(result, expected);
     }
 
-    // -- OSC 7770 UTF-8 rejection --
+    // -- OSC 7770 legacy framing tests --
 
     // LEGACY: this test pins the OSC 7770 truncation bug deliberately —
     // the parser still accepts the 7770 framing for one deprecation cycle
     // even though it is structurally broken. Slated for `#[ignore]` at
     // v0.11.0 and deletion at v0.12.0, once stale shells have been pushed
-    // to the OSC 7772 framing. See ADR 0003 and `osc7772_regression_pin_*`
-    // below for the positive case the new framing fixes.
+    // to the OSC 7772 framing. See ADR 0003 and
+    // `osc7772_regression_pin_canonical_bug_witness` below for the positive
+    // case the new framing fixes.
     //
     // vte splits OSC parameters on `;`, so a buffer like `if true; then`
     // becomes a 4-param OSC: `params[2] = "if true"`, `params[3] = " then"`.
@@ -1344,6 +1350,12 @@ mod tests {
         // Establish a known-good prior buffer state.
         p.process_bytes(&build_osc7772(b"prior", 5));
         assert_eq!(p.state().command_buffer(), Some("prior"));
+        // Drain the dirty flag so the next assertion measures only the
+        // rejected frame's effect on it. This pin is canonical for the
+        // rejection family — gc-pty uses `take_buffer_dirty()` to gate
+        // suggestion recomputes; a regression that flagged dirty on a
+        // dropped frame would silently fire spurious recomputes.
+        assert!(p.state_mut().take_buffer_dirty());
         // `%zz` has invalid hex digits — the whole frame must be rejected.
         p.process_bytes(b"\x1b]7772;3;ab%zz\x07");
         assert_eq!(
@@ -1351,6 +1363,16 @@ mod tests {
             Some("prior"),
             "invalid percent escape must leave state untouched"
         );
+        assert_eq!(p.state().buffer_cursor(), 5);
+        assert!(
+            !p.state_mut().take_buffer_dirty(),
+            "rejected frame must not flip the buffer-dirty flag"
+        );
+        // Recovery path: a subsequent valid frame must still apply. A
+        // regression that latched a 'parser broken' bit would not be
+        // caught without this assertion.
+        p.process_bytes(&build_osc7772(b"after", 5));
+        assert_eq!(p.state().command_buffer(), Some("after"));
         assert_eq!(p.state().buffer_cursor(), 5);
     }
 
@@ -1424,6 +1446,7 @@ mod tests {
         p.process_bytes(&build_osc7772(b"prior", 5));
         p.process_bytes(b"\x1b]7772;-1;abc\x07");
         assert_eq!(p.state().command_buffer(), Some("prior"));
+        assert_eq!(p.state().buffer_cursor(), 5);
     }
 
     #[test]
@@ -1432,8 +1455,10 @@ mod tests {
         p.process_bytes(&build_osc7772(b"prior", 5));
         p.process_bytes(b"\x1b]7772;5\x07");
         assert_eq!(p.state().command_buffer(), Some("prior"));
+        assert_eq!(p.state().buffer_cursor(), 5);
         p.process_bytes(b"\x1b]7772\x07");
         assert_eq!(p.state().command_buffer(), Some("prior"));
+        assert_eq!(p.state().buffer_cursor(), 5);
     }
 
     #[test]
@@ -1453,13 +1478,21 @@ mod tests {
 
     #[test]
     fn osc7770_legacy_dispatch_continues_after_warn_flag_flips() {
-        // Three legacy frames in a row: the one-shot warn flag flips on
-        // the first, but state updates must continue for every dispatch.
+        // Three legacy frames in a row with DIFFERENT cursor/buffer values
+        // and per-frame assertions: the one-shot warn flag flips on the
+        // first, but state updates must continue for every dispatch. A
+        // regression that silently dropped frames 1 or 2 would slip past a
+        // final-only assertion (frame 3 happens to leave the same end
+        // state); per-frame pins catch the silent drop.
         let mut p = make_parser();
-        p.process_bytes(b"\x1b]7770;1;a\x07");
         p.process_bytes(b"\x1b]7770;2;ab\x07");
-        p.process_bytes(b"\x1b]7770;3;abc\x07");
-        assert_eq!(p.state().command_buffer(), Some("abc"));
-        assert_eq!(p.state().buffer_cursor(), 3);
+        assert_eq!(p.state().command_buffer(), Some("ab"));
+        assert_eq!(p.state().buffer_cursor(), 2);
+        p.process_bytes(b"\x1b]7770;4;abcd\x07");
+        assert_eq!(p.state().command_buffer(), Some("abcd"));
+        assert_eq!(p.state().buffer_cursor(), 4);
+        p.process_bytes(b"\x1b]7770;6;abcdef\x07");
+        assert_eq!(p.state().command_buffer(), Some("abcdef"));
+        assert_eq!(p.state().buffer_cursor(), 6);
     }
 }

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -46,6 +46,12 @@ pub struct TerminalState {
     cwd_dirty: bool,
     cursor_sync_requested: bool,
     cpr_synced: bool,
+    /// One-shot guard so the deprecation warning for the legacy OSC 7770
+    /// raw-framing path fires at most once per process. Subsequent legacy
+    /// dispatches downgrade to a `trace!` line so a stale shell does not
+    /// spam the proxy log on every keystroke. Reset only by process exit
+    /// — there is no API to clear it. See ADR 0003.
+    legacy_osc7770_warned: bool,
     /// FIFO queue of pending CPR requests in send-order.
     ///
     /// Terminals respond to `CSI 6n` requests in the same order they
@@ -77,8 +83,23 @@ impl TerminalState {
             cwd_dirty: false,
             cursor_sync_requested: false,
             cpr_synced: false,
+            legacy_osc7770_warned: false,
             cpr_queue: VecDeque::new(),
             next_cpr_id: 0,
+        }
+    }
+
+    /// Returns true the first time it is called per `TerminalState`,
+    /// false thereafter. Used by the OSC 7770 (legacy) dispatch to log a
+    /// one-shot deprecation warning while downgrading repeated hits to
+    /// `trace!` to avoid spamming the log when a stale shell is talking
+    /// to a new binary. Idempotent after first call. See ADR 0003.
+    pub(crate) fn check_and_set_legacy_osc7770_warned(&mut self) -> bool {
+        if self.legacy_osc7770_warned {
+            false
+        } else {
+            self.legacy_osc7770_warned = true;
+            true
         }
     }
 

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -47,10 +47,11 @@ pub struct TerminalState {
     cursor_sync_requested: bool,
     cpr_synced: bool,
     /// One-shot guard so the deprecation warning for the legacy OSC 7770
-    /// raw-framing path fires at most once per process. Subsequent legacy
-    /// dispatches downgrade to a `trace!` line so a stale shell does not
-    /// spam the proxy log on every keystroke. Reset only by process exit
-    /// — there is no API to clear it. See ADR 0003.
+    /// raw-framing path fires at most once per `TerminalState` instance.
+    /// Subsequent legacy dispatches downgrade to a `trace!` line so a stale
+    /// shell does not spam the proxy log on every keystroke. Production
+    /// currently constructs a single parser per proxy session, so this is
+    /// effectively per-process. See ADR 0003.
     legacy_osc7770_warned: bool,
     /// FIFO queue of pending CPR requests in send-order.
     ///
@@ -611,5 +612,27 @@ mod tests {
         assert_eq!(dropped, 1);
         assert_eq!(state.cpr_queue_len(), 1);
         assert_eq!(state.claim_next_cpr(), Some(CprOwner::Shell));
+    }
+
+    #[test]
+    fn check_and_set_legacy_osc7770_warned_is_one_shot() {
+        let mut s = TerminalState::new(24, 80);
+        assert!(
+            s.check_and_set_legacy_osc7770_warned(),
+            "first call returns true"
+        );
+        assert!(
+            !s.check_and_set_legacy_osc7770_warned(),
+            "second call returns false"
+        );
+        assert!(
+            !s.check_and_set_legacy_osc7770_warned(),
+            "third call still false"
+        );
+        s.update_dimensions(48, 120);
+        assert!(
+            !s.check_and_set_legacy_osc7770_warned(),
+            "resize must not reset"
+        );
     }
 }

--- a/crates/gc-parser/tests/osc7772_proptest.rs
+++ b/crates/gc-parser/tests/osc7772_proptest.rs
@@ -1,7 +1,8 @@
 //! Property tests for the OSC 7772 framing.
 //!
-//! `build_osc7772` is the in-test port of `_gc_urlencode_buffer` in
-//! `shell/ghost-complete.zsh`. The two implementations must match
+//! `encode` is the in-test port of `_gc_urlencode_buffer` in
+//! `shell/ghost-complete.zsh`; `build_osc7772` wraps an encoded payload
+//! in the OSC envelope. Both must match the production zsh emitter
 //! byte-for-byte: every legal `$BUFFER` the shell can emit must round-trip
 //! through this encoder and the production decoder. Any divergence here
 //! is also a bug in `crates/gc-parser/src/performer.rs`.
@@ -46,9 +47,10 @@ fn build_osc7772(buffer: &[u8], cursor_chars: usize) -> Vec<u8> {
 }
 
 proptest! {
-    /// Any valid UTF-8 string up to 4 KiB must round-trip exactly.
-    /// `proptest` regex `.{0,4096}` generates Unicode code points; the
-    /// Rust `String` we get is by definition valid UTF-8.
+    /// Any valid UTF-8 string of up to 4096 Unicode code points must
+    /// round-trip exactly. `proptest` regex `.{0,4096}` generates Unicode
+    /// scalar values; the resulting Rust `String` is by definition valid
+    /// UTF-8.
     #[test]
     fn osc7772_roundtrips_arbitrary_utf8(s in ".{0,4096}") {
         let mut p = TerminalParser::new(24, 80);
@@ -59,17 +61,51 @@ proptest! {
 
     /// Arbitrary byte vectors that are NOT valid UTF-8 must be silently
     /// dropped. The buffer state stays as it was prior to the malformed
-    /// frame — no replacement chars, no partial decode.
+    /// frame — no replacement chars, no partial decode. We seed a known
+    /// prior `(buffer, cursor)` so the assertion fails if a rejection bug
+    /// mutates either field independently.
     #[test]
     fn osc7772_rejects_invalid_utf8(bytes in proptest::collection::vec(any::<u8>(), 0..4096)) {
         prop_assume!(std::str::from_utf8(&bytes).is_err());
         let mut p = TerminalParser::new(24, 80);
-        let before = p.state().command_buffer().map(str::to_string);
+        p.process_bytes(&build_osc7772(b"prior", 5));
         let env = build_osc7772(&bytes, 0);
         p.process_bytes(&env);
-        prop_assert_eq!(
-            p.state().command_buffer().map(str::to_string),
-            before
-        );
+        prop_assert_eq!(p.state().command_buffer(), Some("prior"));
+        prop_assert_eq!(p.state().buffer_cursor(), 5);
+    }
+
+    /// Malformed percent escapes (lone `%` at end, non-hex digit after
+    /// `%`) must cause the entire frame to be rejected — buffer state
+    /// stays as it was. The decoder is intentionally stricter than the
+    /// OSC 7 path decoder: a buffer is uniformly percent-encoded by the
+    /// shell, so any malformed escape is corruption, not legal content.
+    ///
+    /// The malformed token is appended after a well-formed prefix so the
+    /// decoder sees a frame whose head looks legal but whose tail forces
+    /// the rejection branches reached only by hand-picked unit tests in
+    /// the encode-and-roundtrip strategies. Placing it at the end avoids
+    /// "rescue by neighbor": e.g. a stray `%` followed by two hex digits
+    /// in a randomly generated suffix would form a valid escape.
+    #[test]
+    fn osc7772_rejects_malformed_percent(
+        prefix in "[A-Za-z0-9._~/ -]{0,64}",
+        bad in r"(%|%[G-Zg-z]|%[0-9A-Fa-f][G-Zg-z]|%[G-Zg-z][0-9A-Fa-f])",
+    ) {
+        let mut p = TerminalParser::new(24, 80);
+        p.process_bytes(&build_osc7772(b"prior", 5));
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&encode(prefix.as_bytes()));
+        payload.extend_from_slice(bad.as_bytes());
+
+        let mut env = Vec::with_capacity(payload.len() + 16);
+        env.extend_from_slice(b"\x1b]7772;0;");
+        env.extend_from_slice(&payload);
+        env.push(0x07);
+        p.process_bytes(&env);
+
+        prop_assert_eq!(p.state().command_buffer(), Some("prior"));
+        prop_assert_eq!(p.state().buffer_cursor(), 5);
     }
 }

--- a/crates/gc-parser/tests/osc7772_proptest.rs
+++ b/crates/gc-parser/tests/osc7772_proptest.rs
@@ -47,16 +47,20 @@ fn build_osc7772(buffer: &[u8], cursor_chars: usize) -> Vec<u8> {
 }
 
 proptest! {
-    /// Any valid UTF-8 string of up to 4096 Unicode code points must
-    /// round-trip exactly. `proptest` regex `.{0,4096}` generates Unicode
-    /// scalar values; the resulting Rust `String` is by definition valid
-    /// UTF-8.
+    /// Any valid non-newline-containing UTF-8 string of up to 4096 code
+    /// points must round-trip exactly. `proptest`'s `.{0,4096}` regex
+    /// generates arbitrary Unicode scalar values except `\n` (regex `.`
+    /// excludes newline by default); the resulting Rust `String` is valid
+    /// UTF-8 by construction. Both `command_buffer()` and `buffer_cursor()`
+    /// are asserted so a regression that writes a fixed (or zero) cursor
+    /// while preserving the buffer cannot slip past this property.
     #[test]
     fn osc7772_roundtrips_arbitrary_utf8(s in ".{0,4096}") {
         let mut p = TerminalParser::new(24, 80);
         let env = build_osc7772(s.as_bytes(), s.chars().count());
         p.process_bytes(&env);
         prop_assert_eq!(p.state().command_buffer(), Some(s.as_str()));
+        prop_assert_eq!(p.state().buffer_cursor(), s.chars().count());
     }
 
     /// Arbitrary byte vectors that are NOT valid UTF-8 must be silently

--- a/crates/gc-parser/tests/osc7772_proptest.rs
+++ b/crates/gc-parser/tests/osc7772_proptest.rs
@@ -1,0 +1,75 @@
+//! Property tests for the OSC 7772 framing.
+//!
+//! `build_osc7772` is the in-test port of `_gc_urlencode_buffer` in
+//! `shell/ghost-complete.zsh`. The two implementations must match
+//! byte-for-byte: every legal `$BUFFER` the shell can emit must round-trip
+//! through this encoder and the production decoder. Any divergence here
+//! is also a bug in `crates/gc-parser/src/performer.rs`.
+
+use gc_parser::TerminalParser;
+use proptest::prelude::*;
+
+const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+/// Mirror `_gc_urlencode_buffer`: pass `[A-Za-z0-9._~/-]` and ` ` through;
+/// percent-encode every other byte as `%XX`. UTF-8 multibyte sequences are
+/// encoded byte-by-byte (each high byte matches `0x80..=0xFF` and is
+/// outside the allow-list).
+fn encode(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    for &b in input {
+        let safe = matches!(b,
+            b'a'..=b'z'
+                | b'A'..=b'Z'
+                | b'0'..=b'9'
+                | b'.' | b'_' | b'~' | b'/' | b'-' | b' '
+        );
+        if safe {
+            out.push(b);
+        } else {
+            out.push(b'%');
+            out.push(HEX[(b >> 4) as usize]);
+            out.push(HEX[(b & 0x0F) as usize]);
+        }
+    }
+    out
+}
+
+fn build_osc7772(buffer: &[u8], cursor_chars: usize) -> Vec<u8> {
+    let mut env = Vec::with_capacity(buffer.len() * 3 + 16);
+    env.extend_from_slice(b"\x1b]7772;");
+    env.extend_from_slice(cursor_chars.to_string().as_bytes());
+    env.push(b';');
+    env.extend_from_slice(&encode(buffer));
+    env.push(0x07);
+    env
+}
+
+proptest! {
+    /// Any valid UTF-8 string up to 4 KiB must round-trip exactly.
+    /// `proptest` regex `.{0,4096}` generates Unicode code points; the
+    /// Rust `String` we get is by definition valid UTF-8.
+    #[test]
+    fn osc7772_roundtrips_arbitrary_utf8(s in ".{0,4096}") {
+        let mut p = TerminalParser::new(24, 80);
+        let env = build_osc7772(s.as_bytes(), s.chars().count());
+        p.process_bytes(&env);
+        prop_assert_eq!(p.state().command_buffer(), Some(s.as_str()));
+    }
+
+    /// Arbitrary byte vectors that are NOT valid UTF-8 must be silently
+    /// dropped. The buffer state stays as it was prior to the malformed
+    /// frame — no replacement chars, no partial decode.
+    #[test]
+    fn osc7772_rejects_invalid_utf8(bytes in proptest::collection::vec(any::<u8>(), 0..4096)) {
+        prop_assume!(std::str::from_utf8(&bytes).is_err());
+        let mut p = TerminalParser::new(24, 80);
+        let before = p.state().command_buffer().map(str::to_string);
+        let env = build_osc7772(&bytes, 0);
+        p.process_bytes(&env);
+        prop_assert_eq!(
+            p.state().command_buffer().map(str::to_string),
+            before
+        );
+    }
+}

--- a/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
@@ -8,7 +8,9 @@
 //! change — proving the decoded bytes never re-entered the VTE state
 //! machine. See ADR 0003.
 //!
-//! Skipped silently on systems without `zsh` on PATH (e.g. Alpine CI).
+//! Silently skipped on local dev systems without `zsh` on PATH; panics
+//! under CI (`CI` env var set) to fail loud if zsh is missing in a
+//! controlled environment.
 
 use std::path::PathBuf;
 use std::process::Command;

--- a/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
@@ -117,7 +117,12 @@ fn assert_roundtrips(label: &str, fixture: &[u8]) {
 #[test]
 fn osc7772_real_zsh_roundtrip() {
     if !zsh_available() {
-        eprintln!("skipping osc7772_real_zsh_roundtrip: zsh not on PATH");
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!("skipping osc7772_real_zsh_roundtrip: zsh not on PATH (local dev)");
         return;
     }
 
@@ -134,4 +139,12 @@ fn osc7772_real_zsh_roundtrip() {
     // round-trip the `cwd` MUST remain unchanged — the decoded bytes go
     // straight to `set_command_buffer`, not back through the VTE parser.
     assert_roundtrips("osc7 smuggle attempt", b"\x1b]7;file:///etc/passwd\x07");
+
+    // Additional ADR-threat-model fixtures verified against the real zsh
+    // emitter: NUL byte, ESC+ST envelope terminator, already-percent-
+    // encoded text (round-trip-once invariant), and the empty buffer.
+    assert_roundtrips("embedded NUL", b"a\x00b");
+    assert_roundtrips("embedded ESC+ST", b"foo\x1b\\bar");
+    assert_roundtrips("all-encoded percent", b"abc%20def");
+    assert_roundtrips("empty buffer", b"");
 }

--- a/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
@@ -4,9 +4,11 @@
 //! `shell/ghost-complete.zsh`, calls `_gc_report_buffer` with the fixture
 //! bytes set as `$BUFFER`, captures stdout, and feeds the bytes through
 //! `gc_parser::TerminalParser`. The reconstructed buffer must equal the
-//! input. The OSC-injection fixture additionally asserts CWD did NOT
-//! change — proving the decoded bytes never re-entered the VTE state
-//! machine. See ADR 0003.
+//! input. Every fixture asserts CWD did not change before/after the
+//! round-trip; this invariant is meaningful only for the OSC-injection
+//! fixture (others have no embedded OSC 7), but all fixtures share the
+//! same assertion path — proving the decoded bytes never re-entered
+//! the VTE state machine. See ADR 0003.
 //!
 //! Silently skipped on local dev systems without `zsh` on PATH; panics
 //! under CI (`CI` env var set) to fail loud if zsh is missing in a
@@ -108,6 +110,11 @@ fn assert_roundtrips(label: &str, fixture: &[u8]) {
         actual,
         Some(expected),
         "[{label}] reconstruction failed; raw zsh stdout = {stdout:02X?}"
+    );
+    assert_eq!(
+        p.state().buffer_cursor(),
+        cursor,
+        "[{label}] buffer cursor not preserved through real-zsh round-trip"
     );
     assert_eq!(
         p.state().cwd().cloned(),

--- a/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
@@ -1,0 +1,137 @@
+//! End-to-end OSC 7772 round-trip: real zsh emitter → real Rust parser.
+//!
+//! Spawns an actual `zsh -c` for each fixture, sources the production
+//! `shell/ghost-complete.zsh`, calls `_gc_report_buffer` with the fixture
+//! bytes set as `$BUFFER`, captures stdout, and feeds the bytes through
+//! `gc_parser::TerminalParser`. The reconstructed buffer must equal the
+//! input. The OSC-injection fixture additionally asserts CWD did NOT
+//! change — proving the decoded bytes never re-entered the VTE state
+//! machine. See ADR 0003.
+//!
+//! Skipped silently on systems without `zsh` on PATH (e.g. Alpine CI).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use gc_parser::TerminalParser;
+
+/// Encode arbitrary bytes into a zsh `$'…'` literal. Every byte goes
+/// through as `\xXX` — verbose but unambiguous, no quoting edge cases.
+fn to_zsh_literal(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 4 + 3);
+    out.push_str("$'");
+    for &b in bytes {
+        out.push_str(&format!("\\x{b:02X}"));
+    }
+    out.push('\'');
+    out
+}
+
+fn repo_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("gc-pty crate should be two dirs deep")
+        .to_path_buf()
+}
+
+fn zsh_available() -> bool {
+    Command::new("zsh")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Run the production emitter for `(buffer, cursor)` and return raw stdout.
+fn emit_via_real_zsh(buffer: &[u8], cursor: usize) -> Vec<u8> {
+    let zsh_init = repo_root().join("shell/ghost-complete.zsh");
+    assert!(zsh_init.exists(), "shell/ghost-complete.zsh not found");
+
+    // Single-line zsh script: source the integration, set BUFFER and
+    // CURSOR, invoke the reporter. `$'…'` escapes through every byte
+    // literally — no quoting hazards.
+    let script = format!(
+        "source {init_q}; BUFFER={buf_lit}; CURSOR={cursor}; _gc_report_buffer",
+        init_q = shell_quote(zsh_init.to_str().expect("path is utf-8")),
+        buf_lit = to_zsh_literal(buffer),
+    );
+
+    let output = Command::new("zsh")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("zsh -c failed to launch");
+    assert!(
+        output.status.success(),
+        "zsh exited non-zero: stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+/// POSIX-quote a string for safe interpolation as one zsh argument.
+fn shell_quote(s: &str) -> String {
+    // Single-quote everything; close-quote, escape any `'` as `'\''`,
+    // reopen. Defensive even for paths we control — tempdirs are fine
+    // but the repo path could in principle contain a quote.
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push_str(r"'\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+fn assert_roundtrips(label: &str, fixture: &[u8]) {
+    let cursor = std::str::from_utf8(fixture)
+        .expect("fixture is valid UTF-8")
+        .chars()
+        .count();
+    let stdout = emit_via_real_zsh(fixture, cursor);
+
+    let mut p = TerminalParser::new(24, 80);
+    let cwd_before = p.state().cwd().cloned();
+    p.process_bytes(&stdout);
+
+    let actual = p.state().command_buffer();
+    let expected = std::str::from_utf8(fixture).unwrap();
+    assert_eq!(
+        actual,
+        Some(expected),
+        "[{label}] reconstruction failed; raw zsh stdout = {stdout:02X?}"
+    );
+    assert_eq!(
+        p.state().cwd().cloned(),
+        cwd_before,
+        "[{label}] OSC 7772 dispatch must not change cwd"
+    );
+}
+
+#[test]
+fn osc7772_real_zsh_roundtrip() {
+    if !zsh_available() {
+        eprintln!("skipping osc7772_real_zsh_roundtrip: zsh not on PATH");
+        return;
+    }
+
+    // Each fixture exercises a different failure mode of the legacy
+    // raw 7770 framing: ';' splitting, BEL early-terminate, ESC[…m
+    // colour codes, multi-byte UTF-8, and a deliberate OSC 7 smuggle.
+    assert_roundtrips("plain semicolon", b"echo a; ls -la");
+    assert_roundtrips("compound", b"if true; then echo a; fi");
+    assert_roundtrips("bel inside", b"x\x07y");
+    assert_roundtrips("ansi colour", b"\x1b[31mred\x1b[0m");
+    assert_roundtrips("cjk + semicolon", "日本語; cmd".as_bytes());
+
+    // Smuggle attempt: the buffer LOOKS like OSC 7 (CWD update). After
+    // round-trip the `cwd` MUST remain unchanged — the decoded bytes go
+    // straight to `set_command_buffer`, not back through the VTE parser.
+    assert_roundtrips("osc7 smuggle attempt", b"\x1b]7;file:///etc/passwd\x07");
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,3 +199,31 @@ Shell integration scripts in `shell/` emit semantic prompt markers:
 Both are emitted simultaneously by the integration scripts, so the parser can use whichever the terminal supports.
 
 Without shell integration, features are limited — prompt boundary detection falls back to heuristics, and manual trigger (Ctrl+/) is the only way to invoke completions.
+
+### Buffer Reporting (OSC 7772)
+
+The shell integration reports the live edit buffer to the proxy after every
+ZLE redraw via OSC 7772:
+
+```
+\e]7772;<cursor>;<percent-encoded-utf8-buffer>\a
+```
+
+- **`<cursor>`** is a decimal codepoint count (zsh `$CURSOR`).
+- **`<percent-encoded-utf8-buffer>`** uses a deliberately small allow-list:
+  bytes in `[A-Za-z0-9._~/-]` and the literal space pass through; every
+  other byte (including `;`, `\a` (BEL), `\x1b` (ESC), `\\`, `%`, all
+  `<0x20` controls, `0x7F`, and `0x80`–`0xFF`) is encoded as `%XX`.
+  UTF-8 multibyte sequences are encoded byte-by-byte.
+
+The narrow alphabet is non-negotiable: any unencoded `;` would split the
+OSC parameter list and silently truncate the buffer at the parser; any
+unencoded BEL would terminate the envelope mid-payload; an unencoded ESC
+could smuggle a nested escape sequence into the parser's state machine.
+See [ADR 0003](adr/0003-osc7772-buffer-framing.md).
+
+OSC 7770 (the prior raw framing) is accepted by the parser as a deprecated
+read-only path for one release: the first hit per process logs a one-shot
+`tracing::warn!` and subsequent hits drop to `trace!`. The 7770 dispatch
+arm is scheduled for `#[ignore]` in v(N+1) and removal in v(N+2). New
+shell integrations only emit 7772.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,5 +225,5 @@ See [ADR 0003](adr/0003-osc7772-buffer-framing.md).
 OSC 7770 (the prior raw framing) is accepted by the parser as a deprecated
 read-only path for one release: the first hit per process logs a one-shot
 `tracing::warn!` and subsequent hits drop to `trace!`. The 7770 dispatch
-arm is scheduled for `#[ignore]` in v(N+1) and removal in v(N+2). New
+arm is scheduled for `#[ignore]` in v0.11.0 and removal in v0.12.0. New
 shell integrations only emit 7772.

--- a/docs/adr/0003-osc7772-buffer-framing.md
+++ b/docs/adr/0003-osc7772-buffer-framing.md
@@ -27,10 +27,16 @@ Two more failure modes compound the problem:
   The parser sees a short, "valid" OSC for everything before the BEL.
 - **Embedded `\x1b]…\a` or `\x1b\\` (ST)** does not just terminate the
   outer envelope; it **smuggles a nested escape sequence into the parser's
-  state machine**. The OSC 7770 path is the only place the proxy ingests
-  fully attacker-controlled bytes (user typing or pasting). A user who
-  pasted text crafted to look like an OSC 7 (CWD update) would see the
-  proxy's view of the working directory shift mid-line — silently.
+  state machine**. OSC 7770 is the only path where the user did NOT opt
+  in to having their bytes parsed as escapes — typing or pasting at the
+  prompt feeds `$BUFFER` to the proxy with no intent to invoke any
+  escape semantics. Other parser inputs (shell stdout from commands the
+  user ran, including `cat <evil>`) are also attacker-controllable in
+  practice, but the user opted in by running the command; defending
+  those is a separate trust-model choice (full output sanitiser), out
+  of scope here. A user who pasted text crafted to look like an OSC 7
+  (CWD update) would see the proxy's view of the working directory
+  shift mid-line — silently.
 
 The threat model is byte-level corruption / smuggling, not eavesdropping;
 this is a local-process side channel between the user's shell and our
@@ -120,7 +126,7 @@ We percent-encode `$BUFFER` in the zsh emitter and bump the OSC number to
 | User typing at prompt | Untrusted in payload bytes; trusted in intent | `$BUFFER` may contain any byte zsh permits in a line |
 | Pasted text from clipboard | Untrusted | Same surface; can include `\x1b…\a` crafted to escape framing |
 | Hostile shell snippet (`.zshrc` injection) | Out of scope | A user with hostile `.zshrc` already owns the proxy |
-| Network / file content displayed by shell | Out of scope | Shell output flows through `gc-parser` separately and is already sanitised |
+| Network / file content displayed by shell | Trusted by deliberate scope | Shell output flows through the same `gc-parser` state machine, so a `cat <evil>` whose bytes contain `\e]7;…\a` would update the proxy's CWD; the user opted in by running the command. Defending against this requires a full output sanitiser, out of scope for the buffer-reporting framing |
 
 Concrete attacker capability denied by this ADR: a user types
 `\e]7;file:///etc\a` at the prompt, expecting the proxy to update its CWD.

--- a/docs/adr/0003-osc7772-buffer-framing.md
+++ b/docs/adr/0003-osc7772-buffer-framing.md
@@ -103,10 +103,15 @@ We percent-encode `$BUFFER` in the zsh emitter and bump the OSC number to
 
 ### Neutral
 
-- bash/fish integrations are unchanged. They emit no buffer report today
-  per `CLAUDE.md` ("Bash/fish scripts exist but are not actively tested")
-  so there is no equivalent corruption to fix. If they grow a buffer
-  reporter later, it MUST emit OSC 7772 from day one.
+- bash/fish integrations still emit raw OSC 7770
+  (`shell/ghost-complete.bash` `_gc_report_buffer` interpolates
+  `$READLINE_LINE`; `shell/ghost-complete.fish` `_gc_report_buffer`
+  interpolates `commandline`) and inherit the same `;` / `\a` / `\e`
+  truncation and smuggling bug class. They are explicitly out of scope
+  for this PR — per `CLAUDE.md` these scripts are not actively tested —
+  but they MUST be migrated to OSC 7772 before the v0.12.0 deletion of
+  the legacy 7770 dispatch arm. Otherwise their buffer reporting breaks
+  entirely the moment the legacy parser path goes away.
 
 ## Threat Model
 
@@ -130,9 +135,10 @@ state machine never sees the inner escape.
   inside vte before our handler runs. The framing layer is owned by vte;
   we cannot bypass its delimiter rules.
 - **Base64.** Rejected on cost. zsh has no builtin base64; spawning
-  `base64(1)` per keystroke is a ~1–3 ms fork-exec, blowing the <100 µs
-  emitter budget by ~30×. Also fragile on minimal images (alpine, busybox)
-  where `base64(1)` is not in the default toolchain.
+  `base64(1)` per keystroke adds a fork-exec on every redraw, dwarfing
+  the in-process zsh encoding loop and visible against the
+  keystroke→suggestion budget. Also fragile on minimal images (alpine,
+  busybox) where `base64(1)` is not in the default toolchain.
 - **DCS (Device Control String) sideband.** Rejected. vte's DCS hook
   surface is narrower than OSC, multiplexers (tmux, screen) handle DCS
   passthrough less consistently, and the framing problem is identical

--- a/docs/adr/0003-osc7772-buffer-framing.md
+++ b/docs/adr/0003-osc7772-buffer-framing.md
@@ -1,0 +1,153 @@
+# 0003. OSC 7772 percent-encoded buffer framing
+
+- **Status:** Accepted
+- **Date:** 2026-04-28
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context
+
+`shell/ghost-complete.zsh` historically reported the live `$BUFFER` to the
+proxy via:
+
+```zsh
+printf '\e]7770;%d;%s\a' "$CURSOR" "$BUFFER"
+```
+
+interpolating `$BUFFER` raw into the OSC payload. `vte = "0.15"` splits OSC
+parameters on `;` (byte `0x3B`), so a buffer like `if true; then` produces a
+4-param OSC: `params[2] = "if true"`, `params[3] = " then"`. The dispatch
+arm in `crates/gc-parser/src/performer.rs` only reads `params[2]`, so the
+buffer is silently truncated at the first semicolon. Every keystroke
+through `; & | && || ;;` was wrong.
+
+Two more failure modes compound the problem:
+
+- **`\a` (BEL, `0x07`) inside `$BUFFER`** terminates the OSC mid-payload.
+  The parser sees a short, "valid" OSC for everything before the BEL.
+- **Embedded `\x1b]…\a` or `\x1b\\` (ST)** does not just terminate the
+  outer envelope; it **smuggles a nested escape sequence into the parser's
+  state machine**. The OSC 7770 path is the only place the proxy ingests
+  fully attacker-controlled bytes (user typing or pasting). A user who
+  pasted text crafted to look like an OSC 7 (CWD update) would see the
+  proxy's view of the working directory shift mid-line — silently.
+
+The threat model is byte-level corruption / smuggling, not eavesdropping;
+this is a local-process side channel between the user's shell and our
+PTY proxy. See the ADR's [`Threat Model`](#threat-model) section below.
+
+## Decision
+
+We percent-encode `$BUFFER` in the zsh emitter and bump the OSC number to
+`7772` so the parser dispatch is atomic at `match params[0]`:
+
+```zsh
+\e]7772;<cursor>;<percent_encoded_buffer>\a
+```
+
+- **Encoded alphabet.** Bytes in `[A-Za-z0-9._~/-]` and the literal space
+  pass through. Everything else — including `;`, `\a`, `\x1b`, `%`, `\\`,
+  all `< 0x20` controls, `0x7F`, and `0x80`–`0xFF` — is encoded as `%XX`
+  (uppercase hex). UTF-8 multibyte sequences are encoded byte-by-byte and
+  reassembled on decode.
+- **Decoder behaviour.** `crates/gc-parser/src/performer.rs::percent_decode_buffer`
+  rejects (returns `None`) on any invalid hex digit or truncated `%`; the
+  whole frame is dropped. Decoded payload is then `String::from_utf8`-validated.
+  Any failure path drops the frame silently via `tracing::warn!` — prior
+  buffer state is preserved.
+- **Migration.** OSC 7770 stays in the parser as a deprecated, read-only
+  legacy path for one minor release. First hit per process logs a one-shot
+  `tracing::warn!`; subsequent hits drop to `trace!`. The 7770 dispatch is
+  scheduled for `#[ignore]` in v(N+1) and deletion in v(N+2). The zsh
+  emitter only writes 7772.
+
+## Consequences
+
+### Positive
+
+- **Correctness.** `if true; then echo a; fi` and every other shell idiom
+  containing `;`, `&`, `|`, `*`, `(`, `)`, `=`, `\`, control bytes, or
+  multi-byte UTF-8 round-trips byte-for-byte. The canonical bug witness is
+  pinned in `osc7772_regression_pin_canonical_bug_witness` and the proptest
+  fuzzer covers arbitrary 4 KiB UTF-8 strings (`crates/gc-parser/tests/osc7772_proptest.rs`).
+- **Security.** A buffer crafted to look like `\e]7;file:///etc/passwd\a`
+  encodes to `%1B%5D7%3Bfile%3A///etc/passwd%07`. vte sees a single,
+  opaque OSC 7772 parameter. The bytes only become `\e]7;…\a` *after*
+  percent-decode inside `osc_dispatch`, where they go straight to
+  `set_command_buffer` — they never re-enter the parser. The integration
+  test `osc7772_real_zsh_roundtrip` includes this fixture and asserts
+  `state.cwd()` does not change.
+- **Wire safety.** The encoded alphabet is `[A-Za-z0-9._~/-% ]`. None of
+  those bytes terminate an OSC, nest an escape, or get mangled by tmux's
+  passthrough mode.
+- **Performance.** Encoder is one zsh string-concatenation loop using the
+  same idiom as `_gc_urlencode_path`; decoder is ~25 lines of pure Rust.
+  Bench `osc7772_decode/1024` runs at ~3.6 µs on a developer laptop —
+  well under the <100 µs/keystroke budget.
+
+### Negative
+
+- **Wire size.** Worst case (every byte encoded) is 3× expansion. Typical
+  buffers (mostly letters, digits, spaces, paths) hit <2×. vte's
+  `MAX_OSC_PARAMS = 16` is irrelevant because the new framing uses a
+  single payload parameter, and the `std`-feature OSC raw buffer grows
+  unbounded.
+- **One shell-side encode loop.** Every keystroke pays a per-byte loop in
+  zsh. Profiling shows ~30 µs for a 100-byte buffer — invisible next to
+  the existing keystroke→suggestion budget.
+- **A deprecation cycle.** The parser keeps two OSC arms (`7770` legacy +
+  `7772`) for one release. Net code grew ~50 lines until v(N+2) deletes
+  the legacy arm.
+
+### Neutral
+
+- bash/fish integrations are unchanged. They emit no buffer report today
+  per `CLAUDE.md` ("Bash/fish scripts exist but are not actively tested")
+  so there is no equivalent corruption to fix. If they grow a buffer
+  reporter later, it MUST emit OSC 7772 from day one.
+
+## Threat Model
+
+| Source | Trust | Surface |
+|---|---|---|
+| User typing at prompt | Untrusted in payload bytes; trusted in intent | `$BUFFER` may contain any byte zsh permits in a line |
+| Pasted text from clipboard | Untrusted | Same surface; can include `\x1b…\a` crafted to escape framing |
+| Hostile shell snippet (`.zshrc` injection) | Out of scope | A user with hostile `.zshrc` already owns the proxy |
+| Network / file content displayed by shell | Out of scope | Shell output flows through `gc-parser` separately and is already sanitised |
+
+Concrete attacker capability denied by this ADR: a user types
+`\e]7;file:///etc\a` at the prompt, expecting the proxy to update its CWD.
+Today (post-fix) the bytes encode to a single opaque payload; the parser's
+state machine never sees the inner escape.
+
+## Alternatives considered
+
+- **Length-prefix `;<len>;<bytes>`.** Rejected. vte 0.15 has no raw-byte
+  OSC hook — `osc_dispatch` is called with parameters already pre-split on
+  `;`, and bytes `0x07` / `0x1B\\` in the payload still terminate the OSC
+  inside vte before our handler runs. The framing layer is owned by vte;
+  we cannot bypass its delimiter rules.
+- **Base64.** Rejected on cost. zsh has no builtin base64; spawning
+  `base64(1)` per keystroke is a ~1–3 ms fork-exec, blowing the <100 µs
+  emitter budget by ~30×. Also fragile on minimal images (alpine, busybox)
+  where `base64(1)` is not in the default toolchain.
+- **DCS (Device Control String) sideband.** Rejected. vte's DCS hook
+  surface is narrower than OSC, multiplexers (tmux, screen) handle DCS
+  passthrough less consistently, and the framing problem is identical
+  (DCS terminates on `\x1b\\` exactly like OSC). Higher integration risk
+  for no security or performance win.
+- **Dual-accept on 7770; sniff first byte for `%`.** Rejected. Raw
+  buffers legitimately contain `%` (e.g. `printf '%s'`); no reliable
+  single-OSC sniff exists. Bumping the OSC number makes the protocol
+  switch atomic at the dispatch level and detectable in regression tests
+  (no caller of 7770 should exist after the deprecation window).
+
+## References
+
+- `docs/plans/ux-2-osc7770-framing/SPEC.md` — original problem analysis
+- `crates/gc-parser/src/performer.rs` — OSC 7772 dispatch + `percent_decode_buffer`
+- `shell/ghost-complete.zsh` — `_gc_urlencode_buffer`, `_gc_report_buffer`
+- `crates/gc-parser/tests/osc7772_proptest.rs` — proptest round-trip
+- `crates/gc-pty/tests/osc7772_zsh_roundtrip.rs` — real zsh integration test
+- [ADR-0002](0002-vte-vs-vt100.md) — why we run on `vte` (and therefore
+  inherit its OSC delimiter rules)

--- a/docs/adr/0003-osc7772-buffer-framing.md
+++ b/docs/adr/0003-osc7772-buffer-framing.md
@@ -53,12 +53,12 @@ We percent-encode `$BUFFER` in the zsh emitter and bump the OSC number to
 - **Decoder behaviour.** `crates/gc-parser/src/performer.rs::percent_decode_buffer`
   rejects (returns `None`) on any invalid hex digit or truncated `%`; the
   whole frame is dropped. Decoded payload is then `String::from_utf8`-validated.
-  Any failure path drops the frame silently via `tracing::warn!` — prior
-  buffer state is preserved.
+  Any failure path drops the frame (logs a `tracing::warn!`; prior buffer
+  state untouched).
 - **Migration.** OSC 7770 stays in the parser as a deprecated, read-only
   legacy path for one minor release. First hit per process logs a one-shot
   `tracing::warn!`; subsequent hits drop to `trace!`. The 7770 dispatch is
-  scheduled for `#[ignore]` in v(N+1) and deletion in v(N+2). The zsh
+  scheduled for `#[ignore]` in v0.11.0 and deletion in v0.12.0. The zsh
   emitter only writes 7772.
 
 ## Consequences
@@ -82,8 +82,9 @@ We percent-encode `$BUFFER` in the zsh emitter and bump the OSC number to
   passthrough mode.
 - **Performance.** Encoder is one zsh string-concatenation loop using the
   same idiom as `_gc_urlencode_path`; decoder is ~25 lines of pure Rust.
-  Bench `osc7772_decode/1024` runs at ~3.6 µs on a developer laptop —
-  well under the <100 µs/keystroke budget.
+  Both run well under the per-keystroke budget. The decoder bench lives in
+  `crates/gc-parser/benches/parser_bench.rs` (`osc7772_decode` group) for
+  reproducibility.
 
 ### Negative
 
@@ -93,10 +94,11 @@ We percent-encode `$BUFFER` in the zsh emitter and bump the OSC number to
   single payload parameter, and the `std`-feature OSC raw buffer grows
   unbounded.
 - **One shell-side encode loop.** Every keystroke pays a per-byte loop in
-  zsh. Profiling shows ~30 µs for a 100-byte buffer — invisible next to
-  the existing keystroke→suggestion budget.
+  zsh. Encoder cost is well under the per-keystroke budget for typical
+  interactive `$BUFFER` sizes — invisible next to the existing
+  keystroke→suggestion budget.
 - **A deprecation cycle.** The parser keeps two OSC arms (`7770` legacy +
-  `7772`) for one release. Net code grew ~50 lines until v(N+2) deletes
+  `7772`) for one release. Net code grew ~50 lines until v0.12.0 deletes
   the legacy arm.
 
 ### Neutral
@@ -144,7 +146,6 @@ state machine never sees the inner escape.
 
 ## References
 
-- `docs/plans/ux-2-osc7770-framing/SPEC.md` — original problem analysis
 - `crates/gc-parser/src/performer.rs` — OSC 7772 dispatch + `percent_decode_buffer`
 - `shell/ghost-complete.zsh` — `_gc_urlencode_buffer`, `_gc_report_buffer`
 - `crates/gc-parser/tests/osc7772_proptest.rs` — proptest round-trip

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ that, it probably belongs in `docs/ARCHITECTURE.md` instead.
 | -------------------------------------------- | -------------------------------------- | -------- |
 | [0001](0001-pty-proxy-vs-plugin.md)          | PTY proxy over shell plugin            | Accepted |
 | [0002](0002-vte-vs-vt100.md)                 | Parser-only VT tracking via `vte`      | Accepted |
+| [0003](0003-osc7772-buffer-framing.md)       | OSC 7772 percent-encoded buffer framing | Accepted |
 
 When you add a new ADR, append a row to this index and bump the next `NNNN`.
 

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -121,6 +121,11 @@ _gc_osc7_precmd() {
 _gc_report_buffer() {
     local encoded
     encoded="$(_gc_urlencode_buffer "$BUFFER")"
+    # Abort if the encoder failed: emitting a partially-encoded payload
+    # would defeat the framing guarantee the parser-side strict decoder
+    # relies on. The parser logs and drops malformed frames anyway, but
+    # don't even put one on the wire.
+    [[ $? -eq 0 ]] || return 0
     printf '\e]7772;%d;%s\a' "$CURSOR" "$encoded"
 }
 

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -121,11 +121,6 @@ _gc_osc7_precmd() {
 _gc_report_buffer() {
     local encoded
     encoded="$(_gc_urlencode_buffer "$BUFFER")"
-    # Abort if the encoder failed: emitting a partially-encoded payload
-    # would defeat the framing guarantee the parser-side strict decoder
-    # relies on. The parser logs and drops malformed frames anyway, but
-    # don't even put one on the wire.
-    [[ $? -eq 0 ]] || return 0
     printf '\e]7772;%d;%s\a' "$CURSOR" "$encoded"
 }
 

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -27,6 +27,38 @@ _gc_urlencode_path() {
     printf '%s' "$encoded"
 }
 
+# Percent-encode a command-line buffer for OSC 7772 transport.
+#
+# STRICTER alphabet than _gc_urlencode_path: only [a-zA-Z0-9._~/-] and the
+# literal space pass through. Everything else — including ';', '%', '\',
+# all control bytes (0x00-0x1F, 0x7F) and high bytes (0x80-0xFF) — gets
+# `%XX`-encoded. This is non-negotiable: any unencoded ';' would split
+# the OSC parameter list and silently truncate the buffer at the parser;
+# any unencoded BEL (0x07) or ESC+ST (0x1B 0x5C) would terminate the OSC
+# envelope mid-payload; an unencoded ESC could smuggle a nested escape
+# sequence into the parser's state machine. See ADR 0003.
+#
+# Do NOT widen the allow-list. If a future use case wants more characters
+# unencoded, weigh it against the cost of re-introducing the original
+# truncation/smuggling bug class and reject it anyway.
+_gc_urlencode_buffer() {
+    local input="$1" encoded="" i ch hex
+    local LC_ALL=C  # byte-level iteration so multi-byte UTF-8 round-trips
+    for (( i = 1; i <= ${#input}; i++ )); do
+        ch="${input[$i]}"
+        case "$ch" in
+            ' '|[a-zA-Z0-9._~/-])
+                encoded+="$ch"
+                ;;
+            *)
+                printf -v hex '%%%02X' "'$ch"
+                encoded+="$hex"
+                ;;
+        esac
+    done
+    printf '%s' "$encoded"
+}
+
 # True when the host terminal natively parses OSC 133 for its own prompt
 # tracking (or emits its own proprietary markers on top, like VSCode's
 # OSC 633). In those terminals our OSC 7771 fallback is redundant — the
@@ -75,10 +107,21 @@ _gc_osc7_precmd() {
     add-zsh-hook -d precmd _gc_osc7_precmd
 }
 
-# Report current command buffer to the proxy via custom OSC 7770.
+# Report current command buffer to the proxy via OSC 7772 (secure framing).
 # Fires after every buffer modification (typing, deletion, cursor movement, paste).
+#
+# Do NOT inline `$BUFFER` raw into the OSC payload. See ADR 0003.
+# Raw bytes corrupt the OSC envelope when `$BUFFER` contains `;`, `\a`,
+# or `\e`: vte splits OSC params on `;`, BEL terminates the envelope, and
+# embedded `\e]…\a` smuggles a nested OSC into the parser's state machine.
+#
+# The legacy OSC 7770 emission is gone. The parser still accepts 7770
+# during the deprecation window but logs a one-shot warn! to nudge the
+# user (or distro packager) towards a fresh shell integration.
 _gc_report_buffer() {
-    printf '\e]7770;%d;%s\a' "$CURSOR" "$BUFFER"
+    local encoded
+    encoded="$(_gc_urlencode_buffer "$BUFFER")"
+    printf '\e]7772;%d;%s\a' "$CURSOR" "$encoded"
 }
 
 # Chain into the existing zle-line-pre-redraw widget without using


### PR DESCRIPTION
## Summary

- Replace the silently-corrupting raw `\$BUFFER` interpolation in the zsh emitter with a percent-encoded **OSC 7772** envelope (parser arm + zsh `_gc_urlencode_buffer`); legacy **OSC 7770** stays parser-only with a one-shot deprecation `tracing::warn!`, scheduled for removal in v(N+2).
- Restricted encoder allow-list (`[A-Za-z0-9._~/-]` + literal space) so `;`, BEL, ESC, NUL, `\\`, `%`, `0x7F`, and `0x80–0xFF` are always `%XX`-escaped — fixes `if true; then …` truncation and shuts the OSC-injection hole that let crafted prompt input update the parser's CWD via a smuggled OSC 7.
- New ADR 0003, `docs/ARCHITECTURE.md` subsection, proptest fuzzer, real-zsh integration test, Criterion bench `osc7772_decode` (1 KiB ≈ 3.6 µs on local laptop, ~27× under the <100 µs/keystroke target).

## Plan & spec

Implements `docs/plans/ux-2-osc7770-framing/PLAN.md` against `docs/plans/ux-2-osc7770-framing/SPEC.md`. SPEC ↔ task mapping covered in PLAN Task 12.

| SPEC requirement | Where it lives |
| --- | --- |
| Percent-encode in zsh | `shell/ghost-complete.zsh::_gc_urlencode_buffer` |
| Bump to 7772 | `crates/gc-parser/src/performer.rs` (\`b\"7772\"\` arm), `shell/ghost-complete.zsh::_gc_report_buffer` |
| Decoder rejects malformed (strict, distinct from `percent_decode_path`) | `crates/gc-parser/src/performer.rs::percent_decode_buffer` |
| Round-trip dangerous bytes (`;`, BEL, ESC, NUL, embedded ST, 8 KiB ASCII, CJK UTF-8, empty, already-encoded alphabet) | `osc7772_roundtrips_*` unit tests + proptest |
| Security: no nested OSC dispatch | `osc7772_security_no_nested_osc7_dispatch`, `osc7772_real_zsh_roundtrip` (\`osc7 smuggle attempt\` fixture asserts \`state.cwd().is_none()\`) |
| Legacy 7770 still parses with deprecation | `osc7770_legacy_truncates_on_semicolon_documented` + `legacy_osc7770_warned` flag in `TerminalState` |
| Doc + ADR | `docs/ARCHITECTURE.md` (new \"Buffer Reporting (OSC 7772)\" subsection), `docs/adr/0003-osc7772-buffer-framing.md`, ADR README index |
| <100 µs decode at 1 KiB | `crates/gc-parser/benches/parser_bench.rs` (\`osc7772_decode\`) |

## Out of scope (explicit, follow-up only)

- `shell/ghost-complete.bash` and `shell/ghost-complete.fish` still emit the raw \`\\e]7770\` framing. Per CLAUDE.md they are not actively tested and, by design, this PR does not expand scope. They continue to work via the legacy 7770 parser path during the deprecation window. **Follow-up:** port `_gc_urlencode_buffer` + 7772 emission to bash and fish before v(N+2) deletes the legacy parser arm.

## Migration notes

- v(N) (this PR): emitter writes only 7772; parser accepts 7770 (legacy, with one-shot warn) and 7772 (new path). Old shells continue to work, with the existing truncation bug, until they are restarted.
- v(N+1): mark the legacy 7770 unit-test \`#[ignore]\` and tighten the deprecation log if needed.
- v(N+2): delete the OSC 7770 parser arm, the legacy guard flag, and the legacy unit-test.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` (full workspace green; 13 new OSC 7772 unit tests + 6 \`percent_decode_buffer\` helper tests + 1 legacy regression pin + 2 proptests + 1 zsh integration test)
- [x] \`cargo bench -p gc-parser --bench parser_bench -- osc7772_decode --sample-size 10\` — 100 B ≈ 538 ns, 1 KiB ≈ 3.6 µs, 8 KiB ≈ 26 µs
- [x] Manual smoke: \`zsh -c 'source shell/ghost-complete.zsh; BUFFER=\"if true; then\"; CURSOR=14; _gc_report_buffer | xxd'\` shows \`if true%3B then\` between OSC params, no early terminator
- [x] Manual smoke: OSC 7 smuggle attempt (\`BUFFER=\$'\\e]7;file:///etc/passwd\\a'\`) round-trips byte-for-byte with \`state.cwd()\` unchanged
- [ ] Soak the new emitter in real interactive zsh for 24 h before merge — verify no regressions in normal usage and that the deprecation warning never fires from the in-tree integration

## Refs

- ADR 0003 — `docs/adr/0003-osc7772-buffer-framing.md`
- Plan / SPEC — `docs/plans/ux-2-osc7770-framing/`