### PR TITLE
fix: expand multi-word aliases for correct spec resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "shlex",
  "tempfile",
  "tokio",
  "tracing",

--- a/crates/gc-suggest/Cargo.toml
+++ b/crates/gc-suggest/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 tracing = { workspace = true }
 dirs = "6"
 regex = "1"
+shlex = "1"
 tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -203,6 +203,50 @@ fn engine_benchmarks(c: &mut Criterion) {
         });
     });
 
+    // Alias expansion overhead. We bench two cases so the delta isolates
+    // the cost of `expand_alias_for_spec` + synthetic-ctx construction
+    // (everything else — spec walk, candidate ranking, filesystem
+    // probing — is held constant against `subcommand_with_spec`).
+    //
+    // Both cases land on the same git top-level subcommand subtree:
+    //   * `subcommand_with_spec` types `git ch<TAB>`.
+    //   * `alias_hit_single` types `g ch<TAB>` with `alias g=git`.
+    //   * `alias_hit_multi` types `gco m<TAB>` with `alias gco='git
+    //     checkout'`. (Different subtree but exercises the multi-word
+    //     expansion code path including the synthetic-ctx clone.)
+    let (alias_engine, alias_tmp) = setup_engine_and_dir();
+    let mut alias_map = std::collections::HashMap::with_capacity(100);
+    alias_map.insert("g".to_string(), vec!["git".to_string()]);
+    alias_map.insert(
+        "gco".to_string(),
+        vec!["git".to_string(), "checkout".to_string()],
+    );
+    for i in 0..98 {
+        alias_map.insert(
+            format!("alias_{i}"),
+            vec![format!("cmd_{i}"), format!("sub_{i}")],
+        );
+    }
+    let alias_engine = alias_engine.with_aliases(alias_map);
+
+    let alias_ctx_single = make_ctx(Some("g"), vec![], "ch", 1);
+    group.bench_function("alias_hit_single", |b| {
+        b.iter(|| {
+            alias_engine
+                .suggest_sync(&alias_ctx_single, alias_tmp.path(), "g ch")
+                .unwrap()
+        });
+    });
+
+    let alias_ctx_multi = make_ctx(Some("gco"), vec![], "m", 1);
+    group.bench_function("alias_hit_multi", |b| {
+        b.iter(|| {
+            alias_engine
+                .suggest_sync(&alias_ctx_multi, alias_tmp.path(), "gco m")
+                .unwrap()
+        });
+    });
+
     group.finish();
 }
 

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -203,17 +203,7 @@ fn engine_benchmarks(c: &mut Criterion) {
         });
     });
 
-    // Alias expansion overhead. We bench two cases so the delta isolates
-    // the cost of `expand_alias_for_spec` + synthetic-ctx construction
-    // (everything else — spec walk, candidate ranking, filesystem
-    // probing — is held constant against `subcommand_with_spec`).
-    //
-    // Both cases land on the same git top-level subcommand subtree:
-    //   * `subcommand_with_spec` types `git ch<TAB>`.
-    //   * `alias_hit_single` types `g ch<TAB>` with `alias g=git`.
-    //   * `alias_hit_multi` types `gco m<TAB>` with `alias gco='git
-    //     checkout'`. (Different subtree but exercises the multi-word
-    //     expansion code path including the synthetic-ctx clone.)
+    // Two cases isolate alias expansion overhead vs the no-alias subcommand bench.
     let (alias_engine, alias_tmp) = setup_engine_and_dir();
     let mut alias_map = std::collections::HashMap::with_capacity(100);
     alias_map.insert("g".to_string(), vec!["git".to_string()]);

--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -72,11 +72,7 @@ struct SourceFingerprint {
 
 #[derive(Serialize, Deserialize)]
 struct CachedAliases {
-    /// Schema version. Older caches without this field deserialise to 0
-    /// via `serde(default)` and are rejected by [`load_alias_cache`] —
-    /// which protects us when the v1 `HashMap<String, String>` shape
-    /// would otherwise silently land in this v2 `HashMap<String, Vec<String>>`
-    /// field as an empty-vec map.
+    /// Bump on incompatible CachedAliases shape changes; mismatch forces regeneration.
     #[serde(default)]
     format_version: u32,
     /// Maps each watched source file (by basename) to its fingerprint at
@@ -293,14 +289,7 @@ impl AliasStore {
         Self::default()
     }
 
-    /// Look up an alias and return the full resolved token vector. Returns
-    /// `None` if the alias isn't known *or* if the background loader hasn't
-    /// filled the store yet.
-    ///
-    /// Multi-word aliases (`alias gco='git checkout'`) return every token —
-    /// callers that only need the head command should index `[0]` (and
-    /// usually want [`crate::alias_expand::expand_alias_for_spec`] instead,
-    /// which handles cycles, depth caps, and recursive aliases-of-aliases).
+    /// Returns the full token vector for `name`, or None if absent or loader still pending.
     pub fn get(&self, name: &str) -> Option<Vec<String>> {
         let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
         guard.get(name).cloned()
@@ -333,28 +322,7 @@ impl AliasStore {
     }
 }
 
-/// Parse shell alias definitions into a map from alias name to the full
-/// resolved token vector.
-///
-/// Supports the output format of `alias` in zsh/bash:
-/// - zsh: `name=value` or `name='value'`
-/// - bash: `alias name='value'` or `alias name="value"`
-///
-/// Stores the entire resolved value as a token vector so callers (e.g.
-/// [`crate::alias_expand::expand_alias_for_spec`]) can walk multi-word
-/// aliases like `gco='git checkout'` into the correct subcommand subtree
-/// rather than dropping every token after the first.
-///
-/// The value is tokenised with [`shlex::split`] so quoted segments and
-/// escaped spaces survive intact (`commit='git commit -m "wip commit"'`
-/// → `["git", "commit", "-m", "wip commit"]`). When `shlex` rejects the
-/// value (typically an unbalanced quote in a malformed user config) we
-/// fall back to `split_whitespace`, keeping **every** whitespace-separated
-/// token rather than dropping the line — a single corrupt entry should
-/// not silently strip the rest of the user's aliases.
-///
-/// Note: bash function-style aliases (`function name() { ... }`) are not
-/// recognised; only the `alias name=value` form is parsed.
+/// Parse zsh/bash `alias` output into name -> token-vector pairs; full tokens preserved via shlex.
 pub fn parse_aliases(output: &str) -> HashMap<String, Vec<String>> {
     let mut map = HashMap::new();
 
@@ -561,6 +529,32 @@ alias ll='ls -la'
         let output = "empty=\n";
         let aliases = parse_aliases(output);
         assert!(!aliases.contains_key("empty"));
+    }
+
+    #[test]
+    fn test_parse_empty_quoted_value_skipped() {
+        let output = "alias x=''\nalias y=\"\"\nalias z=' '\n";
+        let aliases = parse_aliases(output);
+        assert!(!aliases.contains_key("x"));
+        assert!(!aliases.contains_key("y"));
+        assert!(!aliases.contains_key("z"));
+    }
+
+    #[test]
+    fn test_parse_quoted_value_with_padding_trimmed() {
+        let output = "alias k=' kubectl '\n";
+        let aliases = parse_aliases(output);
+        assert_eq!(aliases.get("k"), Some(&token_vec(&["kubectl"])));
+    }
+
+    #[test]
+    fn test_parse_keeps_dollar_var_as_literal_token() {
+        let output = "k='kubectl --context $CTX'\n";
+        let aliases = parse_aliases(output);
+        assert_eq!(
+            aliases.get("k"),
+            Some(&token_vec(&["kubectl", "--context", "$CTX"]))
+        );
     }
 
     #[test]
@@ -955,11 +949,7 @@ alias ll='ls -la'
 
     #[test]
     fn alias_cache_rejects_old_format_version() {
-        // A cache file written by a pre-v2 binary (no `format_version`
-        // field, or one set to anything other than CURRENT_ALIAS_CACHE_VERSION)
-        // must be rejected so we don't silently deserialise the old
-        // `HashMap<String, String>` shape into the new
-        // `HashMap<String, Vec<String>>` field as an empty-vec map.
+        // Pre-v2 cache (no format_version) must be rejected — silent deserialise would land empty Vecs.
         let home = tempfile::tempdir().unwrap();
         std::fs::write(home.path().join(".zshrc"), b"# empty\n").unwrap();
         let cache_path = home.path().join("aliases-cache.json");

--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -20,9 +20,7 @@ use serde::{Deserialize, Serialize};
 /// Cache file name (inside the state directory).
 const ALIAS_CACHE_FILE: &str = "aliases-cache.json";
 
-/// On-disk schema version for the alias cache. Bump whenever the shape
-/// of `CachedAliases` changes incompatibly. A mismatch on load returns
-/// `None`, forcing regeneration. See `load_alias_cache`.
+/// On-disk schema version; bump on incompatible CachedAliases changes.
 const CURRENT_ALIAS_CACHE_VERSION: u32 = 2;
 
 /// Source dotfiles whose mtimes invalidate the alias cache. If any exists
@@ -313,8 +311,6 @@ impl AliasStore {
         *guard = map;
     }
 
-    /// Builder-style alias install for non-test callers (integration tests,
-    /// benches, future API consumers). Replaces the current map atomically.
     #[doc(hidden)]
     pub fn install(&self, map: HashMap<String, Vec<String>>) {
         let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
@@ -359,9 +355,7 @@ pub fn parse_aliases(output: &str) -> HashMap<String, Vec<String>> {
             Some(toks) if !toks.is_empty() => toks,
             Some(_) => continue, // shlex parsed but produced nothing — empty value
             None => {
-                // Malformed value (e.g. unbalanced quote). Keep every
-                // whitespace-separated token so the user still sees the
-                // alias's general intent rather than dropping the line.
+                // Malformed shlex parse: keep raw whitespace tokens so the alias still surfaces partially.
                 tracing::debug!("shlex failed to parse alias value for {alias_name:?}: {value:?}");
                 let fallback: Vec<String> = value.split_whitespace().map(String::from).collect();
                 if fallback.is_empty() {
@@ -575,9 +569,6 @@ alias ll='ls -la'
 
     #[test]
     fn test_parse_double_quoted_with_inner_spaces() {
-        // shlex must collapse the inner double-quoted run into a single
-        // token: this is the difference between resolving a `git commit
-        // -m "wip"` alias correctly versus dropping the message.
         let output = "commit='git commit -m \"wip commit\"'\n";
         let aliases = parse_aliases(output);
         assert_eq!(
@@ -588,8 +579,6 @@ alias ll='ls -la'
 
     #[test]
     fn test_parse_escaped_space() {
-        // POSIX `\ ` joins two whitespace-separated chunks into a single
-        // token. shlex respects the backslash; split_whitespace would not.
         let output = "gx='git foo\\ bar'\n";
         let aliases = parse_aliases(output);
         assert_eq!(aliases.get("gx"), Some(&token_vec(&["git", "foo bar"])));
@@ -597,10 +586,6 @@ alias ll='ls -la'
 
     #[test]
     fn test_parse_falls_back_on_unbalanced_quote() {
-        // Malformed value: the unbalanced double-quote makes shlex return
-        // None. The fallback must keep every whitespace-separated token
-        // (not just the first), and the unaffected sibling alias must
-        // still load.
         let output = "broken=git \"open\nok=ls\n";
         let aliases = parse_aliases(output);
         assert_eq!(

--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -20,6 +20,11 @@ use serde::{Deserialize, Serialize};
 /// Cache file name (inside the state directory).
 const ALIAS_CACHE_FILE: &str = "aliases-cache.json";
 
+/// On-disk schema version for the alias cache. Bump whenever the shape
+/// of `CachedAliases` changes incompatibly. A mismatch on load returns
+/// `None`, forcing regeneration. See `load_alias_cache`.
+const CURRENT_ALIAS_CACHE_VERSION: u32 = 2;
+
 /// Source dotfiles whose mtimes invalidate the alias cache. If any exists
 /// with an mtime newer than the cache file, we regenerate. Includes every
 /// file the load paths in [`load_shell_aliases`] actually consult:
@@ -67,11 +72,18 @@ struct SourceFingerprint {
 
 #[derive(Serialize, Deserialize)]
 struct CachedAliases {
+    /// Schema version. Older caches without this field deserialise to 0
+    /// via `serde(default)` and are rejected by [`load_alias_cache`] —
+    /// which protects us when the v1 `HashMap<String, String>` shape
+    /// would otherwise silently land in this v2 `HashMap<String, Vec<String>>`
+    /// field as an empty-vec map.
+    #[serde(default)]
+    format_version: u32,
     /// Maps each watched source file (by basename) to its fingerprint at
     /// the time of capture. On load, we compare the current fingerprint
     /// against the stored value: any difference invalidates.
     source_mtimes: HashMap<String, SourceFingerprint>,
-    aliases: HashMap<String, String>,
+    aliases: HashMap<String, Vec<String>>,
 }
 
 /// Resolve the state directory path for `aliases-cache.json`. Mirrors the
@@ -171,11 +183,14 @@ fn collect_source_mtimes(home: &Path) -> HashMap<String, SourceFingerprint> {
 }
 
 /// Attempt to load the alias map from the on-disk cache. Returns `None`
-/// when the cache is missing, unreadable, malformed, or stale w.r.t. any
-/// watched source file.
-fn load_alias_cache(home: &Path, cache_path: &Path) -> Option<HashMap<String, String>> {
+/// when the cache is missing, unreadable, malformed, stale w.r.t. any
+/// watched source file, or written by a different schema version.
+fn load_alias_cache(home: &Path, cache_path: &Path) -> Option<HashMap<String, Vec<String>>> {
     let contents = std::fs::read_to_string(cache_path).ok()?;
     let cached: CachedAliases = serde_json::from_str(&contents).ok()?;
+    if cached.format_version != CURRENT_ALIAS_CACHE_VERSION {
+        return None;
+    }
     let current = collect_source_mtimes(home);
     // Any watched file newer than the cache record means regenerate.
     // Also regenerate if a file disappeared or appeared since we cached.
@@ -188,7 +203,7 @@ fn load_alias_cache(home: &Path, cache_path: &Path) -> Option<HashMap<String, St
 /// Write the alias map plus the current source mtimes to the cache file.
 /// Uses atomic write (tmp + rename). Best-effort: any failure is logged
 /// at debug and ignored.
-fn save_alias_cache(home: &Path, cache_path: &Path, aliases: &HashMap<String, String>) {
+fn save_alias_cache(home: &Path, cache_path: &Path, aliases: &HashMap<String, Vec<String>>) {
     if aliases.is_empty() {
         // Don't cache empty results — next startup retries from scratch.
         return;
@@ -202,6 +217,7 @@ fn save_alias_cache(home: &Path, cache_path: &Path, aliases: &HashMap<String, St
         return;
     }
     let payload = CachedAliases {
+        format_version: CURRENT_ALIAS_CACHE_VERSION,
         source_mtimes: collect_source_mtimes(home),
         aliases: aliases.clone(),
     };
@@ -244,7 +260,7 @@ fn save_alias_cache(home: &Path, cache_path: &Path, aliases: &HashMap<String, St
 /// to swap in the populated map.
 #[derive(Clone, Default)]
 pub struct AliasStore {
-    inner: Arc<RwLock<HashMap<String, String>>>,
+    inner: Arc<RwLock<HashMap<String, Vec<String>>>>,
 }
 
 impl AliasStore {
@@ -277,10 +293,15 @@ impl AliasStore {
         Self::default()
     }
 
-    /// Look up an alias and return the resolved command name. Returns `None`
-    /// if the alias isn't known *or* if the background loader hasn't filled
-    /// the store yet.
-    pub fn get(&self, name: &str) -> Option<String> {
+    /// Look up an alias and return the full resolved token vector. Returns
+    /// `None` if the alias isn't known *or* if the background loader hasn't
+    /// filled the store yet.
+    ///
+    /// Multi-word aliases (`alias gco='git checkout'`) return every token —
+    /// callers that only need the head command should index `[0]` (and
+    /// usually want [`crate::alias_expand::expand_alias_for_spec`] instead,
+    /// which handles cycles, depth caps, and recursive aliases-of-aliases).
+    pub fn get(&self, name: &str) -> Option<Vec<String>> {
         let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
         guard.get(name).cloned()
     }
@@ -298,20 +319,35 @@ impl AliasStore {
     /// what the background loader does on completion. Crate-private so
     /// production code keeps using `load_async`.
     #[cfg(test)]
-    pub(crate) fn populate(&self, map: HashMap<String, String>) {
+    pub(crate) fn populate(&self, map: HashMap<String, Vec<String>>) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        *guard = map;
+    }
+
+    /// Builder-style alias install for non-test callers (integration tests,
+    /// benches, future API consumers). Replaces the current map atomically.
+    #[doc(hidden)]
+    pub fn install(&self, map: HashMap<String, Vec<String>>) {
         let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
         *guard = map;
     }
 }
 
-/// Parse shell alias definitions into a map from alias name to resolved command.
+/// Parse shell alias definitions into a map from alias name to the full
+/// resolved token vector.
 ///
 /// Supports the output format of `alias` in zsh/bash:
 /// - zsh: `name=value` or `name='value'`
 /// - bash: `alias name='value'` or `alias name="value"`
 ///
-/// Only extracts the first word of the resolved value (the command name).
-pub fn parse_aliases(output: &str) -> HashMap<String, String> {
+/// Stores the entire resolved value as a token vector so callers (e.g.
+/// [`crate::alias_expand::expand_alias_for_spec`]) can walk multi-word
+/// aliases like `gco='git checkout'` into the correct subcommand subtree
+/// rather than dropping every token after the first.
+///
+/// Note: bash function-style aliases (`function name() { ... }`) are not
+/// recognised; only the `alias name=value` form is parsed.
+pub fn parse_aliases(output: &str) -> HashMap<String, Vec<String>> {
     let mut map = HashMap::new();
 
     for line in output.lines() {
@@ -343,13 +379,14 @@ pub fn parse_aliases(output: &str) -> HashMap<String, String> {
             value = &value[1..value.len() - 1];
         }
 
-        // Extract the first word (the command name)
+        // Extract the first word (the command name). Task 3 replaces this
+        // with `shlex::split` to keep every token in the alias value.
         let command = value.split_whitespace().next().unwrap_or("");
         if command.is_empty() {
             continue;
         }
 
-        map.insert(alias_name.to_string(), command.to_string());
+        map.insert(alias_name.to_string(), vec![command.to_string()]);
     }
 
     map
@@ -362,7 +399,7 @@ pub fn parse_aliases(output: &str) -> HashMap<String, String> {
 /// within the <100ms startup budget. Uses `zsh -c` (not `-ic`) to avoid
 /// loading the full interactive config which can take 200-400ms with
 /// oh-my-zsh/plugins.
-pub fn load_shell_aliases() -> HashMap<String, String> {
+pub fn load_shell_aliases() -> HashMap<String, Vec<String>> {
     let home = dirs::home_dir();
     let cache_path = alias_cache_path();
 
@@ -461,6 +498,11 @@ pub fn load_shell_aliases() -> HashMap<String, String> {
 }
 
 #[cfg(test)]
+fn token_vec(tokens: &[&str]) -> Vec<String> {
+    tokens.iter().map(|s| (*s).to_string()).collect()
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -472,9 +514,11 @@ k=kubectl
 ll='ls -la'
 ";
         let aliases = parse_aliases(output);
-        assert_eq!(aliases.get("g"), Some(&"git".to_string()));
-        assert_eq!(aliases.get("k"), Some(&"kubectl".to_string()));
-        assert_eq!(aliases.get("ll"), Some(&"ls".to_string()));
+        // Task 2 stores a single-token vec; Task 3 swaps in shlex tokenization
+        // and lifts `ll` to a multi-token vector.
+        assert_eq!(aliases.get("g"), Some(&token_vec(&["git"])));
+        assert_eq!(aliases.get("k"), Some(&token_vec(&["kubectl"])));
+        assert_eq!(aliases.get("ll"), Some(&token_vec(&["ls"])));
     }
 
     #[test]
@@ -485,16 +529,16 @@ alias k='kubectl'
 alias ll='ls -la'
 ";
         let aliases = parse_aliases(output);
-        assert_eq!(aliases.get("g"), Some(&"git".to_string()));
-        assert_eq!(aliases.get("k"), Some(&"kubectl".to_string()));
-        assert_eq!(aliases.get("ll"), Some(&"ls".to_string()));
+        assert_eq!(aliases.get("g"), Some(&token_vec(&["git"])));
+        assert_eq!(aliases.get("k"), Some(&token_vec(&["kubectl"])));
+        assert_eq!(aliases.get("ll"), Some(&token_vec(&["ls"])));
     }
 
     #[test]
     fn test_parse_double_quoted() {
         let output = "alias g=\"git\"\n";
         let aliases = parse_aliases(output);
-        assert_eq!(aliases.get("g"), Some(&"git".to_string()));
+        assert_eq!(aliases.get("g"), Some(&token_vec(&["git"])));
     }
 
     #[test]
@@ -512,9 +556,11 @@ alias ll='ls -la'
 
     #[test]
     fn test_parse_complex_value_extracts_first_word() {
+        // Task 2 keeps the single-token semantics — Task 3 generalises this
+        // to the full token vector via shlex.
         let output = "glog='git log --oneline --graph'\n";
         let aliases = parse_aliases(output);
-        assert_eq!(aliases.get("glog"), Some(&"git".to_string()));
+        assert_eq!(aliases.get("glog"), Some(&token_vec(&["git"])));
     }
 
     #[test]
@@ -535,13 +581,13 @@ alias ll='ls -la'
         assert_eq!(store.get("gco"), None);
 
         let mut map = HashMap::new();
-        map.insert("gco".to_string(), "git".to_string());
-        map.insert("k".to_string(), "kubectl".to_string());
+        map.insert("gco".to_string(), token_vec(&["git", "checkout"]));
+        map.insert("k".to_string(), token_vec(&["kubectl"]));
         store.populate(map);
 
         assert_eq!(store.len(), 2);
-        assert_eq!(store.get("gco"), Some("git".to_string()));
-        assert_eq!(store.get("k"), Some("kubectl".to_string()));
+        assert_eq!(store.get("gco"), Some(token_vec(&["git", "checkout"])));
+        assert_eq!(store.get("k"), Some(token_vec(&["kubectl"])));
         assert_eq!(store.get("not-an-alias"), None);
     }
 
@@ -552,8 +598,11 @@ alias ll='ls -la'
         // would observe divergent state once the loader fills.
         let store = AliasStore::empty();
         let store2 = store.clone();
-        store.populate(HashMap::from([("g".to_string(), "git".to_string())]));
-        assert_eq!(store2.get("g"), Some("git".to_string()));
+        store.populate(HashMap::from([(
+            "g".to_string(),
+            token_vec(&["git"]),
+        )]));
+        assert_eq!(store2.get("g"), Some(token_vec(&["git"])));
     }
 
     #[test]
@@ -566,8 +615,8 @@ alias ll='ls -la'
         let cache_path = home.path().join("aliases-cache.json");
 
         let mut aliases = HashMap::new();
-        aliases.insert("g".to_string(), "git".to_string());
-        aliases.insert("k".to_string(), "kubectl".to_string());
+        aliases.insert("g".to_string(), token_vec(&["git"]));
+        aliases.insert("k".to_string(), token_vec(&["kubectl"]));
         save_alias_cache(home.path(), &cache_path, &aliases);
         assert!(cache_path.exists(), "cache file must be written");
 
@@ -613,7 +662,7 @@ alias ll='ls -la'
         let cache_path = home.path().join("aliases-cache.json");
 
         let mut aliases = HashMap::new();
-        aliases.insert("g".to_string(), "git".to_string());
+        aliases.insert("g".to_string(), token_vec(&["git"]));
         save_alias_cache(home.path(), &cache_path, &aliases);
         assert!(load_alias_cache(home.path(), &cache_path).is_some());
 
@@ -653,7 +702,7 @@ alias ll='ls -la'
         let cache_path = home.path().join("aliases-cache.json");
 
         let mut aliases = HashMap::new();
-        aliases.insert("g".to_string(), "git".to_string());
+        aliases.insert("g".to_string(), token_vec(&["git"]));
         save_alias_cache(home.path(), &cache_path, &aliases);
         assert!(load_alias_cache(home.path(), &cache_path).is_some());
 
@@ -691,7 +740,7 @@ alias ll='ls -la'
 
         let cache_path = home.path().join("aliases-cache.json");
         let mut aliases = HashMap::new();
-        aliases.insert("g".to_string(), "git".to_string());
+        aliases.insert("g".to_string(), token_vec(&["git"]));
         save_alias_cache(home.path(), &cache_path, &aliases);
         assert!(load_alias_cache(home.path(), &cache_path).is_some());
 
@@ -720,7 +769,7 @@ alias ll='ls -la'
         let cache_path = home.path().join("aliases-cache.json");
 
         let mut aliases = HashMap::new();
-        aliases.insert("g".to_string(), "git".to_string());
+        aliases.insert("g".to_string(), token_vec(&["git"]));
         save_alias_cache(home.path(), &cache_path, &aliases);
         assert!(load_alias_cache(home.path(), &cache_path).is_some());
 
@@ -775,7 +824,7 @@ alias ll='ls -la'
 
         let cache_path = home.path().join("aliases-cache.json");
         let mut aliases = HashMap::new();
-        aliases.insert("g".to_string(), "git".to_string());
+        aliases.insert("g".to_string(), token_vec(&["git"]));
         save_alias_cache(home.path(), &cache_path, &aliases);
         assert!(load_alias_cache(home.path(), &cache_path).is_some());
 
@@ -797,7 +846,7 @@ alias ll='ls -la'
         let cache_path = home.path().join("aliases-cache.json");
 
         let mut aliases = HashMap::new();
-        aliases.insert("g".to_string(), "git".to_string());
+        aliases.insert("g".to_string(), token_vec(&["git"]));
         save_alias_cache(home.path(), &cache_path, &aliases);
 
         assert!(cache_path.exists(), "cache file must be written");
@@ -828,7 +877,7 @@ alias ll='ls -la'
         std::os::unix::fs::symlink(&victim, &predictable).unwrap();
 
         let mut aliases = HashMap::new();
-        aliases.insert("g".to_string(), "git".to_string());
+        aliases.insert("g".to_string(), token_vec(&["git"]));
         save_alias_cache(home.path(), &cache_path, &aliases);
 
         assert_eq!(
@@ -839,6 +888,44 @@ alias ll='ls -la'
         assert!(
             cache_path.exists(),
             "cache must still be written to its real path"
+        );
+    }
+
+    #[test]
+    fn alias_cache_rejects_old_format_version() {
+        // A cache file written by a pre-v2 binary (no `format_version`
+        // field, or one set to anything other than CURRENT_ALIAS_CACHE_VERSION)
+        // must be rejected so we don't silently deserialise the old
+        // `HashMap<String, String>` shape into the new
+        // `HashMap<String, Vec<String>>` field as an empty-vec map.
+        let home = tempfile::tempdir().unwrap();
+        std::fs::write(home.path().join(".zshrc"), b"# empty\n").unwrap();
+        let cache_path = home.path().join("aliases-cache.json");
+
+        // Hand-craft a v1-shaped payload: no format_version, plain string values.
+        let legacy = serde_json::json!({
+            "source_mtimes": {
+                ".zshrc": { "secs": 0, "nanos": 0, "len": 0 },
+            },
+            "aliases": { "g": "git" },
+        });
+        std::fs::write(&cache_path, legacy.to_string()).unwrap();
+
+        assert!(
+            load_alias_cache(home.path(), &cache_path).is_none(),
+            "v1 cache (missing format_version) must be rejected on load"
+        );
+
+        // Sanity: an explicit older version is also rejected.
+        let stale = serde_json::json!({
+            "format_version": 1u32,
+            "source_mtimes": {},
+            "aliases": {},
+        });
+        std::fs::write(&cache_path, stale.to_string()).unwrap();
+        assert!(
+            load_alias_cache(home.path(), &cache_path).is_none(),
+            "format_version != CURRENT_ALIAS_CACHE_VERSION must be rejected"
         );
     }
 
@@ -857,7 +944,7 @@ alias ll='ls -la'
             handles.push(std::thread::spawn(move || {
                 for i in 0..20 {
                     let mut aliases = HashMap::new();
-                    aliases.insert(format!("k_{t}_{i}"), "cmd".to_string());
+                    aliases.insert(format!("k_{t}_{i}"), token_vec(&["cmd"]));
                     save_alias_cache(home.path(), &cache_path, &aliases);
                 }
             }));

--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -345,6 +345,14 @@ impl AliasStore {
 /// aliases like `gco='git checkout'` into the correct subcommand subtree
 /// rather than dropping every token after the first.
 ///
+/// The value is tokenised with [`shlex::split`] so quoted segments and
+/// escaped spaces survive intact (`commit='git commit -m "wip commit"'`
+/// → `["git", "commit", "-m", "wip commit"]`). When `shlex` rejects the
+/// value (typically an unbalanced quote in a malformed user config) we
+/// fall back to `split_whitespace`, keeping **every** whitespace-separated
+/// token rather than dropping the line — a single corrupt entry should
+/// not silently strip the rest of the user's aliases.
+///
 /// Note: bash function-style aliases (`function name() { ... }`) are not
 /// recognised; only the `alias name=value` form is parsed.
 pub fn parse_aliases(output: &str) -> HashMap<String, Vec<String>> {
@@ -379,14 +387,26 @@ pub fn parse_aliases(output: &str) -> HashMap<String, Vec<String>> {
             value = &value[1..value.len() - 1];
         }
 
-        // Extract the first word (the command name). Task 3 replaces this
-        // with `shlex::split` to keep every token in the alias value.
-        let command = value.split_whitespace().next().unwrap_or("");
-        if command.is_empty() {
-            continue;
-        }
+        let tokens = match shlex::split(value) {
+            Some(toks) if !toks.is_empty() => toks,
+            Some(_) => continue, // shlex parsed but produced nothing — empty value
+            None => {
+                // Malformed value (e.g. unbalanced quote). Keep every
+                // whitespace-separated token so the user still sees the
+                // alias's general intent rather than dropping the line.
+                tracing::debug!(
+                    "shlex failed to parse alias value for {alias_name:?}: {value:?}"
+                );
+                let fallback: Vec<String> =
+                    value.split_whitespace().map(String::from).collect();
+                if fallback.is_empty() {
+                    continue;
+                }
+                fallback
+            }
+        };
 
-        map.insert(alias_name.to_string(), vec![command.to_string()]);
+        map.insert(alias_name.to_string(), tokens);
     }
 
     map
@@ -514,11 +534,9 @@ k=kubectl
 ll='ls -la'
 ";
         let aliases = parse_aliases(output);
-        // Task 2 stores a single-token vec; Task 3 swaps in shlex tokenization
-        // and lifts `ll` to a multi-token vector.
         assert_eq!(aliases.get("g"), Some(&token_vec(&["git"])));
         assert_eq!(aliases.get("k"), Some(&token_vec(&["kubectl"])));
-        assert_eq!(aliases.get("ll"), Some(&token_vec(&["ls"])));
+        assert_eq!(aliases.get("ll"), Some(&token_vec(&["ls", "-la"])));
     }
 
     #[test]
@@ -531,7 +549,7 @@ alias ll='ls -la'
         let aliases = parse_aliases(output);
         assert_eq!(aliases.get("g"), Some(&token_vec(&["git"])));
         assert_eq!(aliases.get("k"), Some(&token_vec(&["kubectl"])));
-        assert_eq!(aliases.get("ll"), Some(&token_vec(&["ls"])));
+        assert_eq!(aliases.get("ll"), Some(&token_vec(&["ls", "-la"])));
     }
 
     #[test]
@@ -555,12 +573,62 @@ alias ll='ls -la'
     }
 
     #[test]
-    fn test_parse_complex_value_extracts_first_word() {
-        // Task 2 keeps the single-token semantics — Task 3 generalises this
-        // to the full token vector via shlex.
+    fn test_parse_complex_value_keeps_full_tokens() {
         let output = "glog='git log --oneline --graph'\n";
         let aliases = parse_aliases(output);
-        assert_eq!(aliases.get("glog"), Some(&token_vec(&["git"])));
+        assert_eq!(
+            aliases.get("glog"),
+            Some(&token_vec(&["git", "log", "--oneline", "--graph"]))
+        );
+    }
+
+    #[test]
+    fn test_parse_double_quoted_with_inner_spaces() {
+        // shlex must collapse the inner double-quoted run into a single
+        // token: this is the difference between resolving a `git commit
+        // -m "wip"` alias correctly versus dropping the message.
+        let output = "commit='git commit -m \"wip commit\"'\n";
+        let aliases = parse_aliases(output);
+        assert_eq!(
+            aliases.get("commit"),
+            Some(&token_vec(&["git", "commit", "-m", "wip commit"]))
+        );
+    }
+
+    #[test]
+    fn test_parse_escaped_space() {
+        // POSIX `\ ` joins two whitespace-separated chunks into a single
+        // token. shlex respects the backslash; split_whitespace would not.
+        let output = "gx='git foo\\ bar'\n";
+        let aliases = parse_aliases(output);
+        assert_eq!(aliases.get("gx"), Some(&token_vec(&["git", "foo bar"])));
+    }
+
+    #[test]
+    fn test_parse_falls_back_on_unbalanced_quote() {
+        // Malformed value: the unbalanced double-quote makes shlex return
+        // None. The fallback must keep every whitespace-separated token
+        // (not just the first), and the unaffected sibling alias must
+        // still load.
+        let output = "broken=git \"open\nok=ls\n";
+        let aliases = parse_aliases(output);
+        assert_eq!(
+            aliases.get("broken"),
+            Some(&token_vec(&["git", "\"open"])),
+            "fallback must preserve every token, not just the first"
+        );
+        assert_eq!(
+            aliases.get("ok"),
+            Some(&token_vec(&["ls"])),
+            "a single corrupt alias must not drop later entries"
+        );
+    }
+
+    #[test]
+    fn test_parse_single_word_unchanged() {
+        let output = "ll=ls\n";
+        let aliases = parse_aliases(output);
+        assert_eq!(aliases.get("ll"), Some(&token_vec(&["ls"])));
     }
 
     #[test]

--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -394,11 +394,8 @@ pub fn parse_aliases(output: &str) -> HashMap<String, Vec<String>> {
                 // Malformed value (e.g. unbalanced quote). Keep every
                 // whitespace-separated token so the user still sees the
                 // alias's general intent rather than dropping the line.
-                tracing::debug!(
-                    "shlex failed to parse alias value for {alias_name:?}: {value:?}"
-                );
-                let fallback: Vec<String> =
-                    value.split_whitespace().map(String::from).collect();
+                tracing::debug!("shlex failed to parse alias value for {alias_name:?}: {value:?}");
+                let fallback: Vec<String> = value.split_whitespace().map(String::from).collect();
                 if fallback.is_empty() {
                     continue;
                 }
@@ -666,10 +663,7 @@ alias ll='ls -la'
         // would observe divergent state once the loader fills.
         let store = AliasStore::empty();
         let store2 = store.clone();
-        store.populate(HashMap::from([(
-            "g".to_string(),
-            token_vec(&["git"]),
-        )]));
+        store.populate(HashMap::from([("g".to_string(), token_vec(&["git"]))]));
         assert_eq!(store2.get("g"), Some(token_vec(&["git"])));
     }
 

--- a/crates/gc-suggest/src/alias_expand.rs
+++ b/crates/gc-suggest/src/alias_expand.rs
@@ -1,16 +1,4 @@
-//! Alias expansion at spec-resolution time.
-//!
-//! Multi-word aliases like `alias gco='git checkout'` need to be unfolded
-//! before the engine asks `SpecStore` which spec applies and walks
-//! [`crate::specs::resolve_spec`] over the args. This module returns a
-//! synthetic *view* of the user's [`CommandContext`] with the alias-tail
-//! prepended to the args; `current_word` and `word_index` are deliberately
-//! left untouched because fuzzy ranking, history matching, frecency
-//! keying, and the accept-completion path all key off the literal buffer
-//! the user typed (`gco`), not the expansion (`git checkout`).
-//!
-//! See `docs/plans/ux-3-multiword-aliases/SPEC.md` (D2 / D3 / D5) for the
-//! invariants.
+//! Alias-expanded view over CommandContext for spec resolution.
 
 use std::borrow::Cow;
 use std::collections::HashSet;
@@ -19,40 +7,17 @@ use gc_buffer::CommandContext;
 
 use crate::alias::AliasStore;
 
-/// Maximum recursive alias-of-alias expansions per lookup. Far above any
-/// realistic depth (zsh users rarely chain more than 2–3 levels deep) and
-/// small enough that the per-keystroke cost stays well under the
-/// suggestion budget. See SPEC D3.
+/// Recursion cap for chained alias-of-alias expansion (cycle/depth guard).
 pub(crate) const MAX_ALIAS_HOPS: usize = 16;
 
-/// Alias-expanded view over a [`CommandContext`] for spec resolution.
-///
-/// Both fields are `Cow` so the no-alias-hit branch costs zero
-/// allocations: `resolved_command` borrows from `ctx.command` and
-/// `effective_args` borrows `ctx.args`. Only when an alias actually fires
-/// do we own the rewritten tokens.
+/// Cow-borrowed in the no-alias-hit path to avoid per-keystroke allocations.
 pub(crate) struct ExpandedCtx<'a> {
-    /// Resolved command name (head of the expansion). Equals the original
-    /// `ctx.command` string when no alias matched.
     pub resolved_command: Cow<'a, str>,
-    /// `expanded-tail-tokens ++ ctx.args`. Borrowed from `ctx.args` when
-    /// no expansion happened.
     pub effective_args: Cow<'a, [String]>,
+    pub aliased: bool,
 }
 
-/// Expand `ctx.command` through the alias map.
-///
-/// Returns `None` only when there is no command to expand at all
-/// (`ctx.word_index == 0` — user is still typing the alias name itself —
-/// or `ctx.command.is_none()`). Every other path, including "command is
-/// not an alias", returns `Some(ExpandedCtx)` so callers can uniformly
-/// look up the spec by `resolved_command` and walk by `effective_args`.
-///
-/// Recursion stops on:
-/// * a head token that is not itself an alias,
-/// * a head token already seen in this expansion (cycle guard), or
-/// * after [`MAX_ALIAS_HOPS`] iterations (depth cap; partial expansion
-///   is preserved).
+/// Walk ctx.command through the alias map; cycle-guarded, capped at MAX_ALIAS_HOPS.
 pub(crate) fn expand_alias_for_spec<'a>(
     ctx: &'a CommandContext,
     alias_map: &AliasStore,
@@ -62,15 +27,14 @@ pub(crate) fn expand_alias_for_spec<'a>(
     }
     let command = ctx.command.as_deref()?;
 
-    // Fast path: no alias hit at all -> borrowed view.
     let Some(initial) = alias_map.get(command) else {
         return Some(ExpandedCtx {
             resolved_command: Cow::Borrowed(command),
             effective_args: Cow::Borrowed(&ctx.args),
+            aliased: false,
         });
     };
 
-    // Slow path: head expansion + recursive head-replacement.
     let mut tokens: Vec<String> = initial;
     let mut visited: HashSet<String> = HashSet::new();
     visited.insert(command.to_string());
@@ -81,7 +45,7 @@ pub(crate) fn expand_alias_for_spec<'a>(
             None => break,
         };
         if visited.contains(&head) {
-            break; // cycle
+            break;
         }
         match alias_map.get(&head) {
             Some(next) => {
@@ -98,13 +62,13 @@ pub(crate) fn expand_alias_for_spec<'a>(
         return None;
     }
     let mut iter = tokens.into_iter();
-    // Safe: tokens.is_empty() returned false above.
     let resolved = iter.next().expect("tokens non-empty");
     let mut effective: Vec<String> = iter.collect();
     effective.extend(ctx.args.iter().cloned());
     Some(ExpandedCtx {
         resolved_command: Cow::Owned(resolved),
         effective_args: Cow::Owned(effective),
+        aliased: true,
     })
 }
 
@@ -153,8 +117,7 @@ mod tests {
 
     #[test]
     fn expand_returns_none_at_word_index_zero() {
-        // The user is still typing the command itself; expansion would
-        // be wrong because `current_word` is the name, not a positional.
+        // word_index 0 means current_word is the alias name itself, not a positional.
         let aliases = store(&[("gco", &["git", "checkout"])]);
         let c = ctx(None, &[], "gc", 0);
         assert!(expand_alias_for_spec(&c, &aliases).is_none());
@@ -162,20 +125,17 @@ mod tests {
 
     #[test]
     fn expand_returns_borrowed_when_no_alias() {
-        // No alias hit must borrow from `ctx` rather than allocate — the
-        // hot path runs on every keystroke.
         let aliases = AliasStore::empty();
         let c = ctx(Some("git"), &["checkout"], "main", 2);
         let exp = expand_alias_for_spec(&c, &aliases).unwrap();
         assert!(matches!(exp.resolved_command, Cow::Borrowed("git")));
         assert!(matches!(exp.effective_args, Cow::Borrowed(_)));
+        assert!(!exp.aliased);
         assert_eq!(exp.effective_args.as_ref(), &["checkout".to_string()]);
     }
 
     #[test]
     fn expand_single_word_alias() {
-        // `alias g=git` resolves to head=git with no tail; ctx.args pass
-        // through unchanged.
         let aliases = store(&[("g", &["git"])]);
         let c = ctx(Some("g"), &["push"], "", 2);
         let exp = expand_alias_for_spec(&c, &aliases).unwrap();
@@ -185,8 +145,6 @@ mod tests {
 
     #[test]
     fn expand_multi_word_alias() {
-        // `alias gco='git checkout'` resolves to head=git with tail=[checkout],
-        // and the user-typed args are appended after.
         let aliases = store(&[("gco", &["git", "checkout"])]);
         let c = ctx(Some("gco"), &["main"], "", 2);
         let exp = expand_alias_for_spec(&c, &aliases).unwrap();
@@ -199,9 +157,6 @@ mod tests {
 
     #[test]
     fn expand_chained_aliases() {
-        // gcb -> gco -> git checkout. The tail from each layer accumulates
-        // (`-b` from gcb, `checkout` from gco), and the user-typed args
-        // come last.
         let aliases = store(&[("gcb", &["gco", "-b"]), ("gco", &["git", "checkout"])]);
         let c = ctx(Some("gcb"), &["feature"], "", 2);
         let exp = expand_alias_for_spec(&c, &aliases).unwrap();
@@ -218,24 +173,15 @@ mod tests {
 
     #[test]
     fn expand_cycle_guard() {
-        // a -> b -> a. Expansion must terminate without recursion: after
-        // two hops `a` is already visited, so the loop bails. The
-        // resulting head doesn't have to be "useful"; it just must not
-        // hang or panic.
+        // a -> b -> a must terminate, not stack-overflow.
         let aliases = store(&[("a", &["b"]), ("b", &["a"])]);
         let c = ctx(Some("a"), &[], "", 1);
         let exp = expand_alias_for_spec(&c, &aliases).unwrap();
-        // The point of the test is termination; we don't assert on
-        // `resolved_command` because either head is acceptable (the
-        // SPEC just says "stop expansion").
         assert!(["a", "b"].contains(&exp.resolved_command.as_ref()));
     }
 
     #[test]
     fn expand_depth_cap_stops_at_max_hops() {
-        // Build a chain longer than MAX_ALIAS_HOPS. Expansion must
-        // terminate (no infinite loop, no panic) and return the partial
-        // result rather than failing.
         let chain_len = MAX_ALIAS_HOPS + 5;
         let names: Vec<String> = (0..chain_len).map(|i| format!("a{i}")).collect();
         let mut entries: Vec<(&str, Vec<String>)> = Vec::new();
@@ -251,11 +197,6 @@ mod tests {
 
         let c = ctx(Some("a0"), &[], "", 1);
         let exp = expand_alias_for_spec(&c, &store).unwrap();
-        // After 16 hops starting from a0, the head should be a16 (we
-        // expand a0 -> a1 once before entering the loop, then 16 more
-        // head-swaps land on a17). Either way the head is somewhere in
-        // the chain and the loop terminated — the absolute index is an
-        // implementation detail; the SPEC guarantees only "stops at 16".
         let head = exp.resolved_command.as_ref();
         assert!(head.starts_with('a'));
         let idx: usize = head[1..].parse().unwrap();

--- a/crates/gc-suggest/src/alias_expand.rs
+++ b/crates/gc-suggest/src/alias_expand.rs
@@ -117,7 +117,12 @@ mod tests {
     use super::*;
     use crate::alias::AliasStore;
 
-    fn ctx(command: Option<&str>, args: &[&str], current_word: &str, word_index: usize) -> CommandContext {
+    fn ctx(
+        command: Option<&str>,
+        args: &[&str],
+        current_word: &str,
+        word_index: usize,
+    ) -> CommandContext {
         CommandContext {
             command: command.map(String::from),
             args: args.iter().map(|s| (*s).to_string()).collect(),

--- a/crates/gc-suggest/src/alias_expand.rs
+++ b/crates/gc-suggest/src/alias_expand.rs
@@ -1,0 +1,262 @@
+//! Alias expansion at spec-resolution time.
+//!
+//! Multi-word aliases like `alias gco='git checkout'` need to be unfolded
+//! before the engine asks `SpecStore` which spec applies and walks
+//! [`crate::specs::resolve_spec`] over the args. This module returns a
+//! synthetic *view* of the user's [`CommandContext`] with the alias-tail
+//! prepended to the args; `current_word` and `word_index` are deliberately
+//! left untouched because fuzzy ranking, history matching, frecency
+//! keying, and the accept-completion path all key off the literal buffer
+//! the user typed (`gco`), not the expansion (`git checkout`).
+//!
+//! See `docs/plans/ux-3-multiword-aliases/SPEC.md` (D2 / D3 / D5) for the
+//! invariants.
+
+use std::borrow::Cow;
+use std::collections::HashSet;
+
+use gc_buffer::CommandContext;
+
+use crate::alias::AliasStore;
+
+/// Maximum recursive alias-of-alias expansions per lookup. Far above any
+/// realistic depth (zsh users rarely chain more than 2–3 levels deep) and
+/// small enough that the per-keystroke cost stays well under the
+/// suggestion budget. See SPEC D3.
+pub(crate) const MAX_ALIAS_HOPS: usize = 16;
+
+/// Alias-expanded view over a [`CommandContext`] for spec resolution.
+///
+/// Both fields are `Cow` so the no-alias-hit branch costs zero
+/// allocations: `resolved_command` borrows from `ctx.command` and
+/// `effective_args` borrows `ctx.args`. Only when an alias actually fires
+/// do we own the rewritten tokens.
+pub(crate) struct ExpandedCtx<'a> {
+    /// Resolved command name (head of the expansion). Equals the original
+    /// `ctx.command` string when no alias matched.
+    pub resolved_command: Cow<'a, str>,
+    /// `expanded-tail-tokens ++ ctx.args`. Borrowed from `ctx.args` when
+    /// no expansion happened.
+    pub effective_args: Cow<'a, [String]>,
+}
+
+/// Expand `ctx.command` through the alias map.
+///
+/// Returns `None` only when there is no command to expand at all
+/// (`ctx.word_index == 0` — user is still typing the alias name itself —
+/// or `ctx.command.is_none()`). Every other path, including "command is
+/// not an alias", returns `Some(ExpandedCtx)` so callers can uniformly
+/// look up the spec by `resolved_command` and walk by `effective_args`.
+///
+/// Recursion stops on:
+/// * a head token that is not itself an alias,
+/// * a head token already seen in this expansion (cycle guard), or
+/// * after [`MAX_ALIAS_HOPS`] iterations (depth cap; partial expansion
+///   is preserved).
+pub(crate) fn expand_alias_for_spec<'a>(
+    ctx: &'a CommandContext,
+    alias_map: &AliasStore,
+) -> Option<ExpandedCtx<'a>> {
+    if ctx.word_index == 0 {
+        return None;
+    }
+    let command = ctx.command.as_deref()?;
+
+    // Fast path: no alias hit at all -> borrowed view.
+    let Some(initial) = alias_map.get(command) else {
+        return Some(ExpandedCtx {
+            resolved_command: Cow::Borrowed(command),
+            effective_args: Cow::Borrowed(&ctx.args),
+        });
+    };
+
+    // Slow path: head expansion + recursive head-replacement.
+    let mut tokens: Vec<String> = initial;
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(command.to_string());
+
+    for _ in 0..MAX_ALIAS_HOPS {
+        let head = match tokens.first() {
+            Some(h) => h.clone(),
+            None => break,
+        };
+        if visited.contains(&head) {
+            break; // cycle
+        }
+        match alias_map.get(&head) {
+            Some(next) => {
+                visited.insert(head);
+                let tail: Vec<String> = tokens.drain(1..).collect();
+                tokens = next;
+                tokens.extend(tail);
+            }
+            None => break,
+        }
+    }
+
+    if tokens.is_empty() {
+        return None;
+    }
+    let mut iter = tokens.into_iter();
+    // Safe: tokens.is_empty() returned false above.
+    let resolved = iter.next().expect("tokens non-empty");
+    let mut effective: Vec<String> = iter.collect();
+    effective.extend(ctx.args.iter().cloned());
+    Some(ExpandedCtx {
+        resolved_command: Cow::Owned(resolved),
+        effective_args: Cow::Owned(effective),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use gc_buffer::{CommandContext, QuoteState};
+
+    use super::*;
+    use crate::alias::AliasStore;
+
+    fn ctx(command: Option<&str>, args: &[&str], current_word: &str, word_index: usize) -> CommandContext {
+        CommandContext {
+            command: command.map(String::from),
+            args: args.iter().map(|s| (*s).to_string()).collect(),
+            current_word: current_word.to_string(),
+            word_index,
+            is_flag: current_word.starts_with('-'),
+            is_long_flag: current_word.starts_with("--"),
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: QuoteState::None,
+            is_first_segment: true,
+        }
+    }
+
+    fn store(entries: &[(&str, &[&str])]) -> AliasStore {
+        let store = AliasStore::empty();
+        let map: HashMap<String, Vec<String>> = entries
+            .iter()
+            .map(|(name, toks)| {
+                let v: Vec<String> = toks.iter().map(|s| (*s).to_string()).collect();
+                ((*name).to_string(), v)
+            })
+            .collect();
+        store.populate(map);
+        store
+    }
+
+    #[test]
+    fn expand_returns_none_at_word_index_zero() {
+        // The user is still typing the command itself; expansion would
+        // be wrong because `current_word` is the name, not a positional.
+        let aliases = store(&[("gco", &["git", "checkout"])]);
+        let c = ctx(None, &[], "gc", 0);
+        assert!(expand_alias_for_spec(&c, &aliases).is_none());
+    }
+
+    #[test]
+    fn expand_returns_borrowed_when_no_alias() {
+        // No alias hit must borrow from `ctx` rather than allocate — the
+        // hot path runs on every keystroke.
+        let aliases = AliasStore::empty();
+        let c = ctx(Some("git"), &["checkout"], "main", 2);
+        let exp = expand_alias_for_spec(&c, &aliases).unwrap();
+        assert!(matches!(exp.resolved_command, Cow::Borrowed("git")));
+        assert!(matches!(exp.effective_args, Cow::Borrowed(_)));
+        assert_eq!(exp.effective_args.as_ref(), &["checkout".to_string()]);
+    }
+
+    #[test]
+    fn expand_single_word_alias() {
+        // `alias g=git` resolves to head=git with no tail; ctx.args pass
+        // through unchanged.
+        let aliases = store(&[("g", &["git"])]);
+        let c = ctx(Some("g"), &["push"], "", 2);
+        let exp = expand_alias_for_spec(&c, &aliases).unwrap();
+        assert_eq!(exp.resolved_command.as_ref(), "git");
+        assert_eq!(exp.effective_args.as_ref(), &["push".to_string()]);
+    }
+
+    #[test]
+    fn expand_multi_word_alias() {
+        // `alias gco='git checkout'` resolves to head=git with tail=[checkout],
+        // and the user-typed args are appended after.
+        let aliases = store(&[("gco", &["git", "checkout"])]);
+        let c = ctx(Some("gco"), &["main"], "", 2);
+        let exp = expand_alias_for_spec(&c, &aliases).unwrap();
+        assert_eq!(exp.resolved_command.as_ref(), "git");
+        assert_eq!(
+            exp.effective_args.as_ref(),
+            &["checkout".to_string(), "main".to_string()]
+        );
+    }
+
+    #[test]
+    fn expand_chained_aliases() {
+        // gcb -> gco -> git checkout. The tail from each layer accumulates
+        // (`-b` from gcb, `checkout` from gco), and the user-typed args
+        // come last.
+        let aliases = store(&[("gcb", &["gco", "-b"]), ("gco", &["git", "checkout"])]);
+        let c = ctx(Some("gcb"), &["feature"], "", 2);
+        let exp = expand_alias_for_spec(&c, &aliases).unwrap();
+        assert_eq!(exp.resolved_command.as_ref(), "git");
+        assert_eq!(
+            exp.effective_args.as_ref(),
+            &[
+                "checkout".to_string(),
+                "-b".to_string(),
+                "feature".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_cycle_guard() {
+        // a -> b -> a. Expansion must terminate without recursion: after
+        // two hops `a` is already visited, so the loop bails. The
+        // resulting head doesn't have to be "useful"; it just must not
+        // hang or panic.
+        let aliases = store(&[("a", &["b"]), ("b", &["a"])]);
+        let c = ctx(Some("a"), &[], "", 1);
+        let exp = expand_alias_for_spec(&c, &aliases).unwrap();
+        // The point of the test is termination; we don't assert on
+        // `resolved_command` because either head is acceptable (the
+        // SPEC just says "stop expansion").
+        assert!(["a", "b"].contains(&exp.resolved_command.as_ref()));
+    }
+
+    #[test]
+    fn expand_depth_cap_stops_at_max_hops() {
+        // Build a chain longer than MAX_ALIAS_HOPS. Expansion must
+        // terminate (no infinite loop, no panic) and return the partial
+        // result rather than failing.
+        let chain_len = MAX_ALIAS_HOPS + 5;
+        let names: Vec<String> = (0..chain_len).map(|i| format!("a{i}")).collect();
+        let mut entries: Vec<(&str, Vec<String>)> = Vec::new();
+        for i in 0..chain_len - 1 {
+            entries.push((names[i].as_str(), vec![names[i + 1].clone()]));
+        }
+        let store = AliasStore::empty();
+        let map: HashMap<String, Vec<String>> = entries
+            .into_iter()
+            .map(|(n, v)| (n.to_string(), v))
+            .collect();
+        store.populate(map);
+
+        let c = ctx(Some("a0"), &[], "", 1);
+        let exp = expand_alias_for_spec(&c, &store).unwrap();
+        // After 16 hops starting from a0, the head should be a16 (we
+        // expand a0 -> a1 once before entering the loop, then 16 more
+        // head-swaps land on a17). Either way the head is somewhere in
+        // the chain and the loop terminated — the absolute index is an
+        // implementation detail; the SPEC guarantees only "stops at 16".
+        let head = exp.resolved_command.as_ref();
+        assert!(head.starts_with('a'));
+        let idx: usize = head[1..].parse().unwrap();
+        assert!(
+            idx >= MAX_ALIAS_HOPS && idx < chain_len,
+            "expansion must stop at the depth cap, not unwind the whole chain (head={head})"
+        );
+    }
+}

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -7,6 +7,7 @@ use gc_buffer::CommandContext;
 use tokio::sync::Semaphore;
 
 use crate::alias::AliasStore;
+use crate::alias_expand::expand_alias_for_spec;
 use crate::cache::{CacheKey, GeneratorCache};
 use crate::commands::CommandsProvider;
 use crate::env::EnvProvider;
@@ -781,17 +782,18 @@ impl SuggestionEngine {
         let Some(cache) = self.ssh_host_cache.as_ref() else {
             return;
         };
-        let Some(cmd) = ctx.command.as_ref() else {
+        if ctx.command.is_none() {
             return;
+        }
+        // Resolve `alias dev='ssh prod.example.com'` so typing `dev <TAB>`
+        // gates ssh-host injection on the alias's true target. The
+        // expander returns `None` only when `word_index == 0` (typing the
+        // alias name itself) — we already bail on that below — so the
+        // explicit `Some(_)` branch is the alias-or-pass-through path.
+        let resolved_cmd: String = match expand_alias_for_spec(ctx, &self.alias_map) {
+            Some(exp) => exp.resolved_command.into_owned(),
+            None => return,
         };
-        // Task 5 swaps this for `expand_alias_for_spec`; in the meantime,
-        // peel the head token off the resolved Vec so behaviour matches
-        // the pre-Task-2 `Option<String>` shape.
-        let resolved_owned = self
-            .alias_map
-            .get(cmd.as_str())
-            .and_then(|tokens| tokens.into_iter().next());
-        let resolved_cmd = resolved_owned.as_deref().unwrap_or(cmd.as_str());
         if resolved_cmd != "ssh" || ctx.word_index == 0 || ctx.is_flag {
             return;
         }
@@ -817,14 +819,18 @@ impl SuggestionEngine {
             return None;
         }
         let command = ctx.command.as_ref()?;
-        // Task 5 routes this through `expand_alias_for_spec`; for now keep
-        // single-token semantics by peeling the head off the resolved Vec.
-        let resolved_owned = self
-            .alias_map
-            .get(command.as_str())
-            .and_then(|tokens| tokens.into_iter().next());
-        let resolved = resolved_owned.as_deref().unwrap_or(command.as_str());
-        self.spec_store.get(resolved)
+        // Walk the alias map first so multi-word aliases land the right
+        // spec — `gco='git checkout'` should resolve to git's spec, not
+        // attempt a literal `gco` lookup.
+        if let Some(expanded) = expand_alias_for_spec(ctx, &self.alias_map) {
+            if let Some(spec) = self.spec_store.get(expanded.resolved_command.as_ref()) {
+                return Some(spec);
+            }
+        }
+        // Fall through: an alias whose head doesn't have a spec, or
+        // word_index == 0 (typing the alias name itself) — try the
+        // literal command name so `git` itself still resolves.
+        self.spec_store.get(command.as_str())
     }
 
     /// Look up the spec for `ctx.command_name` and append its synchronous
@@ -848,6 +854,34 @@ impl SuggestionEngine {
             return Err(candidates);
         };
 
+        // For multi-word aliases (`alias gco='git checkout'`) we need to
+        // walk the spec tree as if the user had typed the expansion —
+        // otherwise `git checkout`'s args are lost and branch generators
+        // never fire. Build a synthetic ctx with the alias-tail prepended
+        // to args; current_word and the rest of the cursor metadata stay
+        // pinned to the literal buffer so fuzzy ranking, filesystem
+        // injection, and history-keyed scoring keep seeing what the user
+        // actually typed (`gco mybr`, not `git checkout mybr`).
+        //
+        // `resolve_spec` only consumes `args` and `preceding_flag` for
+        // the walk, so the `word_index`/`current_word` mismatch on the
+        // synthetic ctx is intentional and safe.
+        let synthetic_ctx;
+        let resolve_ctx: &CommandContext =
+            match expand_alias_for_spec(ctx, &self.alias_map) {
+                Some(exp) if matches!(exp.effective_args, std::borrow::Cow::Owned(_)) => {
+                    synthetic_ctx = CommandContext {
+                        command: Some(exp.resolved_command.into_owned()),
+                        args: exp.effective_args.into_owned(),
+                        ..ctx.clone()
+                    };
+                    &synthetic_ctx
+                }
+                // No alias hit (or borrowed pass-through) — reuse the
+                // original ctx and skip the per-keystroke clone.
+                _ => ctx,
+            };
+
         let specs::SpecResolution {
             subcommands,
             options,
@@ -858,7 +892,7 @@ impl SuggestionEngine {
             wants_folders_only,
             preceding_flag_has_args,
             past_double_dash,
-        } = specs::resolve_spec(spec, ctx);
+        } = specs::resolve_spec(spec, resolve_ctx);
 
         let git_generators = self.git_generators_from(&native_generators);
 

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -784,7 +784,13 @@ impl SuggestionEngine {
         let Some(cmd) = ctx.command.as_ref() else {
             return;
         };
-        let resolved_owned = self.alias_map.get(cmd.as_str());
+        // Task 5 swaps this for `expand_alias_for_spec`; in the meantime,
+        // peel the head token off the resolved Vec so behaviour matches
+        // the pre-Task-2 `Option<String>` shape.
+        let resolved_owned = self
+            .alias_map
+            .get(cmd.as_str())
+            .and_then(|tokens| tokens.into_iter().next());
         let resolved_cmd = resolved_owned.as_deref().unwrap_or(cmd.as_str());
         if resolved_cmd != "ssh" || ctx.word_index == 0 || ctx.is_flag {
             return;
@@ -811,7 +817,12 @@ impl SuggestionEngine {
             return None;
         }
         let command = ctx.command.as_ref()?;
-        let resolved_owned = self.alias_map.get(command.as_str());
+        // Task 5 routes this through `expand_alias_for_spec`; for now keep
+        // single-token semantics by peeling the head off the resolved Vec.
+        let resolved_owned = self
+            .alias_map
+            .get(command.as_str())
+            .and_then(|tokens| tokens.into_iter().next());
         let resolved = resolved_owned.as_deref().unwrap_or(command.as_str());
         self.spec_store.get(resolved)
     }

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -343,19 +343,14 @@ impl SuggestionEngine {
         }
     }
 
-    /// Builder hook for integration tests / benches: install a fixed
-    /// alias map without going through the background loader. Hidden from
-    /// public docs because production code should always use
-    /// [`Self::with_providers`] which spawns the loader.
+    /// Test/bench builder hook to install a fixed alias map.
     #[doc(hidden)]
     pub fn with_aliases(self, map: std::collections::HashMap<String, Vec<String>>) -> Self {
         self.alias_map.install(map);
         self
     }
 
-    /// Builder hook for integration tests / benches: point the SSH host
-    /// cache at a deterministic config path (fed by the test fixture)
-    /// instead of `~/.ssh/config`.
+    /// Test/bench builder hook to redirect ssh-host lookups at a fixed config file.
     #[doc(hidden)]
     pub fn with_ssh_host_cache_path(mut self, path: std::path::PathBuf) -> Self {
         self.ssh_host_cache = Some(SshHostCache::new(path));
@@ -804,11 +799,7 @@ impl SuggestionEngine {
         if ctx.command.is_none() {
             return;
         }
-        // Resolve `alias dev='ssh prod.example.com'` so typing `dev <TAB>`
-        // gates ssh-host injection on the alias's true target. The
-        // expander returns `None` only when `word_index == 0` (typing the
-        // alias name itself) — we already bail on that below — so the
-        // explicit `Some(_)` branch is the alias-or-pass-through path.
+        // Use the alias's resolved head so `alias dev=ssh` still triggers ssh-host injection.
         let resolved_cmd: String = match expand_alias_for_spec(ctx, &self.alias_map) {
             Some(exp) => exp.resolved_command.into_owned(),
             None => return,
@@ -838,17 +829,13 @@ impl SuggestionEngine {
             return None;
         }
         let command = ctx.command.as_ref()?;
-        // Walk the alias map first so multi-word aliases land the right
-        // spec — `gco='git checkout'` should resolve to git's spec, not
-        // attempt a literal `gco` lookup.
+        // Alias head -> spec, so multi-word aliases land their target's spec subtree.
         if let Some(expanded) = expand_alias_for_spec(ctx, &self.alias_map) {
             if let Some(spec) = self.spec_store.get(expanded.resolved_command.as_ref()) {
                 return Some(spec);
             }
         }
-        // Fall through: an alias whose head doesn't have a spec, or
-        // word_index == 0 (typing the alias name itself) — try the
-        // literal command name so `git` itself still resolves.
+        // Fall through: literal lookup so unaliased commands still resolve.
         self.spec_store.get(command.as_str())
     }
 
@@ -873,21 +860,10 @@ impl SuggestionEngine {
             return Err(candidates);
         };
 
-        // For multi-word aliases (`alias gco='git checkout'`) we need to
-        // walk the spec tree as if the user had typed the expansion —
-        // otherwise `git checkout`'s args are lost and branch generators
-        // never fire. Build a synthetic ctx with the alias-tail prepended
-        // to args; current_word and the rest of the cursor metadata stay
-        // pinned to the literal buffer so fuzzy ranking, filesystem
-        // injection, and history-keyed scoring keep seeing what the user
-        // actually typed (`gco mybr`, not `git checkout mybr`).
-        //
-        // `resolve_spec` only consumes `args` and `preceding_flag` for
-        // the walk, so the `word_index`/`current_word` mismatch on the
-        // synthetic ctx is intentional and safe.
+        // Synthetic ctx: spec walk uses the expansion; ranking/history stay on the literal buffer.
         let synthetic_ctx;
         let resolve_ctx: &CommandContext = match expand_alias_for_spec(ctx, &self.alias_map) {
-            Some(exp) if matches!(exp.effective_args, std::borrow::Cow::Owned(_)) => {
+            Some(exp) if exp.aliased => {
                 synthetic_ctx = CommandContext {
                     command: Some(exp.resolved_command.into_owned()),
                     args: exp.effective_args.into_owned(),
@@ -895,8 +871,6 @@ impl SuggestionEngine {
                 };
                 &synthetic_ctx
             }
-            // No alias hit (or borrowed pass-through) — reuse the
-            // original ctx and skip the per-keystroke clone.
             _ => ctx,
         };
 

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -343,6 +343,25 @@ impl SuggestionEngine {
         }
     }
 
+    /// Builder hook for integration tests / benches: install a fixed
+    /// alias map without going through the background loader. Hidden from
+    /// public docs because production code should always use
+    /// [`Self::with_providers`] which spawns the loader.
+    #[doc(hidden)]
+    pub fn with_aliases(self, map: std::collections::HashMap<String, Vec<String>>) -> Self {
+        self.alias_map.install(map);
+        self
+    }
+
+    /// Builder hook for integration tests / benches: point the SSH host
+    /// cache at a deterministic config path (fed by the test fixture)
+    /// instead of `~/.ssh/config`.
+    #[doc(hidden)]
+    pub fn with_ssh_host_cache_path(mut self, path: std::path::PathBuf) -> Self {
+        self.ssh_host_cache = Some(SshHostCache::new(path));
+        self
+    }
+
     /// Record an accepted completion for frecency scoring.
     /// `command` scopes the key so `--help` under `git` doesn't boost `docker`.
     /// `kind` scopes it further so a branch `main` doesn't boost a file `main`.

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -886,20 +886,19 @@ impl SuggestionEngine {
         // the walk, so the `word_index`/`current_word` mismatch on the
         // synthetic ctx is intentional and safe.
         let synthetic_ctx;
-        let resolve_ctx: &CommandContext =
-            match expand_alias_for_spec(ctx, &self.alias_map) {
-                Some(exp) if matches!(exp.effective_args, std::borrow::Cow::Owned(_)) => {
-                    synthetic_ctx = CommandContext {
-                        command: Some(exp.resolved_command.into_owned()),
-                        args: exp.effective_args.into_owned(),
-                        ..ctx.clone()
-                    };
-                    &synthetic_ctx
-                }
-                // No alias hit (or borrowed pass-through) — reuse the
-                // original ctx and skip the per-keystroke clone.
-                _ => ctx,
-            };
+        let resolve_ctx: &CommandContext = match expand_alias_for_spec(ctx, &self.alias_map) {
+            Some(exp) if matches!(exp.effective_args, std::borrow::Cow::Owned(_)) => {
+                synthetic_ctx = CommandContext {
+                    command: Some(exp.resolved_command.into_owned()),
+                    args: exp.effective_args.into_owned(),
+                    ..ctx.clone()
+                };
+                &synthetic_ctx
+            }
+            // No alias hit (or borrowed pass-through) — reuse the
+            // original ctx and skip the per-keystroke clone.
+            _ => ctx,
+        };
 
         let specs::SpecResolution {
             subcommands,

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -343,14 +343,12 @@ impl SuggestionEngine {
         }
     }
 
-    /// Test/bench builder hook to install a fixed alias map.
     #[doc(hidden)]
     pub fn with_aliases(self, map: std::collections::HashMap<String, Vec<String>>) -> Self {
         self.alias_map.install(map);
         self
     }
 
-    /// Test/bench builder hook to redirect ssh-host lookups at a fixed config file.
     #[doc(hidden)]
     pub fn with_ssh_host_cache_path(mut self, path: std::path::PathBuf) -> Self {
         self.ssh_host_cache = Some(SshHostCache::new(path));
@@ -740,7 +738,11 @@ impl SuggestionEngine {
     fn suggest_flag_prefix(&self, ctx: &CommandContext, cwd: &Path, buffer: &str) -> SyncResult {
         let mut candidates = Vec::new();
         if let Some(spec) = self.spec_for_ctx(ctx) {
-            let resolution = specs::resolve_spec(spec, ctx);
+            // Pivot to the alias target's frame so a multi-word alias like
+            // `gco='git checkout'` walks into `git checkout`'s option set,
+            // not `git`'s top-level flags.
+            let resolve_ctx = self.resolve_ctx_for_spec_walk(ctx);
+            let resolution = specs::resolve_spec(spec, resolve_ctx.as_ref());
             candidates.extend(resolution.subcommands);
             candidates.extend(resolution.options);
         }
@@ -821,6 +823,29 @@ impl SuggestionEngine {
         );
     }
 
+    /// Pivot a `CommandContext` into the alias target's frame for spec walks.
+    /// When the alias actually expanded, return an owned synthetic ctx with
+    /// `command` and `args` rewritten to the resolved head + effective args
+    /// so `resolve_spec` walks into the correct subcommand subtree (e.g.
+    /// `gco -<TAB>` lands inside `git checkout`, not `git`'s top-level
+    /// options). Otherwise return the original ctx borrow.
+    fn resolve_ctx_for_spec_walk<'a>(
+        &self,
+        ctx: &'a CommandContext,
+    ) -> std::borrow::Cow<'a, CommandContext> {
+        match expand_alias_for_spec(ctx, &self.alias_map) {
+            Some(exp) if exp.aliased => {
+                let synthetic = CommandContext {
+                    command: Some(exp.resolved_command.into_owned()),
+                    args: exp.effective_args.into_owned(),
+                    ..ctx.clone()
+                };
+                std::borrow::Cow::Owned(synthetic)
+            }
+            _ => std::borrow::Cow::Borrowed(ctx),
+        }
+    }
+
     /// Resolve the alias-aware spec for this command context, if any.
     /// Centralizes the alias lookup + spec_store probe so callers don't
     /// repeat it.
@@ -828,15 +853,12 @@ impl SuggestionEngine {
         if !self.providers_specs {
             return None;
         }
-        let command = ctx.command.as_ref()?;
-        // Alias head -> spec, so multi-word aliases land their target's spec subtree.
-        if let Some(expanded) = expand_alias_for_spec(ctx, &self.alias_map) {
-            if let Some(spec) = self.spec_store.get(expanded.resolved_command.as_ref()) {
-                return Some(spec);
-            }
-        }
-        // Fall through: literal lookup so unaliased commands still resolve.
-        self.spec_store.get(command.as_str())
+        // `expand_alias_for_spec` returns `Cow::Borrowed(ctx.command)` when no
+        // alias fires, so a single lookup covers both the aliased and
+        // unaliased paths and avoids leaking the literal alias-name spec when
+        // the alias target has no spec of its own.
+        let expanded = expand_alias_for_spec(ctx, &self.alias_map)?;
+        self.spec_store.get(expanded.resolved_command.as_ref())
     }
 
     /// Look up the spec for `ctx.command_name` and append its synchronous
@@ -861,18 +883,7 @@ impl SuggestionEngine {
         };
 
         // Synthetic ctx: spec walk uses the expansion; ranking/history stay on the literal buffer.
-        let synthetic_ctx;
-        let resolve_ctx: &CommandContext = match expand_alias_for_spec(ctx, &self.alias_map) {
-            Some(exp) if exp.aliased => {
-                synthetic_ctx = CommandContext {
-                    command: Some(exp.resolved_command.into_owned()),
-                    args: exp.effective_args.into_owned(),
-                    ..ctx.clone()
-                };
-                &synthetic_ctx
-            }
-            _ => ctx,
-        };
+        let resolve_ctx = self.resolve_ctx_for_spec_walk(ctx);
 
         let specs::SpecResolution {
             subcommands,
@@ -884,7 +895,7 @@ impl SuggestionEngine {
             wants_folders_only,
             preceding_flag_has_args,
             past_double_dash,
-        } = specs::resolve_spec(spec, resolve_ctx);
+        } = specs::resolve_spec(spec, resolve_ctx.as_ref());
 
         let git_generators = self.git_generators_from(&native_generators);
 

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -630,18 +630,14 @@ impl SuggestionEngine {
         if !self.providers_specs || ctx.word_index == 0 || ctx.in_redirect {
             return Ok(Vec::new());
         }
-
-        let command = match &ctx.command {
-            Some(c) => c,
-            None => return Ok(Vec::new()),
+        if ctx.command.is_none() {
+            return Ok(Vec::new());
+        }
+        let Some(spec) = self.spec_for_ctx(ctx) else {
+            return Ok(Vec::new());
         };
-
-        let spec = match self.spec_store.get(command) {
-            Some(s) => s,
-            None => return Ok(Vec::new()),
-        };
-
-        let resolution = specs::resolve_spec(spec, ctx);
+        let resolve_ctx = self.resolve_ctx_for_spec_walk(ctx);
+        let resolution = specs::resolve_spec(spec, resolve_ctx.as_ref());
         let generators: Vec<_> = resolution
             .script_generators
             .into_iter()
@@ -738,9 +734,7 @@ impl SuggestionEngine {
     fn suggest_flag_prefix(&self, ctx: &CommandContext, cwd: &Path, buffer: &str) -> SyncResult {
         let mut candidates = Vec::new();
         if let Some(spec) = self.spec_for_ctx(ctx) {
-            // Pivot to the alias target's frame so a multi-word alias like
-            // `gco='git checkout'` walks into `git checkout`'s option set,
-            // not `git`'s top-level flags.
+            // Walk the alias target's spec subtree, not the literal alias name's.
             let resolve_ctx = self.resolve_ctx_for_spec_walk(ctx);
             let resolution = specs::resolve_spec(spec, resolve_ctx.as_ref());
             candidates.extend(resolution.subcommands);
@@ -823,12 +817,7 @@ impl SuggestionEngine {
         );
     }
 
-    /// Pivot a `CommandContext` into the alias target's frame for spec walks.
-    /// When the alias actually expanded, return an owned synthetic ctx with
-    /// `command` and `args` rewritten to the resolved head + effective args
-    /// so `resolve_spec` walks into the correct subcommand subtree (e.g.
-    /// `gco -<TAB>` lands inside `git checkout`, not `git`'s top-level
-    /// options). Otherwise return the original ctx borrow.
+    /// Pivot ctx onto the alias target so spec walks land in the right subcommand.
     fn resolve_ctx_for_spec_walk<'a>(
         &self,
         ctx: &'a CommandContext,
@@ -853,10 +842,7 @@ impl SuggestionEngine {
         if !self.providers_specs {
             return None;
         }
-        // `expand_alias_for_spec` returns `Cow::Borrowed(ctx.command)` when no
-        // alias fires, so a single lookup covers both the aliased and
-        // unaliased paths and avoids leaking the literal alias-name spec when
-        // the alias target has no spec of its own.
+        // expand_alias_for_spec covers both aliased and unaliased paths in one lookup.
         let expanded = expand_alias_for_spec(ctx, &self.alias_map)?;
         self.spec_store.get(expanded.resolved_command.as_ref())
     }

--- a/crates/gc-suggest/src/lib.rs
+++ b/crates/gc-suggest/src/lib.rs
@@ -4,6 +4,7 @@
 //! Fig-compatible JSON specs) and fuzzy-ranks results with `nucleo`.
 
 pub mod alias;
+pub(crate) mod alias_expand;
 pub mod cache;
 pub mod commands;
 pub mod context;

--- a/crates/gc-suggest/tests/aliases.rs
+++ b/crates/gc-suggest/tests/aliases.rs
@@ -1,0 +1,192 @@
+//! Integration tests for multi-word alias expansion in spec resolution.
+//!
+//! These tests load the real workspace `specs/` directory so the wiring
+//! between `parse_aliases` -> `AliasStore` -> `expand_alias_for_spec` ->
+//! `spec_for_ctx` -> `resolve_spec` is exercised end-to-end. A pure unit
+//! test in `alias_expand.rs` proves the helper's contract; this file
+//! proves the engine actually picks up the alias-expanded spec subtree.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use gc_buffer::{CommandContext, QuoteState};
+use gc_suggest::commands::CommandsProvider;
+use gc_suggest::git::GitQueryKind;
+use gc_suggest::history::HistoryProvider;
+use gc_suggest::types::SuggestionSource;
+use gc_suggest::{SpecStore, SuggestionEngine};
+
+/// Path to the workspace's `specs/` directory. Cargo runs integration
+/// tests with `CARGO_MANIFEST_DIR` set to the crate root, so we walk up
+/// two levels to reach the workspace root.
+fn workspace_specs_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs")
+}
+
+fn ctx_with(command: &str, args: Vec<&str>, current: &str, word_index: usize) -> CommandContext {
+    CommandContext {
+        command: Some(command.to_string()),
+        args: args.into_iter().map(String::from).collect(),
+        current_word: current.to_string(),
+        word_index,
+        is_flag: current.starts_with('-'),
+        is_long_flag: current.starts_with("--"),
+        preceding_flag: None,
+        in_pipe: false,
+        in_redirect: false,
+        quote_state: QuoteState::None,
+        is_first_segment: true,
+    }
+}
+
+fn make_engine(aliases: HashMap<String, Vec<String>>) -> SuggestionEngine {
+    let store = SpecStore::load_from_dir(&workspace_specs_dir())
+        .expect("workspace specs/ must load")
+        .store;
+    SuggestionEngine::with_providers(
+        store,
+        HistoryProvider::from_entries(vec![]),
+        CommandsProvider::from_list(vec![]),
+    )
+    .with_aliases(aliases)
+}
+
+#[test]
+fn alias_gco_resolves_to_git_checkout_branches() {
+    // `alias gco='git checkout'` is the canonical failure case. Without
+    // expansion, `gco main` lands on git's top-level subcommand list and
+    // never reaches the checkout subtree's git_branches generator.
+    let aliases = HashMap::from([(
+        "gco".to_string(),
+        vec!["git".to_string(), "checkout".to_string()],
+    )]);
+    let engine = make_engine(aliases);
+
+    // Cursor sits on `main` after `gco `: command="gco", args=[],
+    // current_word="main", word_index=1.
+    let ctx = ctx_with("gco", vec![], "main", 1);
+    let result = engine
+        .suggest_sync(&ctx, Path::new("/tmp"), "gco main")
+        .expect("suggest_sync must not error on a valid alias");
+
+    assert!(
+        result.git_generators.contains(&GitQueryKind::Branches),
+        "alias gco='git checkout' must dispatch git_branches; got {:?}",
+        result.git_generators,
+    );
+}
+
+#[test]
+fn alias_chained_gcb_resolves_to_git_checkout_b() {
+    // `alias gcb='gco -b'` then `alias gco='git checkout'`. Typing
+    // `gcb feat` should resolve to `git checkout -b feat`. The `-b`
+    // option's arg slot accepts a string positional, so this exercises
+    // that the alias-tail reaches the resolved spec subtree (the engine
+    // does not synthesise -b's argument generator from thin air —
+    // `git checkout -b` does not have a generator either, but the spec
+    // walk must still pick the correct subtree without crashing or
+    // attempting to look up `gcb` directly).
+    let aliases = HashMap::from([
+        (
+            "gcb".to_string(),
+            vec!["gco".to_string(), "-b".to_string()],
+        ),
+        (
+            "gco".to_string(),
+            vec!["git".to_string(), "checkout".to_string()],
+        ),
+    ]);
+    let engine = make_engine(aliases);
+
+    let ctx = ctx_with("gcb", vec![], "feat", 1);
+    let result = engine
+        .suggest_sync(&ctx, Path::new("/tmp"), "gcb feat")
+        .expect("suggest_sync must succeed for a chained alias");
+
+    // Chained alias resolution alone is the contract under test; the
+    // engine must not error and must walk the chain to git's subtree.
+    // We assert the negative: the engine did NOT attempt a literal
+    // `gcb` spec lookup (which would yield zero suggestions and zero
+    // generators because no `gcb.json` ships in specs/).
+    let has_any_signal = !result.suggestions.is_empty()
+        || !result.git_generators.is_empty()
+        || !result.script_generators.is_empty()
+        || !result.provider_generators.is_empty();
+    assert!(
+        has_any_signal,
+        "chained alias resolution must produce at least one signal \
+         (suggestions or pending generators); got empty SyncResult — \
+         alias chain probably wasn't expanded",
+    );
+}
+
+#[test]
+fn alias_dev_resolves_to_ssh_for_host_injection() {
+    // `alias dev=ssh` must still trigger ssh-host injection when the
+    // user types `dev pro<TAB>` — the resolved head is `ssh`, so the
+    // engine pulls hosts whose names start with `pro` from the cache.
+    // Multi-word `alias dev='ssh prod.example.com'` would *suppress*
+    // injection per SPEC D6, but a single-word alias is a pure rename
+    // and matches the old behaviour.
+    let ssh_dir = tempfile::tempdir().expect("tempdir for ssh fixture");
+    let ssh_config = ssh_dir.path().join("config");
+    std::fs::write(
+        &ssh_config,
+        "Host prod-east\n    HostName 1.2.3.4\n\nHost prod-west\n\nHost staging\n",
+    )
+    .expect("write ssh fixture");
+
+    let aliases = HashMap::from([("dev".to_string(), vec!["ssh".to_string()])]);
+    let engine = make_engine(aliases).with_ssh_host_cache_path(ssh_config);
+
+    let ctx = ctx_with("dev", vec![], "pro", 1);
+    let result = engine
+        .suggest_sync(&ctx, Path::new("/tmp"), "dev pro")
+        .expect("suggest_sync must succeed");
+
+    let ssh_hits: Vec<_> = result
+        .suggestions
+        .iter()
+        .filter(|s| s.source == SuggestionSource::SshConfig)
+        .map(|s| s.text.clone())
+        .collect();
+    assert!(
+        !ssh_hits.is_empty(),
+        "alias dev=ssh must surface SshConfig hosts matching `pro`; \
+         got suggestions {:?}",
+        result.suggestions,
+    );
+    assert!(
+        ssh_hits.iter().any(|h| h.starts_with("pro")),
+        "every host returned must match the prefix `pro`; got {ssh_hits:?}",
+    );
+}
+
+#[test]
+fn single_word_alias_still_works() {
+    // Backward-compat invariant from SPEC: `alias g=git` continues to
+    // resolve `g push` to git's `push` subcommand subtree.
+    let aliases = HashMap::from([("g".to_string(), vec!["git".to_string()])]);
+    let engine = make_engine(aliases);
+
+    // Cursor at the start of arg-1 with no current_word — engine should
+    // emit git's top-level subcommands (push, pull, checkout, ...).
+    let ctx = ctx_with("g", vec![], "", 1);
+    let result = engine
+        .suggest_sync(&ctx, Path::new("/tmp"), "g ")
+        .expect("suggest_sync must succeed");
+
+    let has_subcommand = result
+        .suggestions
+        .iter()
+        .any(|s| s.text == "push" || s.text == "pull" || s.text == "checkout");
+    assert!(
+        has_subcommand,
+        "alias g=git must surface git's top-level subcommands; got {:?}",
+        result
+            .suggestions
+            .iter()
+            .map(|s| &s.text)
+            .collect::<Vec<_>>(),
+    );
+}

--- a/crates/gc-suggest/tests/aliases.rs
+++ b/crates/gc-suggest/tests/aliases.rs
@@ -10,9 +10,7 @@ use gc_suggest::history::HistoryProvider;
 use gc_suggest::types::SuggestionSource;
 use gc_suggest::{SpecStore, SuggestionEngine};
 
-/// Path to the workspace's `specs/` directory. Cargo runs integration
-/// tests with `CARGO_MANIFEST_DIR` set to the crate root, so we walk up
-/// two levels to reach the workspace root.
+/// CARGO_MANIFEST_DIR is the crate root, so walk up two levels to the workspace specs/.
 fn workspace_specs_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs")
 }
@@ -47,17 +45,12 @@ fn make_engine(aliases: HashMap<String, Vec<String>>) -> SuggestionEngine {
 
 #[test]
 fn alias_gco_resolves_to_git_checkout_branches() {
-    // `alias gco='git checkout'` is the canonical failure case. Without
-    // expansion, `gco main` lands on git's top-level subcommand list and
-    // never reaches the checkout subtree's git_branches generator.
     let aliases = HashMap::from([(
         "gco".to_string(),
         vec!["git".to_string(), "checkout".to_string()],
     )]);
     let engine = make_engine(aliases);
 
-    // Cursor sits on `main` after `gco `: command="gco", args=[],
-    // current_word="main", word_index=1.
     let ctx = ctx_with("gco", vec![], "main", 1);
     let result = engine
         .suggest_sync(&ctx, Path::new("/tmp"), "gco main")
@@ -192,5 +185,59 @@ fn alias_dev_to_ssh_walks_ssh_spec_subtree() {
     assert!(
         texts.iter().any(|t| *t == "-p" || *t == "-l"),
         "alias dev=ssh must surface ssh option flags like -p/-l; got {texts:?}",
+    );
+}
+
+#[test]
+fn alias_gco_flag_prefix_walks_git_checkout_options() {
+    // alias gco='git checkout': typing `gco -<TAB>` must surface git checkout's
+    // flag set (e.g. -b, -B, -t, --track), not git's top-level flags
+    // (--git-dir, --exec-path, --no-pager).
+    let aliases = HashMap::from([(
+        "gco".to_string(),
+        vec!["git".to_string(), "checkout".to_string()],
+    )]);
+    let engine = make_engine(aliases);
+
+    let ctx = ctx_with("gco", vec![], "-", 1);
+    let result = engine
+        .suggest_sync(&ctx, Path::new("/tmp"), "gco -")
+        .expect("suggest_sync must succeed");
+
+    let texts: Vec<&str> = result.suggestions.iter().map(|s| s.text.as_str()).collect();
+    let has_checkout_flag = texts
+        .iter()
+        .any(|t| matches!(*t, "-b" | "-B" | "-t" | "--track"));
+    assert!(
+        has_checkout_flag,
+        "alias gco='git checkout' must surface git checkout flags (-b/-B/-t/--track); got {texts:?}",
+    );
+    let has_top_level_only = texts
+        .iter()
+        .any(|t| matches!(*t, "--git-dir" | "--exec-path" | "--no-pager"));
+    assert!(
+        !has_top_level_only,
+        "alias gco='git checkout' must not leak git's top-level flags; got {texts:?}",
+    );
+}
+
+#[test]
+fn alias_to_unknown_command_does_not_leak_alias_name_spec() {
+    // alias git=somecmd-with-no-spec must NOT resolve to git's spec.
+    let aliases = HashMap::from([("git".to_string(), vec!["somecmd-with-no-spec".to_string()])]);
+    let engine = make_engine(aliases);
+
+    let ctx = ctx_with("git", vec![], "foo", 1);
+    let result = engine
+        .suggest_sync(&ctx, Path::new("/tmp"), "git foo")
+        .expect("suggest_sync must succeed");
+
+    let texts: Vec<&str> = result.suggestions.iter().map(|s| s.text.as_str()).collect();
+    let has_git_subcommand = texts
+        .iter()
+        .any(|t| matches!(*t, "checkout" | "rebase" | "branch" | "commit"));
+    assert!(
+        !has_git_subcommand,
+        "alias to an unknown spec must not leak git's subcommands; got {texts:?}",
     );
 }

--- a/crates/gc-suggest/tests/aliases.rs
+++ b/crates/gc-suggest/tests/aliases.rs
@@ -87,10 +87,7 @@ fn alias_chained_gcb_resolves_to_git_checkout_b() {
     // walk must still pick the correct subtree without crashing or
     // attempting to look up `gcb` directly).
     let aliases = HashMap::from([
-        (
-            "gcb".to_string(),
-            vec!["gco".to_string(), "-b".to_string()],
-        ),
+        ("gcb".to_string(), vec!["gco".to_string(), "-b".to_string()]),
         (
             "gco".to_string(),
             vec!["git".to_string(), "checkout".to_string()],

--- a/crates/gc-suggest/tests/aliases.rs
+++ b/crates/gc-suggest/tests/aliases.rs
@@ -1,10 +1,4 @@
-//! Integration tests for multi-word alias expansion in spec resolution.
-//!
-//! These tests load the real workspace `specs/` directory so the wiring
-//! between `parse_aliases` -> `AliasStore` -> `expand_alias_for_spec` ->
-//! `spec_for_ctx` -> `resolve_spec` is exercised end-to-end. A pure unit
-//! test in `alias_expand.rs` proves the helper's contract; this file
-//! proves the engine actually picks up the alias-expanded spec subtree.
+//! Integration tests: alias map -> spec resolution wiring against real specs/.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -78,14 +72,7 @@ fn alias_gco_resolves_to_git_checkout_branches() {
 
 #[test]
 fn alias_chained_gcb_resolves_to_git_checkout_b() {
-    // `alias gcb='gco -b'` then `alias gco='git checkout'`. Typing
-    // `gcb feat` should resolve to `git checkout -b feat`. The `-b`
-    // option's arg slot accepts a string positional, so this exercises
-    // that the alias-tail reaches the resolved spec subtree (the engine
-    // does not synthesise -b's argument generator from thin air —
-    // `git checkout -b` does not have a generator either, but the spec
-    // walk must still pick the correct subtree without crashing or
-    // attempting to look up `gcb` directly).
+    // gcb -> gco -> git checkout: chained expansion must reach git's spec subtree.
     let aliases = HashMap::from([
         ("gcb".to_string(), vec!["gco".to_string(), "-b".to_string()]),
         (
@@ -95,36 +82,21 @@ fn alias_chained_gcb_resolves_to_git_checkout_b() {
     ]);
     let engine = make_engine(aliases);
 
-    let ctx = ctx_with("gcb", vec![], "feat", 1);
+    let ctx = ctx_with("gcb", vec![], "main", 1);
     let result = engine
-        .suggest_sync(&ctx, Path::new("/tmp"), "gcb feat")
+        .suggest_sync(&ctx, Path::new("/tmp"), "gcb main")
         .expect("suggest_sync must succeed for a chained alias");
 
-    // Chained alias resolution alone is the contract under test; the
-    // engine must not error and must walk the chain to git's subtree.
-    // We assert the negative: the engine did NOT attempt a literal
-    // `gcb` spec lookup (which would yield zero suggestions and zero
-    // generators because no `gcb.json` ships in specs/).
-    let has_any_signal = !result.suggestions.is_empty()
-        || !result.git_generators.is_empty()
-        || !result.script_generators.is_empty()
-        || !result.provider_generators.is_empty();
     assert!(
-        has_any_signal,
-        "chained alias resolution must produce at least one signal \
-         (suggestions or pending generators); got empty SyncResult — \
-         alias chain probably wasn't expanded",
+        result.git_generators.contains(&GitQueryKind::Branches),
+        "chained alias gcb -> gco -> git checkout must dispatch git_branches; got {:?}",
+        result.git_generators,
     );
 }
 
 #[test]
 fn alias_dev_resolves_to_ssh_for_host_injection() {
-    // `alias dev=ssh` must still trigger ssh-host injection when the
-    // user types `dev pro<TAB>` — the resolved head is `ssh`, so the
-    // engine pulls hosts whose names start with `pro` from the cache.
-    // Multi-word `alias dev='ssh prod.example.com'` would *suppress*
-    // injection per SPEC D6, but a single-word alias is a pure rename
-    // and matches the old behaviour.
+    // alias dev=ssh: resolved head is `ssh`, so ssh-host injection still fires.
     let ssh_dir = tempfile::tempdir().expect("tempdir for ssh fixture");
     let ssh_config = ssh_dir.path().join("config");
     std::fs::write(
@@ -161,13 +133,9 @@ fn alias_dev_resolves_to_ssh_for_host_injection() {
 
 #[test]
 fn single_word_alias_still_works() {
-    // Backward-compat invariant from SPEC: `alias g=git` continues to
-    // resolve `g push` to git's `push` subcommand subtree.
     let aliases = HashMap::from([("g".to_string(), vec!["git".to_string()])]);
     let engine = make_engine(aliases);
 
-    // Cursor at the start of arg-1 with no current_word — engine should
-    // emit git's top-level subcommands (push, pull, checkout, ...).
     let ctx = ctx_with("g", vec![], "", 1);
     let result = engine
         .suggest_sync(&ctx, Path::new("/tmp"), "g ")
@@ -185,5 +153,44 @@ fn single_word_alias_still_works() {
             .iter()
             .map(|s| &s.text)
             .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn alias_shadows_spec_with_same_name() {
+    // alias git=ls must redirect resolution to ls's spec, not git's subcommands.
+    let aliases = HashMap::from([("git".to_string(), vec!["ls".to_string()])]);
+    let engine = make_engine(aliases);
+
+    let ctx = ctx_with("git", vec![], "-", 1);
+    let result = engine
+        .suggest_sync(&ctx, Path::new("/tmp"), "git -")
+        .expect("suggest_sync must succeed");
+
+    let texts: Vec<&str> = result.suggestions.iter().map(|s| s.text.as_str()).collect();
+    assert!(
+        texts.iter().any(|t| *t == "-a" || *t == "-l"),
+        "alias git=ls must surface ls flags like -a/-l; got {texts:?}",
+    );
+    assert!(
+        !texts.iter().any(|t| *t == "checkout" || *t == "rebase"),
+        "alias git=ls must not leak git subcommands; got {texts:?}",
+    );
+}
+
+#[test]
+fn alias_dev_to_ssh_walks_ssh_spec_subtree() {
+    let aliases = HashMap::from([("dev".to_string(), vec!["ssh".to_string()])]);
+    let engine = make_engine(aliases);
+
+    let ctx = ctx_with("dev", vec![], "-", 1);
+    let result = engine
+        .suggest_sync(&ctx, Path::new("/tmp"), "dev -")
+        .expect("suggest_sync must succeed");
+
+    let texts: Vec<&str> = result.suggestions.iter().map(|s| s.text.as_str()).collect();
+    assert!(
+        texts.iter().any(|t| *t == "-p" || *t == "-l"),
+        "alias dev=ssh must surface ssh option flags like -p/-l; got {texts:?}",
     );
 }

--- a/crates/gc-suggest/tests/aliases.rs
+++ b/crates/gc-suggest/tests/aliases.rs
@@ -190,9 +190,7 @@ fn alias_dev_to_ssh_walks_ssh_spec_subtree() {
 
 #[test]
 fn alias_gco_flag_prefix_walks_git_checkout_options() {
-    // alias gco='git checkout': typing `gco -<TAB>` must surface git checkout's
-    // flag set (e.g. -b, -B, -t, --track), not git's top-level flags
-    // (--git-dir, --exec-path, --no-pager).
+    // gco -<TAB> must surface git checkout's flags, not git's top-level flags.
     let aliases = HashMap::from([(
         "gco".to_string(),
         vec!["git".to_string(), "checkout".to_string()],


### PR DESCRIPTION
## Summary

`alias gco='git checkout'` was previously collapsed to `gco -> git`, so typing `gco mybranch` landed on `git`'s top-level subcommand list instead of the `checkout` subtree, and branch/tag generators never fired. This PR fixes that by storing the full token vector per alias and walking it at spec-resolution time, without rewriting the user-visible buffer.

* `AliasStore` now holds `HashMap<String, Vec<String>>`; on-disk cache schema gains `format_version: 2` so old caches are rejected on load.
* `parse_aliases` uses `shlex::split` to honour quoted/escaped values; falls back to `split_whitespace` (keeping every token) when the value is malformed.
* New crate-private `alias_expand::expand_alias_for_spec` returns a `Cow`-based `ExpandedCtx` view: `current_word`/`word_index` keep pointing at the literal buffer (so fuzzy ranking, history, frecency, and accept-completion paths all keep seeing `gco`), while `effective_args` carry the alias-tail prepended to the user's args. Recursion is bounded (`MAX_ALIAS_HOPS = 16`) with a `HashSet` cycle guard for chained aliases-of-aliases.
* `spec_for_ctx`, `try_suggest_from_spec`, and `extend_with_ssh_hosts` route their alias lookups through the expander. The synthetic `CommandContext` clone in `try_suggest_from_spec` only fires when an alias actually rewrote the args (`Cow::Owned`); the no-alias-hit branch reuses `ctx` verbatim — zero per-keystroke clones.

## Bench results (engine_suggest_sync, 100-alias map)

| Bench | Time |
|-------|------|
| `subcommand_with_spec` (no alias) | 17.28 µs |
| `alias_hit_single` (`alias g=git`) | 16.31 µs |
| `alias_hit_multi` (`alias gco='git checkout'`) | 1.24 ms |

Single-word alias overhead is within bench noise of the no-alias reference; the multi-word case time is dominated by the bench fixture's 2k-file tmp dir (`git checkout` walks filepaths), not the alias machinery. Well under the SPEC's <50 µs added-latency target.

## Test Plan

- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test` — full workspace passes (470 lib + 4 new integration tests + the 7 new alias_expand unit tests).
- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` (shlex 1.3.0 is MIT/Apache-2.0).
- [x] `cargo bench -p gc-suggest -- engine_suggest_sync` — alias-hit cases reported above.
- [ ] Manual smoke test in zsh: `alias gco='git checkout'`, type `gco m<TAB>` inside a real git repo and confirm branch list filtered by `m` appears (cannot run in CI).

## Notes on design choices

* Storage shape (`Vec<String>` per alias): SPEC D1 — re-tokenising on every keystroke would force every caller to re-implement quote handling and burns the parse-once-at-load advantage.
* Splice point (spec-resolution time, not buffer rewriting): SPEC D2 — keeps frecency/history/accept paths keyed off the literal alias name the user typed.
* Bounded recursion (16) with cycle guard: SPEC D3 — matches zsh's recursive-expansion behaviour for chained aliases without risking pathological loops.
* `shlex` dependency (one new crate): SPEC D4 — small, MIT/Apache-2.0, no native deps; replaces ~10 lines of bespoke quote handling with a correct tokeniser.
* `ctx.word_index >= 1` gate: SPEC D5 — at `word_index == 0` the user is still typing the alias name itself, expansion would be premature.