### PR TITLE
feat(suggest): runtime support for args.suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Surface static `args.suggestions` from completion specs as runtime
+  candidates. New `SuggestionKind::EnumValue` (base priority 65) ranks them
+  between subcommands (70) and environment variables (50). Affects ~54%
+  of bundled specs; e.g. `git archive --format=` now suggests `tar`/`zip`,
+  `tar --atime-preserve` suggests `replace`/`system`. See
+  [ADR 0004](docs/adr/0004-static-arg-suggestions.md).
+
 ## [0.10.0] - 2026-04-26
 
 ### Corrected

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
  "gc-config",
  "libc",
  "nucleo",
+ "proptest",
  "regex",
  "serde",
  "serde_json",

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -2335,4 +2335,9 @@ mod tests {
         assert_eq!(layout.width, 0);
         assert_eq!(layout.height, 0);
     }
+
+    #[test]
+    fn kind_icon_returns_documented_glyph_for_enum_value() {
+        assert_eq!(kind_icon(SuggestionKind::EnumValue), '\u{F0CB}');
+    }
 }

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -482,6 +482,7 @@ pub(crate) fn kind_icon(kind: SuggestionKind) -> char {
         SuggestionKind::History => '\u{F1DA}',    // nf-fa-history
         SuggestionKind::EnvVar => '$',
         SuggestionKind::ProviderValue => '\u{F0AD}', // nf-fa-wrench — dynamic arg value from a native provider
+        SuggestionKind::EnumValue => '\u{F0CB}',     // nf-fa-list_ol — enumerated arg value
     }
 }
 

--- a/crates/gc-suggest/Cargo.toml
+++ b/crates/gc-suggest/Cargo.toml
@@ -28,6 +28,7 @@ libc = "0.2"
 tempfile = "3"
 filetime = "0.2"
 criterion = { version = "0.8", features = ["html_reports"] }
+proptest = "1"
 
 [build-dependencies]
 serde_json = "1"

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -289,11 +289,40 @@ fn memory_benchmarks(c: &mut Criterion) {
     group.finish();
 }
 
+fn static_suggestion_resolution_benchmarks(c: &mut Criterion) {
+    let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
+    let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;
+    let tar_spec = store.get("tar").expect("tar spec must exist");
+
+    // tar c --atime-preserve <TAB> — exercises preceding_flag path with
+    // static suggestions populated.
+    let ctx = CommandContext {
+        command: Some("tar".into()),
+        args: vec!["c".into(), "--atime-preserve".into()],
+        current_word: String::new(),
+        word_index: 3,
+        is_flag: false,
+        is_long_flag: false,
+        preceding_flag: Some("--atime-preserve".into()),
+        in_pipe: false,
+        in_redirect: false,
+        quote_state: QuoteState::None,
+        is_first_segment: true,
+    };
+
+    let mut group = c.benchmark_group("spec_resolution");
+    group.bench_function("with_static_suggestions_tar", |b| {
+        b.iter(|| specs::resolve_spec(tar_spec, &ctx));
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     fuzzy_benchmarks,
     spec_benchmarks,
     resolution_benchmarks,
+    static_suggestion_resolution_benchmarks,
     transform_benchmarks,
     engine_benchmarks,
     priority_sort_benchmarks,

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -98,6 +98,26 @@ fn resolution_benchmarks(c: &mut Criterion) {
         b.iter(|| specs::resolve_spec(docker_spec, &deep_ctx));
     });
 
+    // tar c --atime-preserve <TAB> — exercises the preceding_flag path with
+    // static suggestions populated.
+    let tar_spec = store.get("tar").expect("tar spec must exist");
+    let static_ctx = CommandContext {
+        command: Some("tar".into()),
+        args: vec!["c".into(), "--atime-preserve".into()],
+        current_word: String::new(),
+        word_index: 3,
+        is_flag: false,
+        is_long_flag: false,
+        preceding_flag: Some("--atime-preserve".into()),
+        in_pipe: false,
+        in_redirect: false,
+        quote_state: QuoteState::None,
+        is_first_segment: true,
+    };
+    group.bench_function("with_static_suggestions_tar", |b| {
+        b.iter(|| specs::resolve_spec(tar_spec, &static_ctx));
+    });
+
     group.finish();
 }
 
@@ -275,9 +295,9 @@ fn priority_sort_benchmarks(c: &mut Criterion) {
 
 fn memory_benchmarks(c: &mut Criterion) {
     let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
+    let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;
     let mut group = c.benchmark_group("memory");
     group.bench_function("embedded_specs_heap_walk", |b| {
-        let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;
         b.iter(|| {
             let total: usize = store
                 .iter()
@@ -289,40 +309,11 @@ fn memory_benchmarks(c: &mut Criterion) {
     group.finish();
 }
 
-fn static_suggestion_resolution_benchmarks(c: &mut Criterion) {
-    let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
-    let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;
-    let tar_spec = store.get("tar").expect("tar spec must exist");
-
-    // tar c --atime-preserve <TAB> — exercises preceding_flag path with
-    // static suggestions populated.
-    let ctx = CommandContext {
-        command: Some("tar".into()),
-        args: vec!["c".into(), "--atime-preserve".into()],
-        current_word: String::new(),
-        word_index: 3,
-        is_flag: false,
-        is_long_flag: false,
-        preceding_flag: Some("--atime-preserve".into()),
-        in_pipe: false,
-        in_redirect: false,
-        quote_state: QuoteState::None,
-        is_first_segment: true,
-    };
-
-    let mut group = c.benchmark_group("spec_resolution");
-    group.bench_function("with_static_suggestions_tar", |b| {
-        b.iter(|| specs::resolve_spec(tar_spec, &ctx));
-    });
-    group.finish();
-}
-
 criterion_group!(
     benches,
     fuzzy_benchmarks,
     spec_benchmarks,
     resolution_benchmarks,
-    static_suggestion_resolution_benchmarks,
     transform_benchmarks,
     engine_benchmarks,
     priority_sort_benchmarks,

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -273,6 +273,22 @@ fn priority_sort_benchmarks(c: &mut Criterion) {
     group.finish();
 }
 
+fn memory_benchmarks(c: &mut Criterion) {
+    let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
+    let mut group = c.benchmark_group("memory");
+    group.bench_function("embedded_specs_heap_walk", |b| {
+        let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;
+        b.iter(|| {
+            let total: usize = store
+                .iter()
+                .map(|(_, s)| specs::estimated_heap_bytes(s))
+                .sum();
+            std::hint::black_box(total)
+        });
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     fuzzy_benchmarks,
@@ -281,5 +297,6 @@ criterion_group!(
     transform_benchmarks,
     engine_benchmarks,
     priority_sort_benchmarks,
+    memory_benchmarks,
 );
 criterion_main!(benches);

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -881,7 +881,7 @@ impl SuggestionEngine {
             wants_folders_only,
             preceding_flag_has_args,
             past_double_dash,
-            ..
+            static_suggestions,
         } = specs::resolve_spec(spec, resolve_ctx.as_ref());
 
         let git_generators = self.git_generators_from(&native_generators);
@@ -895,6 +895,11 @@ impl SuggestionEngine {
             candidates.extend(subcommands);
             candidates.extend(options);
         }
+
+        // Static `args.suggestions` are values for an arg position, not commands —
+        // they MUST surface even when `suppress_commands` is true (preceding flag
+        // has args, or past `--`). Keep this extend OUTSIDE the suppression guard.
+        candidates.extend(static_suggestions);
 
         if wants_folders_only && self.providers_filesystem {
             self.extend_with_folders(ctx, cwd, &mut candidates);

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -2500,7 +2500,6 @@ mod tests {
     #[test]
     fn tar_atime_preserve_returns_replace_system() {
         let engine = make_engine();
-        // --atime-preserve lives under `tar c` (the create subcommand).
         let ctx = CommandContext {
             command: Some("tar".into()),
             args: vec!["c".into(), "--atime-preserve".into()],
@@ -2578,6 +2577,8 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let spec_json = r#"{
             "name": "myfake",
+            "subcommands": [{"name": "sub"}],
+            "options": [{"name": ["--flag"]}],
             "args": [{
                 "name": "value",
                 "suggestions": ["alpha", "beta"]

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -2462,4 +2462,31 @@ mod tests {
                 .collect::<Vec<_>>()
         );
     }
+
+    #[test]
+    fn git_archive_format_returns_tar_zip() {
+        let engine = make_engine();
+        let ctx = CommandContext {
+            command: Some("git".into()),
+            args: vec!["archive".into(), "--format=".into()],
+            current_word: String::new(),
+            word_index: 3,
+            is_flag: false,
+            is_long_flag: false,
+            // `find_option` strips the `=value` suffix internally, so passing
+            // `--format=` (with trailing `=`) or `--format` both resolve to the
+            // archive subcommand's `--format` option.
+            preceding_flag: Some("--format=".into()),
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: QuoteState::None,
+            is_first_segment: true,
+        };
+        let results = engine
+            .suggest_sync(&ctx, Path::new("/tmp"), "git archive --format=")
+            .unwrap();
+        let texts: Vec<&str> = results.iter().map(|s| s.text.as_str()).collect();
+        assert!(texts.contains(&"tar"), "expected `tar` in {texts:?}");
+        assert!(texts.contains(&"zip"), "expected `zip` in {texts:?}");
+    }
 }

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -2522,4 +2522,45 @@ mod tests {
         );
         assert!(texts.contains(&"system"), "expected `system` in {texts:?}");
     }
+
+    #[test]
+    fn static_suggestions_coexist_with_native_generators() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let spec_json = r#"{
+            "name": "myfake",
+            "args": [{
+                "name": "ref",
+                "generators": [{"type": "git_branches"}],
+                "suggestions": ["HEAD"]
+            }]
+        }"#;
+        std::fs::write(tmp.path().join("myfake.json"), spec_json).unwrap();
+
+        let spec_store = SpecStore::load_from_dir(tmp.path()).unwrap().store;
+        let history = HistoryProvider::from_entries(vec![]);
+        let commands = CommandsProvider::from_list(vec!["myfake".into()]);
+        let engine = SuggestionEngine::with_providers(spec_store, history, commands);
+
+        let ctx = CommandContext {
+            command: Some("myfake".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: QuoteState::None,
+            is_first_segment: true,
+        };
+        let results = engine
+            .suggest_sync(&ctx, Path::new("/tmp"), "myfake ")
+            .unwrap();
+        let texts: Vec<&str> = results.iter().map(|s| s.text.as_str()).collect();
+        assert!(
+            texts.contains(&"HEAD"),
+            "static suggestion `HEAD` must surface alongside the git_branches generator: {texts:?}"
+        );
+    }
 }

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -2468,8 +2468,7 @@ mod tests {
         );
     }
 
-    // Depends on specs/git.json: archive subcommand, --format option, suggestions: [tar, zip].
-    // If this test breaks, check whether the spec was modified before suspecting the engine.
+    // End-to-end: depends on specs/git.json declaring `archive --format` suggestions [tar, zip].
     #[test]
     fn git_archive_format_returns_tar_zip() {
         let engine = make_engine();
@@ -2497,8 +2496,7 @@ mod tests {
         assert!(texts.contains(&"zip"), "expected `zip` in {texts:?}");
     }
 
-    // Depends on specs/tar.json: `c` subcommand, --atime-preserve option, suggestions: [replace, system].
-    // If this test breaks, check whether the spec was modified before suspecting the engine.
+    // End-to-end: depends on specs/tar.json declaring `c --atime-preserve` suggestions [replace, system].
     #[test]
     fn tar_atime_preserve_returns_replace_system() {
         let engine = make_engine();
@@ -2572,6 +2570,57 @@ mod tests {
                 .contains(&crate::git::GitQueryKind::Branches),
             "git_branches generator must be dispatched alongside static suggestions: {:?}",
             results.git_generators
+        );
+    }
+
+    #[test]
+    fn static_suggestions_surface_past_double_dash() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let spec_json = r#"{
+            "name": "myfake",
+            "args": [{
+                "name": "value",
+                "suggestions": ["alpha", "beta"]
+            }]
+        }"#;
+        std::fs::write(tmp.path().join("myfake.json"), spec_json).unwrap();
+
+        let spec_store = SpecStore::load_from_dir(tmp.path()).unwrap().store;
+        let history = HistoryProvider::from_entries(vec![]);
+        let commands = CommandsProvider::from_list(vec!["myfake".into()]);
+        let engine = SuggestionEngine::with_providers(spec_store, history, commands);
+
+        let ctx = CommandContext {
+            command: Some("myfake".into()),
+            args: vec!["--".into()],
+            current_word: String::new(),
+            word_index: 2,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: QuoteState::None,
+            is_first_segment: true,
+        };
+        let results = engine
+            .suggest_sync(&ctx, Path::new("/tmp"), "myfake -- ")
+            .unwrap();
+        assert!(
+            results.iter().any(|s| s.text == "alpha"),
+            "static suggestion `alpha` must surface past `--`: {:?}",
+            results.suggestions
+        );
+        assert!(
+            results
+                .iter()
+                .all(|s| s.kind != SuggestionKind::Subcommand && s.kind != SuggestionKind::Flag),
+            "no Subcommand/Flag entries must leak past `--`: {:?}",
+            results
+                .suggestions
+                .iter()
+                .map(|s| (&s.text, &s.kind))
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -874,6 +874,7 @@ impl SuggestionEngine {
         let specs::SpecResolution {
             subcommands,
             options,
+            static_suggestions: _static_suggestions,
             native_generators,
             provider_generators,
             script_generators,

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -874,7 +874,6 @@ impl SuggestionEngine {
         let specs::SpecResolution {
             subcommands,
             options,
-            static_suggestions: _static_suggestions,
             native_generators,
             provider_generators,
             script_generators,
@@ -882,6 +881,7 @@ impl SuggestionEngine {
             wants_folders_only,
             preceding_flag_has_args,
             past_double_dash,
+            ..
         } = specs::resolve_spec(spec, resolve_ctx.as_ref());
 
         let git_generators = self.git_generators_from(&native_generators);

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -2468,6 +2468,8 @@ mod tests {
         );
     }
 
+    // Depends on specs/git.json: archive subcommand, --format option, suggestions: [tar, zip].
+    // If this test breaks, check whether the spec was modified before suspecting the engine.
     #[test]
     fn git_archive_format_returns_tar_zip() {
         let engine = make_engine();
@@ -2495,6 +2497,8 @@ mod tests {
         assert!(texts.contains(&"zip"), "expected `zip` in {texts:?}");
     }
 
+    // Depends on specs/tar.json: `c` subcommand, --atime-preserve option, suggestions: [replace, system].
+    // If this test breaks, check whether the spec was modified before suspecting the engine.
     #[test]
     fn tar_atime_preserve_returns_replace_system() {
         let engine = make_engine();
@@ -2561,6 +2565,13 @@ mod tests {
         assert!(
             texts.contains(&"HEAD"),
             "static suggestion `HEAD` must surface alongside the git_branches generator: {texts:?}"
+        );
+        assert!(
+            results
+                .git_generators
+                .contains(&crate::git::GitQueryKind::Branches),
+            "git_branches generator must be dispatched alongside static suggestions: {:?}",
+            results.git_generators
         );
     }
 }

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -2494,4 +2494,32 @@ mod tests {
         assert!(texts.contains(&"tar"), "expected `tar` in {texts:?}");
         assert!(texts.contains(&"zip"), "expected `zip` in {texts:?}");
     }
+
+    #[test]
+    fn tar_atime_preserve_returns_replace_system() {
+        let engine = make_engine();
+        // --atime-preserve lives under `tar c` (the create subcommand).
+        let ctx = CommandContext {
+            command: Some("tar".into()),
+            args: vec!["c".into(), "--atime-preserve".into()],
+            current_word: String::new(),
+            word_index: 3,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: Some("--atime-preserve".into()),
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: QuoteState::None,
+            is_first_segment: true,
+        };
+        let results = engine
+            .suggest_sync(&ctx, Path::new("/tmp"), "tar c --atime-preserve ")
+            .unwrap();
+        let texts: Vec<&str> = results.iter().map(|s| s.text.as_str()).collect();
+        assert!(
+            texts.contains(&"replace"),
+            "expected `replace` in {texts:?}"
+        );
+        assert!(texts.contains(&"system"), "expected `system` in {texts:?}");
+    }
 }

--- a/crates/gc-suggest/src/priority.rs
+++ b/crates/gc-suggest/src/priority.rs
@@ -63,8 +63,10 @@ mod tests {
             SuggestionKind::ProviderValue.base_priority()
         );
         assert!(
-            SuggestionKind::ProviderValue.base_priority() > SuggestionKind::EnvVar.base_priority()
+            SuggestionKind::ProviderValue.base_priority()
+                > SuggestionKind::EnumValue.base_priority()
         );
+        assert!(SuggestionKind::EnumValue.base_priority() > SuggestionKind::EnvVar.base_priority());
         assert!(SuggestionKind::EnvVar.base_priority() > SuggestionKind::Command.base_priority());
         assert!(SuggestionKind::Command.base_priority() > SuggestionKind::Flag.base_priority());
         assert!(SuggestionKind::Flag.base_priority() > SuggestionKind::Directory.base_priority());
@@ -72,10 +74,6 @@ mod tests {
             SuggestionKind::Directory.base_priority() > SuggestionKind::FilePath.base_priority()
         );
         assert!(SuggestionKind::FilePath.base_priority() > SuggestionKind::History.base_priority());
-        assert!(
-            SuggestionKind::Subcommand.base_priority() > SuggestionKind::EnumValue.base_priority()
-        );
-        assert!(SuggestionKind::EnumValue.base_priority() > SuggestionKind::Flag.base_priority());
     }
 
     #[test]

--- a/crates/gc-suggest/src/priority.rs
+++ b/crates/gc-suggest/src/priority.rs
@@ -72,6 +72,10 @@ mod tests {
             SuggestionKind::Directory.base_priority() > SuggestionKind::FilePath.base_priority()
         );
         assert!(SuggestionKind::FilePath.base_priority() > SuggestionKind::History.base_priority());
+        assert!(
+            SuggestionKind::Subcommand.base_priority() > SuggestionKind::EnumValue.base_priority()
+        );
+        assert!(SuggestionKind::EnumValue.base_priority() > SuggestionKind::Flag.base_priority());
     }
 
     #[test]
@@ -108,6 +112,7 @@ mod tests {
             SuggestionKind::Directory,
             SuggestionKind::FilePath,
             SuggestionKind::History,
+            SuggestionKind::EnumValue,
         ] {
             let p = k.base_priority().get();
             assert!(p <= 100, "{k:?} base priority {p} out of range");

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -708,21 +708,26 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
         }
     }
 
-    // Also check positional arg specs at the resolved position
-    for arg_spec in current_args {
-        collect_generators(
-            &arg_spec.generators,
-            &mut native_generators,
-            &mut provider_generators,
-            &mut script_generators,
-            &mut wants_filepaths,
-            &mut wants_folders_only,
-        );
-        collect_static_suggestions(&arg_spec.suggestions, &mut static_suggestions);
-        match arg_spec.template.as_deref() {
-            Some("filepaths") => wants_filepaths = true,
-            Some("folders") => wants_folders_only = true,
-            _ => {}
+    // Check positional arg specs at the resolved position, but only when
+    // not filling a flag argument. When `preceding_flag_has_args` is true,
+    // the user is supplying the flag's value — positional arg specs are
+    // irrelevant and their suggestions would pollute the candidate set.
+    if !preceding_flag_has_args {
+        for arg_spec in current_args {
+            collect_generators(
+                &arg_spec.generators,
+                &mut native_generators,
+                &mut provider_generators,
+                &mut script_generators,
+                &mut wants_filepaths,
+                &mut wants_folders_only,
+            );
+            collect_static_suggestions(&arg_spec.suggestions, &mut static_suggestions);
+            match arg_spec.template.as_deref() {
+                Some("filepaths") => wants_filepaths = true,
+                Some("folders") => wants_folders_only = true,
+                _ => {}
+            }
         }
     }
 

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -299,17 +299,25 @@ pub struct ArgSpec {
     pub template: Option<String>,
     /// Static suggestions — plain string or full object entries from the spec's
     /// `args.suggestions` field.
+    ///
+    /// `pub(crate)` because `SuggestionEntry` itself is `pub(crate)` —
+    /// external consumers (`ghost-complete::status`/`doctor`) only inspect
+    /// `args` and `generators`, never `suggestions`.
     #[serde(default, deserialize_with = "deserialize_suggestions_one_or_many")]
-    pub suggestions: Vec<SuggestionEntry>,
+    pub(crate) suggestions: Vec<SuggestionEntry>,
 }
 
 /// Static suggestion entry — either a plain string shorthand or a full object.
 /// Mirrors the Fig schema. Fields not present in [`SuggestionObject`] (insertValue,
 /// displayName, replaceValue, icon, isDangerous) are silently ignored by serde; v2
 /// may add them.
+///
+/// `pub(crate)` to keep external callers from constructing entries that bypass
+/// the `validate_arg_generators` invariant pass (empty names / hidden entries
+/// are stripped there before any keystroke ever sees them).
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
-pub enum SuggestionEntry {
+pub(crate) enum SuggestionEntry {
     Plain(String),
     Object(SuggestionObject),
 }
@@ -339,15 +347,15 @@ impl SuggestionEntry {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct SuggestionObject {
+pub(crate) struct SuggestionObject {
     #[serde(default, deserialize_with = "deserialize_name_one_or_many")]
-    pub name: Vec<String>,
-    pub description: Option<String>,
+    pub(crate) name: Vec<String>,
+    pub(crate) description: Option<String>,
     #[serde(rename = "type")]
-    pub kind: Option<String>,
-    pub priority: Option<Priority>,
+    pub(crate) kind: Option<String>,
+    pub(crate) priority: Option<Priority>,
     #[serde(default)]
-    pub hidden: bool,
+    pub(crate) hidden: bool,
 }
 
 fn deserialize_name_one_or_many<'de, D>(d: D) -> std::result::Result<Vec<String>, D::Error>
@@ -746,7 +754,8 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
 }
 
 /// Map Fig `Suggestion.type` strings to `SuggestionKind`.
-/// Per SPEC.md §"type mapping": subcommand/option/file/folder map to their
+/// Per `docs/COMPLETION_SPEC.md` ("type mapping" table under
+/// `Static suggestions`): subcommand/option/file/folder map to their
 /// equivalents; "arg", "special", "shortcut", "mixin", "auto-execute", and
 /// missing/unknown all fall back to `EnumValue`. This runs on the keystroke
 /// hot path via `resolve_spec`, so it MUST stay a pure mapping with no
@@ -789,6 +798,15 @@ fn is_known_suggestion_type(s: &str) -> bool {
 /// `nucleo` handles duplicates transparently).
 fn collect_static_suggestions(entries: &[SuggestionEntry], out: &mut Vec<Suggestion>) {
     for entry in entries {
+        // Defensive guard: `validate_arg_generators` already prunes empty-name
+        // and hidden entries at load time, but `collect_static_suggestions`
+        // is the last stop before the popup. Re-checking here means that a
+        // future caller who skips validation (or a code path that resolves
+        // an unvalidated `CompletionSpec`) cannot leak empty-text or hidden
+        // entries into the ranked candidate set.
+        if entry.is_empty_name() || entry.is_hidden() {
+            continue;
+        }
         match entry {
             SuggestionEntry::Plain(text) => {
                 out.push(Suggestion {
@@ -2763,11 +2781,10 @@ mod tests {
     #[test]
     fn embedded_specs_under_memory_budget() {
         // Measured baseline: ~37.5 MB (37,536,540 bytes) on 709 specs as of
-        // v0.10.0 (2026-04-28). SPEC §Memory budget estimated 8 MB for
-        // suggestions alone; the full CompletionSpec tree walk is much larger
-        // because it covers js_source, transforms, descriptions, etc. across
-        // all 709 specs. 64 MiB (67,108,864 bytes) gives ~1.78x headroom for
-        // spec corpus growth before requiring a deliberate budget raise.
+        // v0.10.0 (2026-04-28). The `estimated_heap_bytes` walk covers the
+        // whole `CompletionSpec` tree (js_source, transforms, descriptions,
+        // etc.). 64 MiB (67,108,864 bytes) gives ~1.78x headroom for spec
+        // corpus growth before requiring a deliberate budget raise.
         const BUDGET_BYTES: usize = 64 * 1024 * 1024;
         let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
         let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;
@@ -2783,5 +2800,229 @@ mod tests {
             total,
             total / 1024
         );
+    }
+
+    #[test]
+    fn preceding_flag_args_suppress_positional_static_and_generators() {
+        // ADR 0004 calls out the `if !preceding_flag_has_args` guard on
+        // positional-arg collection as a plan-deviation bug fix:
+        // `pip install -r ` previously mixed `-r`'s `template: filepaths`
+        // with the positional package-name generators. Pulling the guard
+        // would silently re-introduce the bug; this test pins it.
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{
+                "name": "pip",
+                "subcommands": [{
+                    "name": "install",
+                    "options": [{
+                        "name": ["-r"],
+                        "args": { "name": "file", "template": "filepaths" }
+                    }],
+                    "args": [{
+                        "name": "pkg",
+                        "suggestions": ["pos1", "pos2"],
+                        "generators": [{"type": "git_branches"}]
+                    }]
+                }]
+            }"#,
+        )
+        .unwrap();
+        let ctx = CommandContext {
+            command: Some("pip".into()),
+            args: vec!["install".into(), "-r".into()],
+            current_word: String::new(),
+            word_index: 3,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: Some("-r".into()),
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        assert!(res.preceding_flag_has_args);
+        assert!(
+            res.static_suggestions.is_empty(),
+            "positional static suggestions must NOT leak when filling a flag arg: {:?}",
+            res.static_suggestions
+        );
+        assert!(
+            res.native_generators.is_empty(),
+            "positional native generators must NOT leak when filling a flag arg: {:?}",
+            res.native_generators
+        );
+        assert!(res.wants_filepaths);
+    }
+
+    #[test]
+    fn static_suggestion_priority_field_round_trips() {
+        // `collect_static_suggestions` copies `obj.priority` into the
+        // resulting Suggestion. Pin the round-trip so a regression that
+        // drops or replaces the priority field is caught.
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{
+                "name": "foo",
+                "args": [{
+                    "name": "x",
+                    "suggestions": [
+                        {"name": "x", "priority": 90},
+                        {"name": "y"}
+                    ]
+                }]
+            }"#,
+        )
+        .unwrap();
+        let ctx = CommandContext {
+            command: Some("foo".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        let by_text: HashMap<String, Option<Priority>> = res
+            .static_suggestions
+            .iter()
+            .map(|s| (s.text.clone(), s.priority))
+            .collect();
+        assert_eq!(by_text["x"], Some(Priority::new(90)));
+        assert_eq!(by_text["y"], None);
+    }
+
+    #[test]
+    fn static_suggestions_accept_singular_string_and_object() {
+        // Fig schema permits `suggestions` as a singular form (string or
+        // object) as well as an array. Likewise `name` inside a
+        // SuggestionObject. Exercise the One arm of every OneOrMany so a
+        // regression that only kept the Many path is caught.
+        let plain: CompletionSpec =
+            serde_json::from_str(r#"{"name":"a","args":{"name":"x","suggestions":"foo"}}"#)
+                .unwrap();
+        assert_eq!(plain.args[0].suggestions.len(), 1);
+        match &plain.args[0].suggestions[0] {
+            SuggestionEntry::Plain(s) => assert_eq!(s, "foo"),
+            _ => panic!("expected Plain singular"),
+        }
+
+        let obj: CompletionSpec = serde_json::from_str(
+            r#"{"name":"a","args":{"name":"x","suggestions":{"name":"bar"}}}"#,
+        )
+        .unwrap();
+        assert_eq!(obj.args[0].suggestions.len(), 1);
+        match &obj.args[0].suggestions[0] {
+            SuggestionEntry::Object(o) => assert_eq!(o.name, vec!["bar".to_string()]),
+            _ => panic!("expected Object singular"),
+        }
+
+        let str_name: CompletionSpec = serde_json::from_str(
+            r#"{"name":"a","args":{"name":"x","suggestions":[{"name":"singlestr"}]}}"#,
+        )
+        .unwrap();
+        match &str_name.args[0].suggestions[0] {
+            SuggestionEntry::Object(o) => {
+                assert_eq!(o.name, vec!["singlestr".to_string()]);
+            }
+            _ => panic!("expected Object with singular name"),
+        }
+    }
+
+    #[test]
+    fn option_arg_static_suggestions_emit_one_per_alias() {
+        // `collect_static_suggestions` is invoked from both the positional
+        // and the preceding_flag paths. Cover the latter with a multi-alias
+        // name array — a regression that emitted only the first alias on
+        // the option-arg path (vs the positional path) wouldn't be caught
+        // by the existing tests.
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{
+                "name": "fmt",
+                "options": [{
+                    "name": ["--format"],
+                    "args": {
+                        "name": "kind",
+                        "suggestions": [
+                            {"name": ["json", "j"], "description": "JSON output"}
+                        ]
+                    }
+                }]
+            }"#,
+        )
+        .unwrap();
+        let ctx = CommandContext {
+            command: Some("fmt".into()),
+            args: vec!["--format".into()],
+            current_word: String::new(),
+            word_index: 2,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: Some("--format".into()),
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        assert_eq!(res.static_suggestions.len(), 2);
+        for s in &res.static_suggestions {
+            assert_eq!(s.description.as_deref(), Some("JSON output"));
+            assert_eq!(s.kind, SuggestionKind::EnumValue);
+        }
+        let texts: Vec<&str> = res
+            .static_suggestions
+            .iter()
+            .map(|s| s.text.as_str())
+            .collect();
+        assert!(texts.contains(&"json"));
+        assert!(texts.contains(&"j"));
+    }
+
+    #[test]
+    fn pure_control_char_suggestion_name_pruned_after_sanitize() {
+        // The combined sanitize → validate pipeline must drop entries whose
+        // names sanitize down to empty strings. A regression that runs
+        // validation before sanitize, or skips the post-sanitize empty
+        // check, would leak an empty-text suggestion to the popup.
+        let json = "{\"name\":\"x\",\"args\":{\"name\":\"y\",\"suggestions\":[{\"name\":\"\\u0001\\u0002\"},\"ok\"]}}";
+        let mut spec = parse_spec_checked_and_sanitized(json).unwrap();
+        let _ = validate_spec_generators(&mut spec);
+        assert_eq!(spec.args[0].suggestions.len(), 1);
+        match &spec.args[0].suggestions[0] {
+            SuggestionEntry::Plain(s) => assert_eq!(s, "ok"),
+            _ => panic!("expected Plain(\"ok\") to be the sole survivor"),
+        }
+    }
+
+    #[test]
+    fn duplicate_suggestion_names_emit_both_entries() {
+        // `collect_static_suggestions` documents "no dedup — nucleo handles
+        // duplicates transparently". Pin that contract so a future change
+        // that introduces dedup at the spec layer is caught.
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{"name":"d","args":[{"name":"x","suggestions":["foo","foo"]}]}"#,
+        )
+        .unwrap();
+        let ctx = CommandContext {
+            command: Some("d".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        assert_eq!(res.static_suggestions.len(), 2);
+        assert!(res.static_suggestions.iter().all(|s| s.text == "foo"));
     }
 }

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -2186,4 +2186,31 @@ mod tests {
         assert_eq!(gen.corrected_in.as_deref(), Some("v0.10.0"));
         assert_eq!(gen.template.as_deref(), Some("filepaths"));
     }
+
+    #[test]
+    fn static_suggestions_deserialize_plain_and_object() {
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{
+            "name": "x",
+            "args": {
+                "name": "y",
+                "suggestions": ["plain", {"name": "obj", "description": "d"}]
+            }
+        }"#,
+        )
+        .unwrap();
+        let arg = &spec.args[0];
+        assert_eq!(arg.suggestions.len(), 2);
+        match &arg.suggestions[0] {
+            SuggestionEntry::Plain(s) => assert_eq!(s, "plain"),
+            _ => panic!("expected Plain"),
+        }
+        match &arg.suggestions[1] {
+            SuggestionEntry::Object(o) => {
+                assert_eq!(o.name, vec!["obj".to_string()]);
+                assert_eq!(o.description.as_deref(), Some("d"));
+            }
+            _ => panic!("expected Object"),
+        }
+    }
 }

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -899,7 +899,7 @@ fn validate_arg_generators(arg_spec: &mut ArgSpec, spec_name: &str, warnings: &m
     });
     if arg_spec.suggestions.len() < original_suggestions_len {
         tracing::warn!(
-            "{spec_name}: removed {} suggestion(s) with empty names",
+            "{spec_name}: removed {} suggestion(s) (empty name or hidden)",
             original_suggestions_len - arg_spec.suggestions.len()
         );
     }
@@ -2409,7 +2409,11 @@ mod tests {
             }
         }"#;
         let mut spec = parse_spec_checked_and_sanitized(json).unwrap();
-        let _warnings = validate_spec_generators(&mut spec);
+        let warnings = validate_spec_generators(&mut spec);
+        assert!(
+            warnings.is_empty(),
+            "hidden entries should be dropped silently"
+        );
         let names: Vec<&str> = spec.args[0]
             .suggestions
             .iter()

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -284,9 +284,69 @@ pub struct ArgSpec {
     pub generators: Vec<GeneratorSpec>,
     #[serde(default, deserialize_with = "deserialize_template")]
     pub template: Option<String>,
-    /// Static suggestions — accepted from specs but not yet used at runtime.
+    /// Static suggestions — plain string or full object entries from the spec's
+    /// `args.suggestions` field.
+    #[serde(default, deserialize_with = "deserialize_suggestions_one_or_many")]
+    pub suggestions: Vec<SuggestionEntry>,
+}
+
+/// Static suggestion entry — either a plain string shorthand or a full object.
+/// Mirrors the Fig schema; reserved fields (insertValue, displayName,
+/// replaceValue, icon, isDangerous) deserialize-but-not-honored in v1.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum SuggestionEntry {
+    Plain(String),
+    Object(SuggestionObject),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SuggestionObject {
+    #[serde(default, deserialize_with = "deserialize_name_one_or_many")]
+    pub name: Vec<String>,
+    pub description: Option<String>,
+    #[serde(rename = "type")]
+    pub kind: Option<String>,
+    pub priority: Option<Priority>,
     #[serde(default)]
-    pub suggestions: Option<serde_json::Value>,
+    pub hidden: bool,
+}
+
+fn deserialize_name_one_or_many<'de, D>(d: D) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+    match OneOrMany::deserialize(d)? {
+        OneOrMany::One(s) => Ok(vec![s]),
+        OneOrMany::Many(v) => Ok(v),
+    }
+}
+
+fn deserialize_suggestions_one_or_many<'de, D>(
+    d: D,
+) -> std::result::Result<Vec<SuggestionEntry>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    // Fig allows the suggestions field to be either an array (canonical) or
+    // a single entry. Mirror the existing `deserialize_args_one_or_many`
+    // pattern so a malformed/single-entry spec still loads.
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(SuggestionEntry),
+        Many(Vec<SuggestionEntry>),
+    }
+    match OneOrMany::deserialize(d)? {
+        OneOrMany::One(s) => Ok(vec![s]),
+        OneOrMany::Many(v) => Ok(v),
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1481,7 +1541,7 @@ mod tests {
                 description: None,
                 generators: vec![],
                 template: None,
-                suggestions: None,
+                suggestions: vec![],
             }),
             priority: None,
         }];
@@ -1510,7 +1570,7 @@ mod tests {
                         description: None,
                         generators: vec![],
                         template: None,
-                        suggestions: None,
+                        suggestions: vec![],
                     })
                 } else {
                     None

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -2505,4 +2505,53 @@ mod tests {
             .iter()
             .all(|s| s.source == crate::types::SuggestionSource::Spec));
     }
+
+    #[test]
+    fn test_static_suggestion_type_field_maps_to_kind() {
+        use crate::types::SuggestionKind;
+
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{
+            "name":"foo",
+            "args":[{"name":"x","suggestions":[
+                {"name":"sub","type":"subcommand"},
+                {"name":"opt","type":"option"},
+                {"name":"file","type":"file"},
+                {"name":"folder","type":"folder"},
+                {"name":"defaulted"},
+                {"name":"argish","type":"arg"},
+                {"name":"specialish","type":"special"},
+                {"name":"unknown","type":"made_up_xyz"}
+            ]}]
+        }"#,
+        )
+        .unwrap();
+        let ctx = CommandContext {
+            command: Some("foo".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        let by_text: std::collections::HashMap<String, SuggestionKind> = res
+            .static_suggestions
+            .into_iter()
+            .map(|s| (s.text, s.kind))
+            .collect();
+        assert_eq!(by_text["sub"], SuggestionKind::Subcommand);
+        assert_eq!(by_text["opt"], SuggestionKind::Flag);
+        assert_eq!(by_text["file"], SuggestionKind::FilePath);
+        assert_eq!(by_text["folder"], SuggestionKind::Directory);
+        assert_eq!(by_text["defaulted"], SuggestionKind::EnumValue);
+        assert_eq!(by_text["argish"], SuggestionKind::EnumValue);
+        assert_eq!(by_text["specialish"], SuggestionKind::EnumValue);
+        assert_eq!(by_text["unknown"], SuggestionKind::EnumValue);
+    }
 }

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -314,6 +314,24 @@ pub enum SuggestionEntry {
     Object(SuggestionObject),
 }
 
+impl SuggestionEntry {
+    /// Returns true if this entry has no usable name.
+    ///
+    /// Covers both the empty-array case (`name: []`) and the blank-string case
+    /// (`name: ""` or whitespace-only).  For an Object with any empty/whitespace
+    /// name the whole entry is dropped — this is conservative but correct for
+    /// the specs we know about.  If a future spec legitimately uses
+    /// `["valid", ""]` with an intentional empty alias, loosen this check then.
+    fn is_empty_name(&self) -> bool {
+        match self {
+            SuggestionEntry::Plain(s) => s.trim().is_empty(),
+            SuggestionEntry::Object(o) => {
+                o.name.is_empty() || o.name.iter().any(|n| n.trim().is_empty())
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct SuggestionObject {
     #[serde(default, deserialize_with = "deserialize_name_one_or_many")]
@@ -855,6 +873,23 @@ fn validate_arg_generators(arg_spec: &mut ArgSpec, spec_name: &str, warnings: &m
         tracing::warn!(
             "{spec_name}: removed {} generator(s) with invalid transform pipelines",
             original_len - arg_spec.generators.len()
+        );
+    }
+
+    let original_suggestions_len = arg_spec.suggestions.len();
+    arg_spec.suggestions.retain(|entry| {
+        if entry.is_empty_name() {
+            warnings.push(format!(
+                "suggestion in {spec_name} has empty name; dropping"
+            ));
+            return false;
+        }
+        true
+    });
+    if arg_spec.suggestions.len() < original_suggestions_len {
+        tracing::warn!(
+            "{spec_name}: removed {} suggestion(s) with empty names",
+            original_suggestions_len - arg_spec.suggestions.len()
         );
     }
 }
@@ -2336,7 +2371,11 @@ mod tests {
             SuggestionEntry::Plain(s) => assert_eq!(s, "ok"),
             _ => panic!("expected Plain(\"ok\")"),
         }
-        assert_eq!(warnings.len(), 2, "expected two warnings (one per empty entry)");
+        assert_eq!(
+            warnings.len(),
+            2,
+            "expected two warnings (one per empty entry)"
+        );
         for w in &warnings {
             assert!(
                 w.contains('x'),

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -675,7 +675,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
     let mut script_generators = Vec::new();
     let mut wants_filepaths = false;
     let mut wants_folders_only = false;
-    let mut static_suggestions: Vec<Suggestion> = Vec::new();
+    let mut static_suggestions = Vec::new();
 
     // If the preceding token was a flag that takes an argument, check
     // the option's arg spec for templates/generators instead of the
@@ -743,9 +743,10 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
 /// Map Fig `Suggestion.type` strings to `SuggestionKind`.
 /// Per SPEC.md §"type mapping": subcommand/option/file/folder map to their
 /// equivalents; "arg", "special", "shortcut", "mixin", "auto-execute", and
-/// missing/unknown all fall back to `EnumValue`. Unknown strings emit a
-/// warning via `tracing` so misconfigured specs surface but don't break
-/// loading.
+/// missing/unknown all fall back to `EnumValue`. This runs on the keystroke
+/// hot path via `resolve_spec`, so it MUST stay a pure mapping with no
+/// logging — `validate_arg_generators` already warns once at load time about
+/// unknown type strings (see `is_known_suggestion_type`).
 fn suggestion_kind_from_type(s: Option<&str>) -> SuggestionKind {
     match s {
         Some("subcommand") => SuggestionKind::Subcommand,
@@ -754,14 +755,26 @@ fn suggestion_kind_from_type(s: Option<&str>) -> SuggestionKind {
         Some("folder") => SuggestionKind::Directory,
         Some("arg") | Some("special") | Some("shortcut") | Some("mixin") | Some("auto-execute")
         | None => SuggestionKind::EnumValue,
-        Some(other) => {
-            tracing::warn!(
-                suggestion_type = %other,
-                "unknown Fig suggestion `type`; falling back to EnumValue"
-            );
-            SuggestionKind::EnumValue
-        }
+        Some(_) => SuggestionKind::EnumValue, // load-time validation already warned
     }
+}
+
+/// Set of Fig `Suggestion.type` strings recognized by `suggestion_kind_from_type`.
+/// Kept in sync with that function; used at load time by `validate_arg_generators`
+/// to warn once per unknown type string instead of warning on every keystroke.
+fn is_known_suggestion_type(s: &str) -> bool {
+    matches!(
+        s,
+        "subcommand"
+            | "option"
+            | "file"
+            | "folder"
+            | "arg"
+            | "special"
+            | "shortcut"
+            | "mixin"
+            | "auto-execute"
+    )
 }
 
 /// Lift static `SuggestionEntry` values into ranked-pool `Suggestion`s.
@@ -970,6 +983,22 @@ fn validate_arg_generators(arg_spec: &mut ArgSpec, spec_name: &str, warnings: &m
             "{spec_name}: removed {} suggestion(s) (empty name or hidden)",
             original_suggestions_len - arg_spec.suggestions.len()
         );
+    }
+
+    // Surface unknown `type` strings once at load time. `suggestion_kind_from_type`
+    // is on the keystroke hot path and must stay silent — emitting the warning
+    // here means each unknown type shows up once per spec load instead of once
+    // per keystroke. The entry itself is kept; `EnumValue` is a safe fallback.
+    for entry in &arg_spec.suggestions {
+        if let SuggestionEntry::Object(obj) = entry {
+            if let Some(type_str) = &obj.kind {
+                if !is_known_suggestion_type(type_str) {
+                    warnings.push(format!(
+                        "suggestion in {spec_name} has unknown `type` \"{type_str}\"; falling back to EnumValue"
+                    ));
+                }
+            }
+        }
     }
 }
 
@@ -2546,6 +2575,9 @@ mod tests {
                 {"name":"defaulted"},
                 {"name":"argish","type":"arg"},
                 {"name":"specialish","type":"special"},
+                {"name":"sh","type":"shortcut"},
+                {"name":"mx","type":"mixin"},
+                {"name":"ae","type":"auto-execute"},
                 {"name":"unknown","type":"made_up_xyz"}
             ]}]
         }"#,
@@ -2577,6 +2609,26 @@ mod tests {
         assert_eq!(by_text["defaulted"], SuggestionKind::EnumValue);
         assert_eq!(by_text["argish"], SuggestionKind::EnumValue);
         assert_eq!(by_text["specialish"], SuggestionKind::EnumValue);
+        assert_eq!(by_text["sh"], SuggestionKind::EnumValue);
+        assert_eq!(by_text["mx"], SuggestionKind::EnumValue);
+        assert_eq!(by_text["ae"], SuggestionKind::EnumValue);
         assert_eq!(by_text["unknown"], SuggestionKind::EnumValue);
+    }
+
+    #[test]
+    fn unknown_suggestion_type_warns_at_load_time() {
+        let json = r#"{"name":"x","args":{"name":"y","suggestions":[
+            {"name":"a","type":"made_up_xyz"},
+            {"name":"b","type":"file"}
+        ]}}"#;
+        let mut spec = parse_spec_checked_and_sanitized(json).unwrap();
+        let warnings = validate_spec_generators(&mut spec);
+        assert!(warnings.iter().any(|w| w.contains("made_up_xyz")));
+        assert!(!warnings.iter().any(|w| w.contains("\"file\"")));
+        assert_eq!(
+            spec.args[0].suggestions.len(),
+            2,
+            "unknown-type entry should NOT be dropped"
+        );
     }
 }

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1036,8 +1036,9 @@ fn validate_arg_generators(arg_spec: &mut ArgSpec, spec_name: &str, warnings: &m
 /// The walk is iterative to avoid recursion-depth issues on deeply nested
 /// specs. Accuracy is approximate; the goal is a stable number that detects
 /// large regressions, not a byte-perfect heap profiler reading.
-// `pub` (not `pub(crate)`) is required because the criterion bench is a
-// separate compilation unit linked against the gc-suggest cdylib boundary.
+// `pub` (not `pub(crate)`): the criterion bench is a separate Cargo target
+// in `benches/` and links to gc-suggest as an external consumer, so
+// `pub(crate)` items would not be visible to it.
 pub fn estimated_heap_bytes(spec: &CompletionSpec) -> usize {
     use crate::transform::{ParameterizedTransform, Transform};
 

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -330,6 +330,12 @@ impl SuggestionEntry {
             }
         }
     }
+
+    /// Returns true if the spec author explicitly marked this entry as hidden.
+    /// Plain strings have no hidden field and therefore are never hidden.
+    fn is_hidden(&self) -> bool {
+        matches!(self, SuggestionEntry::Object(o) if o.hidden)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -882,6 +888,11 @@ fn validate_arg_generators(arg_spec: &mut ArgSpec, spec_name: &str, warnings: &m
             warnings.push(format!(
                 "suggestion in {spec_name} has empty name; dropping"
             ));
+            return false;
+        }
+        if entry.is_hidden() {
+            // Silent drop — `hidden: true` is the spec author's explicit signal
+            // to suppress this entry.  No warning needed.
             return false;
         }
         true
@@ -2382,5 +2393,31 @@ mod tests {
                 "warning should contain the spec name 'x', got: {w}"
             );
         }
+    }
+
+    #[test]
+    fn hidden_suggestion_is_dropped_at_load_time() {
+        let json = r#"{
+            "name": "x",
+            "args": {
+                "name": "y",
+                "suggestions": [
+                    {"name": "visible"},
+                    {"name": "hush", "hidden": true},
+                    "plain-also-visible"
+                ]
+            }
+        }"#;
+        let mut spec = parse_spec_checked_and_sanitized(json).unwrap();
+        let _warnings = validate_spec_generators(&mut spec);
+        let names: Vec<&str> = spec.args[0]
+            .suggestions
+            .iter()
+            .map(|e| match e {
+                SuggestionEntry::Plain(s) => s.as_str(),
+                SuggestionEntry::Object(o) => o.name[0].as_str(),
+            })
+            .collect();
+        assert_eq!(names, vec!["visible", "plain-also-visible"]);
     }
 }

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -2424,4 +2424,31 @@ mod tests {
             .collect();
         assert_eq!(names, vec!["visible", "plain-also-visible"]);
     }
+
+    #[test]
+    fn test_resolve_static_suggestions_positional() {
+        let spec: CompletionSpec = serde_json::from_str(
+            r#"{"name":"foo","args":[{"name":"fmt","suggestions":["a","b"]}]}"#
+        ).unwrap();
+        let ctx = CommandContext {
+            command: Some("foo".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: gc_buffer::QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        assert_eq!(res.static_suggestions.len(), 2);
+        let texts: Vec<&str> = res.static_suggestions.iter().map(|s| s.text.as_str()).collect();
+        assert!(texts.contains(&"a"));
+        assert!(texts.contains(&"b"));
+        assert!(res.static_suggestions.iter().all(|s| s.kind == crate::types::SuggestionKind::EnumValue));
+        assert!(res.static_suggestions.iter().all(|s| s.source == crate::types::SuggestionSource::Spec));
+    }
 }

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -304,8 +304,9 @@ pub struct ArgSpec {
 }
 
 /// Static suggestion entry — either a plain string shorthand or a full object.
-/// Mirrors the Fig schema; reserved fields (insertValue, displayName,
-/// replaceValue, icon, isDangerous) deserialize-but-not-honored in v1.
+/// Mirrors the Fig schema. Fields not present in [`SuggestionObject`] (insertValue,
+/// displayName, replaceValue, icon, isDangerous) are silently ignored by serde; v2
+/// may add them.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum SuggestionEntry {
@@ -2296,8 +2297,7 @@ mod tests {
         //   "d\u001b"     -> parsed as "d\x1b"    -> sanitized to "d"
         //   "pl\u001bain" -> parsed as "pl\x1bain"-> sanitized to "plain"
         let json = "{\"name\":\"x\",\"args\":{\"name\":\"y\",\"suggestions\":[{\"name\":\"ev\\u001bil\",\"description\":\"d\\u001b\"},\"pl\\u001bain\"]}}";
-        let mut spec = parse_spec_checked_and_sanitized(json).unwrap();
-        let _ = validate_spec_generators(&mut spec);
+        let spec = parse_spec_checked_and_sanitized(json).unwrap();
         let arg = &spec.args[0];
         match &arg.suggestions[0] {
             SuggestionEntry::Object(o) => {

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -2311,4 +2311,37 @@ mod tests {
             _ => panic!("expected Plain"),
         }
     }
+
+    #[test]
+    fn empty_suggestion_names_are_pruned_with_warning() {
+        let json = r#"{
+            "name": "x",
+            "args": {
+                "name": "y",
+                "suggestions": [
+                    {"name": []},
+                    {"name": ""},
+                    "ok"
+                ]
+            }
+        }"#;
+        let mut spec = parse_spec_checked_and_sanitized(json).unwrap();
+        let warnings = validate_spec_generators(&mut spec);
+        assert_eq!(
+            spec.args[0].suggestions.len(),
+            1,
+            "only 'ok' should survive pruning"
+        );
+        match &spec.args[0].suggestions[0] {
+            SuggestionEntry::Plain(s) => assert_eq!(s, "ok"),
+            _ => panic!("expected Plain(\"ok\")"),
+        }
+        assert_eq!(warnings.len(), 2, "expected two warnings (one per empty entry)");
+        for w in &warnings {
+            assert!(
+                w.contains('x'),
+                "warning should contain the spec name 'x', got: {w}"
+            );
+        }
+    }
 }

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -2779,12 +2779,55 @@ mod tests {
     }
 
     #[test]
+    fn suggestion_object_ignores_reserved_fig_fields() {
+        // Reserved Fig fields not modeled on `SuggestionObject` must remain
+        // silently ignored by serde. A future `#[serde(deny_unknown_fields)]`
+        // would otherwise break parsing of real bundled specs that carry
+        // `insertValue`, `displayName`, `replaceValue`, `icon`,
+        // `isDangerous`, or `deprecated`.
+        let json = r#"{
+            "name": "x",
+            "args": {
+                "name": "y",
+                "suggestions": [{
+                    "name": "a",
+                    "description": "desc",
+                    "insertValue": "a ",
+                    "displayName": "Alpha",
+                    "replaceValue": "alpha",
+                    "icon": "fig://icon?type=string",
+                    "isDangerous": true,
+                    "deprecated": true
+                }]
+            }
+        }"#;
+        let mut spec = parse_spec_checked_and_sanitized(json).unwrap();
+        let warnings = validate_spec_generators(&mut spec);
+        assert_eq!(
+            spec.args[0].suggestions.len(),
+            1,
+            "entry with reserved fields should parse and survive validation"
+        );
+        match &spec.args[0].suggestions[0] {
+            SuggestionEntry::Object(o) => {
+                assert_eq!(o.name, vec!["a".to_string()]);
+                assert_eq!(o.description.as_deref(), Some("desc"));
+            }
+            _ => panic!("expected Object"),
+        }
+        assert!(
+            warnings.is_empty(),
+            "reserved Fig fields must not produce warnings, got: {warnings:?}"
+        );
+    }
+
+    #[test]
     fn embedded_specs_under_memory_budget() {
-        // Measured baseline: ~37.5 MB (37,536,540 bytes) on 709 specs as of
-        // v0.10.0 (2026-04-28). The `estimated_heap_bytes` walk covers the
-        // whole `CompletionSpec` tree (js_source, transforms, descriptions,
-        // etc.). 64 MiB (67,108,864 bytes) gives ~1.78x headroom for spec
-        // corpus growth before requiring a deliberate budget raise.
+        // Measured baseline: ~37.5 MB (37,536,540 bytes), measured 2026-04-28
+        // on 709 specs. The `estimated_heap_bytes` walk covers the whole
+        // `CompletionSpec` tree (js_source, transforms, descriptions, etc.).
+        // 64 MiB (67,108,864 bytes) gives ~1.78x headroom for spec corpus
+        // growth before requiring a deliberate budget raise.
         const BUDGET_BYTES: usize = 64 * 1024 * 1024;
         let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
         let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;
@@ -2804,11 +2847,11 @@ mod tests {
 
     #[test]
     fn preceding_flag_args_suppress_positional_static_and_generators() {
-        // ADR 0004 calls out the `if !preceding_flag_has_args` guard on
-        // positional-arg collection as a plan-deviation bug fix:
-        // `pip install -r ` previously mixed `-r`'s `template: filepaths`
-        // with the positional package-name generators. Pulling the guard
-        // would silently re-introduce the bug; this test pins it.
+        // Invariant: filling a flag's argument must not also collect
+        // positional-arg generators or static suggestions. Mixing them
+        // produces wrong candidates (e.g. for templated flags like
+        // `-r filepaths`, where positional package-name generators would
+        // otherwise leak in alongside the file completions).
         let spec: CompletionSpec = serde_json::from_str(
             r#"{
                 "name": "pip",

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1009,76 +1009,104 @@ fn validate_arg_generators(arg_spec: &mut ArgSpec, spec_name: &str, warnings: &m
 
 /// Approximate heap bytes owned by `spec`.
 ///
-/// Sums `capacity()` for every heap-allocated `String` and `Vec` in the spec
-/// tree. Uses capacities (not lengths) because that's what the allocator
-/// reserved — a String that grew to capacity 64 but only has 12 bytes of
-/// content still holds 64 bytes of heap. This is the right unit for memory
-/// budget regression tests.
+/// Sums `len()` for every heap-allocated `String` and `capacity()` for every
+/// `Vec` in the spec tree. Length (not capacity) is the stable proxy for
+/// content size — capacities vary by allocator and serde's internal
+/// `String::reserve` calls, which would make the metric noisy across runs.
+/// For regression detection, content size is the right signal.
 ///
 /// The walk is iterative to avoid recursion-depth issues on deeply nested
 /// specs. Accuracy is approximate; the goal is a stable number that detects
 /// large regressions, not a byte-perfect heap profiler reading.
+// `pub` (not `pub(crate)`) is required because the criterion bench is a
+// separate compilation unit linked against the gc-suggest cdylib boundary.
 pub fn estimated_heap_bytes(spec: &CompletionSpec) -> usize {
-    fn string_heap(s: &str) -> usize {
-        s.len() // capacity not available on &str; use len as proxy for owned strings
-    }
+    use crate::transform::{ParameterizedTransform, Transform};
+
     fn opt_string_heap(s: &Option<String>) -> usize {
-        s.as_deref().map(string_heap).unwrap_or(0)
+        s.as_deref().map(str::len).unwrap_or(0)
+    }
+    fn transform_heap(t: &Transform) -> usize {
+        match t {
+            // Named transforms carry no heap-owned strings (they're Copy enums).
+            Transform::Named(_) => 0,
+            Transform::Parameterized(p) => match p {
+                ParameterizedTransform::SplitOn { delimiter } => delimiter.len(),
+                ParameterizedTransform::ErrorGuard {
+                    starts_with,
+                    contains,
+                } => opt_string_heap(starts_with) + opt_string_heap(contains),
+                ParameterizedTransform::Suffix { value } => value.len(),
+                ParameterizedTransform::JsonExtractArray { split_on, .. } => {
+                    opt_string_heap(split_on)
+                }
+                // Skip the compiled regex (not heap-walkable cleanly) and
+                // JsonPath/usize-only variants (heap is negligible or
+                // structurally fixed).
+                ParameterizedTransform::Skip { .. }
+                | ParameterizedTransform::Take { .. }
+                | ParameterizedTransform::RegexExtract { .. }
+                | ParameterizedTransform::JsonExtract { .. }
+                | ParameterizedTransform::ColumnExtract { .. } => 0,
+            },
+        }
     }
     fn suggestion_entry_heap(entry: &SuggestionEntry) -> usize {
         match entry {
-            SuggestionEntry::Plain(s) => s.capacity(),
+            SuggestionEntry::Plain(s) => s.len(),
             SuggestionEntry::Object(obj) => {
-                let names: usize = obj.name.iter().map(|n| n.capacity()).sum();
+                let names: usize = obj.name.iter().map(|n| n.len()).sum();
                 let names_vec = obj.name.capacity() * std::mem::size_of::<String>();
-                let desc = obj.description.as_ref().map(|s| s.capacity()).unwrap_or(0);
-                let kind = obj.kind.as_ref().map(|s| s.capacity()).unwrap_or(0);
+                let desc = opt_string_heap(&obj.description);
+                let kind = opt_string_heap(&obj.kind);
                 names + names_vec + desc + kind
             }
         }
     }
+    fn generator_heap(g: &GeneratorSpec) -> usize {
+        let gt = opt_string_heap(&g.generator_type);
+        let script: usize = g
+            .script
+            .as_ref()
+            .map(|v| {
+                v.capacity() * std::mem::size_of::<String>()
+                    + v.iter().map(|s| s.len()).sum::<usize>()
+            })
+            .unwrap_or(0);
+        let script_tmpl: usize = g
+            .script_template
+            .as_ref()
+            .map(|v| {
+                v.capacity() * std::mem::size_of::<String>()
+                    + v.iter().map(|s| s.len()).sum::<usize>()
+            })
+            .unwrap_or(0);
+        // 180 specs carry inline JS source; this is the largest single field.
+        let js = opt_string_heap(&g.js_source);
+        let tmpl = opt_string_heap(&g.template);
+        let transforms_vec = g.transforms.capacity() * std::mem::size_of::<Transform>();
+        let transforms_inner: usize = g.transforms.iter().map(transform_heap).sum();
+        gt + script + script_tmpl + js + tmpl + transforms_vec + transforms_inner
+    }
     fn arg_spec_heap(arg: &ArgSpec) -> usize {
         let name = opt_string_heap(&arg.name);
         let desc = opt_string_heap(&arg.description);
-        let gens = arg.generators.capacity() * std::mem::size_of::<GeneratorSpec>()
-            + arg
-                .generators
-                .iter()
-                .map(|g| {
-                    let gt = g.generator_type.as_ref().map(|s| s.capacity()).unwrap_or(0);
-                    let script: usize = g
-                        .script
-                        .as_ref()
-                        .map(|v| {
-                            v.capacity() * std::mem::size_of::<String>()
-                                + v.iter().map(|s| s.capacity()).sum::<usize>()
-                        })
-                        .unwrap_or(0);
-                    let script_tmpl: usize = g
-                        .script_template
-                        .as_ref()
-                        .map(|v| {
-                            v.capacity() * std::mem::size_of::<String>()
-                                + v.iter().map(|s| s.capacity()).sum::<usize>()
-                        })
-                        .unwrap_or(0);
-                    gt + script + script_tmpl
-                })
-                .sum::<usize>();
-        let tmpl = arg.template.as_ref().map(|s| s.capacity()).unwrap_or(0);
+        let gens_vec = arg.generators.capacity() * std::mem::size_of::<GeneratorSpec>();
+        let gens: usize = arg.generators.iter().map(generator_heap).sum();
+        let tmpl = opt_string_heap(&arg.template);
         let sugg_vec = arg.suggestions.capacity() * std::mem::size_of::<SuggestionEntry>();
         let sugg: usize = arg.suggestions.iter().map(suggestion_entry_heap).sum();
-        name + desc + gens + tmpl + sugg_vec + sugg
+        name + desc + gens_vec + gens + tmpl + sugg_vec + sugg
     }
     fn option_spec_heap(opt: &OptionSpec) -> usize {
-        let names: usize = opt.name.iter().map(|n| n.capacity()).sum();
+        let names: usize = opt.name.iter().map(|n| n.len()).sum();
         let names_vec = opt.name.capacity() * std::mem::size_of::<String>();
         let desc = opt_string_heap(&opt.description);
         let args = opt.args.as_ref().map(arg_spec_heap).unwrap_or(0);
         names + names_vec + desc + args
     }
 
-    let mut total = spec.name.capacity()
+    let mut total = spec.name.len()
         + opt_string_heap(&spec.description)
         + spec.args.capacity() * std::mem::size_of::<ArgSpec>()
         + spec.args.iter().map(arg_spec_heap).sum::<usize>()
@@ -1089,7 +1117,7 @@ pub fn estimated_heap_bytes(spec: &CompletionSpec) -> usize {
     // Walk subcommands iteratively
     let mut stack: Vec<&SubcommandSpec> = spec.subcommands.iter().collect();
     while let Some(sub) = stack.pop() {
-        total += sub.name.capacity();
+        total += sub.name.len();
         total += opt_string_heap(&sub.description);
         total += sub.args.capacity() * std::mem::size_of::<ArgSpec>();
         total += sub.args.iter().map(arg_spec_heap).sum::<usize>();
@@ -2734,6 +2762,12 @@ mod tests {
 
     #[test]
     fn embedded_specs_under_memory_budget() {
+        // Measured baseline: ~37.5 MB (37,536,540 bytes) on 709 specs as of
+        // v0.10.0 (2026-04-28). SPEC §Memory budget estimated 8 MB for
+        // suggestions alone; the full CompletionSpec tree walk is much larger
+        // because it covers js_source, transforms, descriptions, etc. across
+        // all 709 specs. 64 MiB (67,108,864 bytes) gives ~1.78x headroom for
+        // spec corpus growth before requiring a deliberate budget raise.
         const BUDGET_BYTES: usize = 64 * 1024 * 1024;
         let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
         let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -129,9 +129,22 @@ fn sanitize_opt(text: &mut Option<String>) {
     }
 }
 
+fn sanitize_suggestion_object(obj: &mut SuggestionObject) {
+    sanitize_opt(&mut obj.description);
+    for n in &mut obj.name {
+        sanitize_string(n);
+    }
+}
+
 fn sanitize_arg_spec(arg: &mut ArgSpec) {
     sanitize_opt(&mut arg.name);
     sanitize_opt(&mut arg.description);
+    for entry in &mut arg.suggestions {
+        match entry {
+            SuggestionEntry::Plain(s) => sanitize_string(s),
+            SuggestionEntry::Object(obj) => sanitize_suggestion_object(obj),
+        }
+    }
 }
 
 fn sanitize_option_spec(opt: &mut OptionSpec) {
@@ -2271,6 +2284,31 @@ mod tests {
                 assert_eq!(o.description.as_deref(), Some("d"));
             }
             _ => panic!("expected Object"),
+        }
+    }
+
+    #[test]
+    fn sanitize_strips_control_chars_in_suggestion_name() {
+        // The JSON uses \u001b (the valid JSON unicode escape for ESC = 0x1B).
+        // serde_json parses \u001b into an actual ESC byte inside the Rust
+        // String; sanitize_string then strips it because ESC is a control char.
+        //   "ev\u001bil"  -> parsed as "ev\x1bil" -> sanitized to "evil"
+        //   "d\u001b"     -> parsed as "d\x1b"    -> sanitized to "d"
+        //   "pl\u001bain" -> parsed as "pl\x1bain"-> sanitized to "plain"
+        let json = "{\"name\":\"x\",\"args\":{\"name\":\"y\",\"suggestions\":[{\"name\":\"ev\\u001bil\",\"description\":\"d\\u001b\"},\"pl\\u001bain\"]}}";
+        let mut spec = parse_spec_checked_and_sanitized(json).unwrap();
+        let _ = validate_spec_generators(&mut spec);
+        let arg = &spec.args[0];
+        match &arg.suggestions[0] {
+            SuggestionEntry::Object(o) => {
+                assert_eq!(o.name[0], "evil");
+                assert_eq!(o.description.as_deref(), Some("d"));
+            }
+            _ => panic!("expected Object"),
+        }
+        match &arg.suggestions[1] {
+            SuggestionEntry::Plain(s) => assert_eq!(s, "plain"),
+            _ => panic!("expected Plain"),
         }
     }
 }

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -740,9 +740,33 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
     }
 }
 
+/// Map Fig `Suggestion.type` strings to `SuggestionKind`.
+/// Per SPEC.md §"type mapping": subcommand/option/file/folder map to their
+/// equivalents; "arg", "special", "shortcut", "mixin", "auto-execute", and
+/// missing/unknown all fall back to `EnumValue`. Unknown strings emit a
+/// warning via `tracing` so misconfigured specs surface but don't break
+/// loading.
+fn suggestion_kind_from_type(s: Option<&str>) -> SuggestionKind {
+    match s {
+        Some("subcommand") => SuggestionKind::Subcommand,
+        Some("option") => SuggestionKind::Flag,
+        Some("file") => SuggestionKind::FilePath,
+        Some("folder") => SuggestionKind::Directory,
+        Some("arg") | Some("special") | Some("shortcut") | Some("mixin") | Some("auto-execute")
+        | None => SuggestionKind::EnumValue,
+        Some(other) => {
+            tracing::warn!(
+                suggestion_type = %other,
+                "unknown Fig suggestion `type`; falling back to EnumValue"
+            );
+            SuggestionKind::EnumValue
+        }
+    }
+}
+
 /// Lift static `SuggestionEntry` values into ranked-pool `Suggestion`s.
 /// Plain strings become `EnumValue`; objects use their declared `type` →
-/// `SuggestionKind` mapping (Step 12 refines via `suggestion_kind_from_type`).
+/// `SuggestionKind` mapping via `suggestion_kind_from_type`.
 /// Aliases in `name: ["a", "b"]` emit one `Suggestion` per alias (no dedup —
 /// `nucleo` handles duplicates transparently).
 fn collect_static_suggestions(entries: &[SuggestionEntry], out: &mut Vec<Suggestion>) {
@@ -759,11 +783,12 @@ fn collect_static_suggestions(entries: &[SuggestionEntry], out: &mut Vec<Suggest
                 });
             }
             SuggestionEntry::Object(obj) => {
+                let kind = suggestion_kind_from_type(obj.kind.as_deref());
                 for name in &obj.name {
                     out.push(Suggestion {
                         text: name.clone(),
                         description: obj.description.clone(),
-                        kind: SuggestionKind::EnumValue, // Step 12 will refine via obj.kind
+                        kind,
                         source: SuggestionSource::Spec,
                         priority: obj.priority,
                         ..Default::default()

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -549,6 +549,11 @@ pub fn parse_spec_checked_and_sanitized(contents: &str) -> Result<CompletionSpec
 pub struct SpecResolution {
     pub subcommands: Vec<Suggestion>,
     pub options: Vec<Suggestion>,
+    /// Static enum-like suggestions from `args.suggestions` blocks at the
+    /// resolved arg position. Populated by `collect_static_suggestions`.
+    /// Surfaces via the engine candidate set unconditionally — these are
+    /// values, not commands, so suppression flags do NOT apply.
+    pub static_suggestions: Vec<Suggestion>,
     pub native_generators: Vec<String>,
     /// Native providers resolved from the spec (e.g.
     /// `arduino_cli_boards`). The engine dispatches these asynchronously
@@ -670,6 +675,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
     let mut script_generators = Vec::new();
     let mut wants_filepaths = false;
     let mut wants_folders_only = false;
+    let mut static_suggestions: Vec<Suggestion> = Vec::new();
 
     // If the preceding token was a flag that takes an argument, check
     // the option's arg spec for templates/generators instead of the
@@ -692,6 +698,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
                     &mut wants_filepaths,
                     &mut wants_folders_only,
                 );
+                collect_static_suggestions(&arg_spec.suggestions, &mut static_suggestions);
                 match arg_spec.template.as_deref() {
                     Some("filepaths") => wants_filepaths = true,
                     Some("folders") => wants_folders_only = true,
@@ -711,6 +718,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
             &mut wants_filepaths,
             &mut wants_folders_only,
         );
+        collect_static_suggestions(&arg_spec.suggestions, &mut static_suggestions);
         match arg_spec.template.as_deref() {
             Some("filepaths") => wants_filepaths = true,
             Some("folders") => wants_folders_only = true,
@@ -721,6 +729,7 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
     SpecResolution {
         subcommands: subcommand_suggestions,
         options: option_suggestions,
+        static_suggestions,
         native_generators,
         provider_generators,
         script_generators,
@@ -728,6 +737,40 @@ pub fn resolve_spec(spec: &CompletionSpec, ctx: &CommandContext) -> SpecResoluti
         wants_folders_only,
         preceding_flag_has_args,
         past_double_dash: past_positional && ctx.args.iter().any(|a| a == "--"),
+    }
+}
+
+/// Lift static `SuggestionEntry` values into ranked-pool `Suggestion`s.
+/// Plain strings become `EnumValue`; objects use their declared `type` →
+/// `SuggestionKind` mapping (Step 12 refines via `suggestion_kind_from_type`).
+/// Aliases in `name: ["a", "b"]` emit one `Suggestion` per alias (no dedup —
+/// `nucleo` handles duplicates transparently).
+fn collect_static_suggestions(entries: &[SuggestionEntry], out: &mut Vec<Suggestion>) {
+    for entry in entries {
+        match entry {
+            SuggestionEntry::Plain(text) => {
+                out.push(Suggestion {
+                    text: text.clone(),
+                    description: None,
+                    kind: SuggestionKind::EnumValue,
+                    source: SuggestionSource::Spec,
+                    priority: None,
+                    ..Default::default()
+                });
+            }
+            SuggestionEntry::Object(obj) => {
+                for name in &obj.name {
+                    out.push(Suggestion {
+                        text: name.clone(),
+                        description: obj.description.clone(),
+                        kind: SuggestionKind::EnumValue, // Step 12 will refine via obj.kind
+                        source: SuggestionSource::Spec,
+                        priority: obj.priority,
+                        ..Default::default()
+                    });
+                }
+            }
+        }
     }
 }
 
@@ -2428,8 +2471,9 @@ mod tests {
     #[test]
     fn test_resolve_static_suggestions_positional() {
         let spec: CompletionSpec = serde_json::from_str(
-            r#"{"name":"foo","args":[{"name":"fmt","suggestions":["a","b"]}]}"#
-        ).unwrap();
+            r#"{"name":"foo","args":[{"name":"fmt","suggestions":["a","b"]}]}"#,
+        )
+        .unwrap();
         let ctx = CommandContext {
             command: Some("foo".into()),
             args: vec![],
@@ -2445,10 +2489,20 @@ mod tests {
         };
         let res = resolve_spec(&spec, &ctx);
         assert_eq!(res.static_suggestions.len(), 2);
-        let texts: Vec<&str> = res.static_suggestions.iter().map(|s| s.text.as_str()).collect();
+        let texts: Vec<&str> = res
+            .static_suggestions
+            .iter()
+            .map(|s| s.text.as_str())
+            .collect();
         assert!(texts.contains(&"a"));
         assert!(texts.contains(&"b"));
-        assert!(res.static_suggestions.iter().all(|s| s.kind == crate::types::SuggestionKind::EnumValue));
-        assert!(res.static_suggestions.iter().all(|s| s.source == crate::types::SuggestionSource::Spec));
+        assert!(res
+            .static_suggestions
+            .iter()
+            .all(|s| s.kind == crate::types::SuggestionKind::EnumValue));
+        assert!(res
+            .static_suggestions
+            .iter()
+            .all(|s| s.source == crate::types::SuggestionSource::Spec));
     }
 }

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1007,6 +1007,101 @@ fn validate_arg_generators(arg_spec: &mut ArgSpec, spec_name: &str, warnings: &m
     }
 }
 
+/// Approximate heap bytes owned by `spec`.
+///
+/// Sums `capacity()` for every heap-allocated `String` and `Vec` in the spec
+/// tree. Uses capacities (not lengths) because that's what the allocator
+/// reserved — a String that grew to capacity 64 but only has 12 bytes of
+/// content still holds 64 bytes of heap. This is the right unit for memory
+/// budget regression tests.
+///
+/// The walk is iterative to avoid recursion-depth issues on deeply nested
+/// specs. Accuracy is approximate; the goal is a stable number that detects
+/// large regressions, not a byte-perfect heap profiler reading.
+pub fn estimated_heap_bytes(spec: &CompletionSpec) -> usize {
+    fn string_heap(s: &str) -> usize {
+        s.len() // capacity not available on &str; use len as proxy for owned strings
+    }
+    fn opt_string_heap(s: &Option<String>) -> usize {
+        s.as_deref().map(string_heap).unwrap_or(0)
+    }
+    fn suggestion_entry_heap(entry: &SuggestionEntry) -> usize {
+        match entry {
+            SuggestionEntry::Plain(s) => s.capacity(),
+            SuggestionEntry::Object(obj) => {
+                let names: usize = obj.name.iter().map(|n| n.capacity()).sum();
+                let names_vec = obj.name.capacity() * std::mem::size_of::<String>();
+                let desc = obj.description.as_ref().map(|s| s.capacity()).unwrap_or(0);
+                let kind = obj.kind.as_ref().map(|s| s.capacity()).unwrap_or(0);
+                names + names_vec + desc + kind
+            }
+        }
+    }
+    fn arg_spec_heap(arg: &ArgSpec) -> usize {
+        let name = opt_string_heap(&arg.name);
+        let desc = opt_string_heap(&arg.description);
+        let gens = arg.generators.capacity() * std::mem::size_of::<GeneratorSpec>()
+            + arg
+                .generators
+                .iter()
+                .map(|g| {
+                    let gt = g.generator_type.as_ref().map(|s| s.capacity()).unwrap_or(0);
+                    let script: usize = g
+                        .script
+                        .as_ref()
+                        .map(|v| {
+                            v.capacity() * std::mem::size_of::<String>()
+                                + v.iter().map(|s| s.capacity()).sum::<usize>()
+                        })
+                        .unwrap_or(0);
+                    let script_tmpl: usize = g
+                        .script_template
+                        .as_ref()
+                        .map(|v| {
+                            v.capacity() * std::mem::size_of::<String>()
+                                + v.iter().map(|s| s.capacity()).sum::<usize>()
+                        })
+                        .unwrap_or(0);
+                    gt + script + script_tmpl
+                })
+                .sum::<usize>();
+        let tmpl = arg.template.as_ref().map(|s| s.capacity()).unwrap_or(0);
+        let sugg_vec = arg.suggestions.capacity() * std::mem::size_of::<SuggestionEntry>();
+        let sugg: usize = arg.suggestions.iter().map(suggestion_entry_heap).sum();
+        name + desc + gens + tmpl + sugg_vec + sugg
+    }
+    fn option_spec_heap(opt: &OptionSpec) -> usize {
+        let names: usize = opt.name.iter().map(|n| n.capacity()).sum();
+        let names_vec = opt.name.capacity() * std::mem::size_of::<String>();
+        let desc = opt_string_heap(&opt.description);
+        let args = opt.args.as_ref().map(arg_spec_heap).unwrap_or(0);
+        names + names_vec + desc + args
+    }
+
+    let mut total = spec.name.capacity()
+        + opt_string_heap(&spec.description)
+        + spec.args.capacity() * std::mem::size_of::<ArgSpec>()
+        + spec.args.iter().map(arg_spec_heap).sum::<usize>()
+        + spec.options.capacity() * std::mem::size_of::<OptionSpec>()
+        + spec.options.iter().map(option_spec_heap).sum::<usize>()
+        + spec.subcommands.capacity() * std::mem::size_of::<SubcommandSpec>();
+
+    // Walk subcommands iteratively
+    let mut stack: Vec<&SubcommandSpec> = spec.subcommands.iter().collect();
+    while let Some(sub) = stack.pop() {
+        total += sub.name.capacity();
+        total += opt_string_heap(&sub.description);
+        total += sub.args.capacity() * std::mem::size_of::<ArgSpec>();
+        total += sub.args.iter().map(arg_spec_heap).sum::<usize>();
+        total += sub.options.capacity() * std::mem::size_of::<OptionSpec>();
+        total += sub.options.iter().map(option_spec_heap).sum::<usize>();
+        total += sub.subcommands.capacity() * std::mem::size_of::<SubcommandSpec>();
+        stack.extend(sub.subcommands.iter());
+    }
+
+    total
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2634,6 +2729,25 @@ mod tests {
             spec.args[0].suggestions.len(),
             2,
             "unknown-type entry should NOT be dropped"
+        );
+    }
+
+    #[test]
+    fn embedded_specs_under_memory_budget() {
+        const BUDGET_BYTES: usize = 64 * 1024 * 1024;
+        let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
+        let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;
+        let total: usize = store.iter().map(|(_, s)| estimated_heap_bytes(s)).sum();
+        assert!(
+            total < BUDGET_BYTES,
+            "embedded specs heap {} bytes exceeds budget {} bytes — investigate before raising the limit",
+            total,
+            BUDGET_BYTES
+        );
+        eprintln!(
+            "INFO: embedded specs estimated heap: {} bytes ({} KB)",
+            total,
+            total / 1024
         );
     }
 }

--- a/crates/gc-suggest/src/types.rs
+++ b/crates/gc-suggest/src/types.rs
@@ -20,8 +20,9 @@ pub enum SuggestionKind {
     /// values with the same text from a different provider.
     ProviderValue,
     /// Static enum-style value declared in `args.suggestions` inside a spec.
-    /// Sits between `Subcommand` (70) and `Flag` (30) so enum values surface
-    /// above flag completions but below subcommands and dynamic provider results.
+    /// Sits between `Subcommand`/`ProviderValue` (70) and `Command` (40) so enum
+    /// values surface above generic commands and flags but below subcommands and
+    /// dynamic provider results.
     EnumValue,
 }
 

--- a/crates/gc-suggest/src/types.rs
+++ b/crates/gc-suggest/src/types.rs
@@ -19,6 +19,10 @@ pub enum SuggestionKind {
     /// bucket so accepting one provider's value does not boost unrelated
     /// values with the same text from a different provider.
     ProviderValue,
+    /// Static enum-style value declared in `args.suggestions` inside a spec.
+    /// Sits between `Subcommand` (70) and `Flag` (30) so enum values surface
+    /// above flag completions but below subcommands and dynamic provider results.
+    EnumValue,
 }
 
 impl SuggestionKind {
@@ -37,6 +41,7 @@ impl SuggestionKind {
             Self::History => "hist",
             Self::EnvVar => "env",
             Self::ProviderValue => "provider",
+            Self::EnumValue => "enum",
         }
     }
 
@@ -53,6 +58,7 @@ impl SuggestionKind {
             Self::ProviderValue => 70,
             Self::EnvVar => 50,
             Self::Command => 40,
+            Self::EnumValue => 65,
             Self::Flag => 30,
             Self::Directory => 25,
             Self::FilePath => 20,
@@ -134,5 +140,11 @@ mod kind_invariants {
     fn suggestion_priority_defaults_to_none() {
         let s = Suggestion::default();
         assert_eq!(s.priority, None);
+    }
+
+    #[test]
+    fn enum_value_contract() {
+        assert_eq!(SuggestionKind::EnumValue.key_tag(), "enum");
+        assert_eq!(SuggestionKind::EnumValue.base_priority().get(), 65);
     }
 }

--- a/crates/gc-suggest/src/types.rs
+++ b/crates/gc-suggest/src/types.rs
@@ -20,9 +20,9 @@ pub enum SuggestionKind {
     /// values with the same text from a different provider.
     ProviderValue,
     /// Static enum-style value declared in `args.suggestions` inside a spec.
-    /// Sits between `Subcommand`/`ProviderValue` (70) and `Command` (40) so enum
-    /// values surface above generic commands and flags but below subcommands and
-    /// dynamic provider results.
+    /// Sits between `Subcommand`/`ProviderValue` (70) and `EnvVar` (50) so enum
+    /// values surface above environment variables, generic $PATH commands, and
+    /// flags but below subcommands and dynamic provider results.
     EnumValue,
 }
 

--- a/crates/gc-suggest/tests/static_suggestions_proptest.proptest-regressions
+++ b/crates/gc-suggest/tests/static_suggestions_proptest.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc be8697c1e6e4efb1688578abb2e6e1f1e7d6b4f5bb1b45d7a40d37083a9fdcd2 # shrinks to entries = [ObjectEntry { names: ["g"], priority: None, hidden: false }, ObjectEntry { names: ["g"], priority: None, hidden: true }]

--- a/crates/gc-suggest/tests/static_suggestions_proptest.rs
+++ b/crates/gc-suggest/tests/static_suggestions_proptest.rs
@@ -1,4 +1,5 @@
 use gc_buffer::{CommandContext, QuoteState};
+use gc_suggest::priority::Priority;
 use gc_suggest::specs::{parse_spec_checked_and_sanitized, resolve_spec, validate_spec_generators};
 use proptest::prelude::*;
 
@@ -106,6 +107,139 @@ proptest! {
         let res = resolve_spec(&spec, &ctx);
         for s in &res.static_suggestions {
             prop_assert!(!s.text.is_empty(), "static suggestion has empty text: {:?}", s);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ObjectEntry {
+    names: Vec<String>,
+    priority: Option<i32>,
+    hidden: bool,
+}
+
+fn arb_typed_object_entry() -> impl Strategy<Value = ObjectEntry> {
+    (
+        prop::collection::vec("[a-zA-Z][a-zA-Z0-9]{0,8}", 1..=3),
+        prop::option::of(0i32..=100),
+        any::<bool>(),
+    )
+        .prop_map(|(names, priority, hidden)| ObjectEntry {
+            names,
+            priority,
+            hidden,
+        })
+}
+
+fn object_entry_to_json(e: &ObjectEntry) -> serde_json::Value {
+    let mut m = serde_json::Map::new();
+    m.insert(
+        "name".to_string(),
+        serde_json::Value::Array(
+            e.names
+                .iter()
+                .cloned()
+                .map(serde_json::Value::String)
+                .collect(),
+        ),
+    );
+    if let Some(p) = e.priority {
+        m.insert(
+            "priority".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(p)),
+        );
+    }
+    m.insert("hidden".to_string(), serde_json::Value::Bool(e.hidden));
+    serde_json::Value::Object(m)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..Default::default() })]
+
+    #[test]
+    fn hidden_entries_pruned_and_priority_round_trips(
+        entries in prop::collection::vec(arb_typed_object_entry(), 0..=8)
+    ) {
+        let entries_json = serde_json::Value::Array(
+            entries.iter().map(object_entry_to_json).collect(),
+        );
+        let spec_json = serde_json::json!({
+            "name": "fakecmd",
+            "args": [{
+                "name": "x",
+                "suggestions": entries_json,
+            }],
+        })
+        .to_string();
+
+        let mut spec = match parse_spec_checked_and_sanitized(&spec_json) {
+            Ok(s) => s,
+            Err(_) => return Ok(()),
+        };
+        let _warnings = validate_spec_generators(&mut spec);
+
+        let ctx = CommandContext {
+            command: Some("fakecmd".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+
+        let visible_names: std::collections::HashSet<&str> = entries
+            .iter()
+            .filter(|e| !e.hidden)
+            .flat_map(|e| e.names.iter().map(String::as_str))
+            .collect();
+        let exclusively_hidden: std::collections::HashSet<&str> = entries
+            .iter()
+            .filter(|e| e.hidden)
+            .flat_map(|e| e.names.iter().map(String::as_str))
+            .filter(|n| !visible_names.contains(n))
+            .collect();
+        for s in &res.static_suggestions {
+            prop_assert!(
+                !exclusively_hidden.contains(s.text.as_str()),
+                "hidden entry leaked into static_suggestions: {:?}",
+                s,
+            );
+        }
+
+        let mut expected_priorities: std::collections::HashMap<&str, Vec<Option<Priority>>> =
+            std::collections::HashMap::new();
+        for e in &entries {
+            if e.hidden {
+                continue;
+            }
+            let p = e
+                .priority
+                .map(|raw| Priority::new(raw.clamp(0, 100) as u8));
+            for n in &e.names {
+                expected_priorities.entry(n.as_str()).or_default().push(p);
+            }
+        }
+        for s in &res.static_suggestions {
+            let allowed = expected_priorities.get(s.text.as_str());
+            prop_assert!(
+                allowed.is_some(),
+                "emitted suggestion {:?} did not originate from any non-hidden input entry",
+                s.text,
+            );
+            let allowed = allowed.unwrap();
+            prop_assert!(
+                allowed.contains(&s.priority),
+                "priority {:?} for {:?} not among expected {:?}",
+                s.priority,
+                s.text,
+                allowed,
+            );
         }
     }
 }

--- a/crates/gc-suggest/tests/static_suggestions_proptest.rs
+++ b/crates/gc-suggest/tests/static_suggestions_proptest.rs
@@ -48,10 +48,21 @@ fn arb_object_entry() -> impl Strategy<Value = serde_json::Value> {
         })
 }
 
+fn arb_dirty_plain() -> impl Strategy<Value = serde_json::Value> {
+    prop_oneof![
+        Just(serde_json::Value::String("\u{001b}[31mred".to_string())),
+        Just(serde_json::Value::String("tab\there".to_string())),
+        // whitespace-only → empty-name pruning
+        Just(serde_json::Value::String("   ".to_string())),
+        Just(serde_json::Value::String("\u{0000}null".to_string())),
+    ]
+}
+
 fn arb_entry() -> impl Strategy<Value = serde_json::Value> {
     prop_oneof![
         "[a-zA-Z][a-zA-Z0-9]{0,8}".prop_map(serde_json::Value::String),
         arb_object_entry(),
+        arb_dirty_plain(),
     ]
 }
 

--- a/crates/gc-suggest/tests/static_suggestions_proptest.rs
+++ b/crates/gc-suggest/tests/static_suggestions_proptest.rs
@@ -1,0 +1,100 @@
+use gc_buffer::{CommandContext, QuoteState};
+use gc_suggest::specs::{parse_spec_checked_and_sanitized, resolve_spec, validate_spec_generators};
+use proptest::prelude::*;
+
+fn arb_name_value() -> impl Strategy<Value = serde_json::Value> {
+    prop_oneof![
+        // Single string
+        "[a-zA-Z][a-zA-Z0-9]{0,8}".prop_map(serde_json::Value::String),
+        // Array of 0..3 names
+        prop::collection::vec("[a-zA-Z][a-zA-Z0-9]{0,8}", 0..=3).prop_map(|names| {
+            serde_json::Value::Array(names.into_iter().map(serde_json::Value::String).collect())
+        }),
+    ]
+}
+
+fn arb_object_entry() -> impl Strategy<Value = serde_json::Value> {
+    (
+        arb_name_value(),
+        prop::option::of("[a-zA-Z ]{0,30}"),
+        prop::option::of(prop_oneof![
+            Just("subcommand"),
+            Just("option"),
+            Just("file"),
+            Just("folder"),
+            Just("arg"),
+            Just("made_up"),
+        ]),
+        prop::option::of(0i32..=120),
+        any::<bool>(),
+    )
+        .prop_map(|(name, desc, kind, prio, hidden)| {
+            let mut m = serde_json::Map::new();
+            m.insert("name".to_string(), name);
+            if let Some(d) = desc {
+                m.insert("description".to_string(), serde_json::Value::String(d));
+            }
+            if let Some(k) = kind {
+                m.insert("type".to_string(), serde_json::Value::String(k.to_string()));
+            }
+            if let Some(p) = prio {
+                m.insert(
+                    "priority".to_string(),
+                    serde_json::Value::Number(serde_json::Number::from(p)),
+                );
+            }
+            m.insert("hidden".to_string(), serde_json::Value::Bool(hidden));
+            serde_json::Value::Object(m)
+        })
+}
+
+fn arb_entry() -> impl Strategy<Value = serde_json::Value> {
+    prop_oneof![
+        "[a-zA-Z][a-zA-Z0-9]{0,8}".prop_map(serde_json::Value::String),
+        arb_object_entry(),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..Default::default() })]
+
+    #[test]
+    fn static_suggestion_entries_never_panic_or_emit_empty_text(
+        entries in prop::collection::vec(arb_entry(), 0..=8)
+    ) {
+        let entries_json = serde_json::Value::Array(entries);
+        let spec_json = serde_json::json!({
+            "name": "fakecmd",
+            "args": [{
+                "name": "x",
+                "suggestions": entries_json,
+            }],
+        })
+        .to_string();
+
+        let mut spec = match parse_spec_checked_and_sanitized(&spec_json) {
+            Ok(s) => s,
+            // Some property-generated input may legitimately fail to parse
+            Err(_) => return Ok(()),
+        };
+        let _warnings = validate_spec_generators(&mut spec);
+
+        let ctx = CommandContext {
+            command: Some("fakecmd".into()),
+            args: vec![],
+            current_word: String::new(),
+            word_index: 1,
+            is_flag: false,
+            is_long_flag: false,
+            preceding_flag: None,
+            in_pipe: false,
+            in_redirect: false,
+            quote_state: QuoteState::None,
+            is_first_segment: true,
+        };
+        let res = resolve_spec(&spec, &ctx);
+        for s in &res.static_suggestions {
+            prop_assert!(!s.text.is_empty(), "static suggestion has empty text: {:?}", s);
+        }
+    }
+}

--- a/docs/COMPLETION_SPEC.md
+++ b/docs/COMPLETION_SPEC.md
@@ -87,7 +87,7 @@ Ghost Complete uses a Fig-compatible JSON format for completion specs. Specs def
 | `description` | string | No | Description of the argument |
 | `template` | string | No | Built-in template: `"filepaths"` or `"folders"` |
 | `generators` | GeneratorSpec[] | No | Dynamic generators for values |
-| `suggestions` | SuggestionEntry[] | No | Static enum-like candidates, see below |
+| `suggestions` | SuggestionEntry \| SuggestionEntry[] | No | Static enum-like candidates, see below. Accepts either a single entry or an array; the array form is canonical |
 
 #### Static suggestions
 

--- a/docs/COMPLETION_SPEC.md
+++ b/docs/COMPLETION_SPEC.md
@@ -87,6 +87,49 @@ Ghost Complete uses a Fig-compatible JSON format for completion specs. Specs def
 | `description` | string | No | Description of the argument |
 | `template` | string | No | Built-in template: `"filepaths"` or `"folders"` |
 | `generators` | GeneratorSpec[] | No | Dynamic generators for values |
+| `suggestions` | SuggestionEntry[] | No | Static enum-like candidates, see below |
+
+#### Static suggestions
+
+Specs may declare a fixed list of completion candidates for an arg position via the `suggestions` field. Each entry is either a plain string (shorthand) or a `SuggestionObject` with metadata.
+
+```json
+{
+  "name": "format",
+  "suggestions": [
+    "tar",
+    {
+      "name": ["json", "j"],
+      "description": "JSON output",
+      "type": "arg",
+      "priority": 80,
+      "hidden": false
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Behavior |
+|-------|------|----------|----------|
+| `name` | `string \| string[]` | Yes | Each alias becomes its own ranked candidate |
+| `description` | `string` | No | Forwarded to the candidate's description |
+| `type` | `string` | No | Maps to `SuggestionKind` (see table below). Default: `EnumValue` |
+| `priority` | `0..=100` | No | Per-item priority override |
+| `hidden` | bool | No | When true, entry is dropped at load time |
+
+**`type` mapping:**
+
+| Fig `type` | `SuggestionKind` |
+|------------|------------------|
+| `"subcommand"` | `Subcommand` |
+| `"option"` | `Flag` |
+| `"file"` | `FilePath` |
+| `"folder"` | `Directory` |
+| `"arg"`, `"special"`, `"shortcut"`, `"mixin"`, `"auto-execute"`, missing | `EnumValue` |
+
+Unknown `type` strings emit a load-time warning (visible via `ghost-complete validate-specs`) and fall back to `EnumValue`. Static suggestions surface in the candidate pool *unconditionally* — they are values for an arg slot, not commands, and are not affected by the suppression rules that hide subcommands and options when the user is filling in a flag's argument or has passed `--`.
+
+Mirrors Fig's [`Suggestion`](https://fig.io/api/interfaces/Suggestion) interface (subset). Reserved fields (`insertValue`, `displayName`, `replaceValue`, `icon`, `isDangerous`) are silently ignored by the deserializer; v2 may surface them.
 
 ### GeneratorSpec
 
@@ -308,6 +351,7 @@ value is used. Otherwise the engine falls back to a per-kind base:
 | GitRemote     | 70   |                                                |
 | Subcommand    | 70   |                                                |
 | ProviderValue | 70   | Generator output (npm, docker, kubectl, …)     |
+| EnumValue     | 65   | Static `args.suggestions` enum-like values        |
 | EnvVar        | 50   |                                                |
 | Command       | 40   | `$PATH` binaries                               |
 | Flag          | 30   |                                                |

--- a/docs/adr/0004-static-arg-suggestions.md
+++ b/docs/adr/0004-static-arg-suggestions.md
@@ -65,8 +65,10 @@ surface even when the user is filling a flag argument or past `--`.
   `Value` enum + heap-allocated `Map`/`Number`/`Array` per node) and rejects
   malformed shapes at deserialize time instead of at first-use.
 - **Documented priority slot.** `EnumValue` at 65 is pinned by
-  `priority::base_priorities_are_in_documented_order` and
-  `docs/COMPLETION_SPEC.md`; future drift requires a deliberate test edit.
+  `types::kind_invariants::enum_value_contract` (exact value) and
+  `priority::base_priorities_are_in_documented_order` (relative ordering against
+  neighbours), with `docs/COMPLETION_SPEC.md` as the human-readable reference.
+  Future drift requires a deliberate test edit.
 - **Memory budget gate.** A new test `embedded_specs_under_memory_budget`
   walks the full `CompletionSpec` heap (including `args.suggestions`) and
   asserts the total stays under 64 MiB. Regression detection without external

--- a/docs/adr/0004-static-arg-suggestions.md
+++ b/docs/adr/0004-static-arg-suggestions.md
@@ -1,0 +1,134 @@
+# 0004. Surface static `args.suggestions` at runtime
+
+- **Status:** Accepted
+- **Date:** 2026-04-28
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context
+
+384 of 709 bundled Fig specs (~54%) carry `args.suggestions` arrays — static
+enum-like completions such as `git archive --format=tar|zip`,
+`tar --atime-preserve replace|system`,
+`curl --request GET|POST|PUT|DELETE|...`. Until this change,
+`ArgSpec.suggestions` was deserialized as `Option<serde_json::Value>` and
+discarded at runtime: users typing `git archive --format=` got nothing where
+the spec author had explicitly enumerated the valid options.
+
+The bundled spec corpus already encodes these enumerations — surfacing them is
+purely a runtime gap, not a missing data problem.
+
+## Decision
+
+Replace `ArgSpec.suggestions: Option<serde_json::Value>` with a
+strongly-typed `Vec<SuggestionEntry>`, where:
+
+```rust
+pub enum SuggestionEntry {
+    Plain(String),
+    Object(SuggestionObject),
+}
+pub struct SuggestionObject {
+    pub name: Vec<String>,           // alias array; serde untags string-or-array
+    pub description: Option<String>,
+    pub kind: Option<String>,        // Fig "type" field; mapped to SuggestionKind
+    pub priority: Option<Priority>,
+    pub hidden: bool,
+}
+```
+
+Add `SuggestionKind::EnumValue` at base priority **65**, slotting between
+`Subcommand`/`ProviderValue` (70) and `EnvVar` (50). `key_tag()` returns
+`"enum"` so its frecency bucket is independent — accepting `tar` as a
+`--format` value does not boost `tar` typed elsewhere as a subcommand.
+
+`SpecResolution` gains `static_suggestions: Vec<Suggestion>`. The engine
+appends these to the candidate set **outside** the `suppress_commands` guard:
+static suggestions are values for an arg slot, not commands, so they must
+surface even when the user is filling a flag argument or past `--`.
+
+`validate_arg_generators` runs at load time and:
+- Drops entries where every name is empty/whitespace (with a warning).
+- Drops `hidden: true` entries silently (the spec author's explicit signal).
+- Warns once per spec on unknown `type` strings (no per-keystroke trace flood).
+
+## Consequences
+
+### Positive
+
+- **Spec coverage.** ~54% of bundled specs now contribute completion data they
+  previously withheld. `git archive --format=`, `tar --atime-preserve`,
+  `curl --request`, and similar all surface tab-complete candidates at the
+  right slot.
+- **Strongly-typed deserialization.** Replacing `Option<serde_json::Value>`
+  with `Vec<SuggestionEntry>` is strictly cheaper at parse time (no nested
+  `Value` enum + heap-allocated `Map`/`Number`/`Array` per node) and rejects
+  malformed shapes at deserialize time instead of at first-use.
+- **Documented priority slot.** `EnumValue` at 65 is pinned by
+  `priority::base_priorities_are_in_documented_order` and
+  `docs/COMPLETION_SPEC.md`; future drift requires a deliberate test edit.
+- **Memory budget gate.** A new test `embedded_specs_under_memory_budget`
+  walks the full `CompletionSpec` heap (including `args.suggestions`) and
+  asserts the total stays under 64 MiB. Regression detection without external
+  tooling.
+
+### Negative
+
+- **One enum variant added.** `SuggestionKind` is not `#[non_exhaustive]`, so
+  adding `EnumValue` is a breaking change for any external `match` site over
+  the enum. The internal `kind_icon` match in `gc-overlay::render` was
+  extended in the same change. No public-API consumers exist outside the
+  workspace.
+- **Modest memory increase.** Strongly-typed parsing of the 384 specs with
+  `suggestions` arrays adds ~600 KB to the spec heap. Comfortably under the
+  64 MiB budget.
+- **Plan-deviation: the `if !preceding_flag_has_args` guard.** Wiring static
+  suggestions surfaced a latent bug: `resolve_spec` was unconditionally
+  collecting positional-arg generators even when filling a flag's argument
+  (e.g. `pip install -r ` was mixing `-r`'s filepaths template with pip's
+  positional package-name generators). The guard was added to skip positional
+  collection in that case. Out of scope for the original spec but a strict
+  semantic improvement that test coverage now pins.
+
+### Neutral
+
+- **`insertValue`, `displayName`, `replaceValue`, `icon`, `isDangerous`.**
+  Deserialized but ignored in v1 — the engine has no cursor-positioning
+  insertion API to honor `insertValue`. Tracked separately for v2.
+- **Nested `generators` inside a Suggestion.** Fig's schema allows it; we
+  don't. Tracked as a follow-up if a real spec needs it.
+- **`deprecated` flag.** Entry is kept; no popup styling distinguishes it.
+  Acceptable v1.
+
+## Alternatives considered
+
+- **Defer the feature.** Rejected — ~54% of bundled specs were carrying the
+  data the user already expected to see. Closing the gap was the highest-ratio
+  UX win available without writing any new spec data.
+- **Reuse `SuggestionKind::ProviderValue` instead of adding `EnumValue`.**
+  Rejected. `ProviderValue` is for *dynamic* native-provider output (npm pkg
+  list, kubectl namespaces, etc.). Sharing the bucket would conflate frecency
+  boosts: accepting `tar` as a static `--format` value would boost any
+  *dynamic* provider value with the same string. Separate kind = separate
+  bucket = correct behaviour.
+- **Add a `static_suggestions: bool` flag on `Suggestion` and route through
+  existing kinds.** Rejected. The kind / source / priority dimensions are
+  already three orthogonal axes; adding a fourth would couple the ranker to
+  the source pathway. New variant is the smaller surface change.
+- **Keep `Option<serde_json::Value>` and lazy-parse at resolve time.**
+  Rejected. Resolve runs on every keystroke; lazy-parse would re-deserialize
+  the same `Value` ~hundreds of times during interactive completion.
+  Strongly-typed parse-once is strictly cheaper and rejects malformed input
+  earlier.
+
+## References
+
+- `crates/gc-suggest/src/specs.rs` — `SuggestionEntry`, `SuggestionObject`,
+  `collect_static_suggestions`, validation
+- `crates/gc-suggest/src/types.rs` — `SuggestionKind::EnumValue`, `key_tag`,
+  `base_priority`
+- `crates/gc-suggest/src/engine.rs::try_suggest_from_spec` — unconditional
+  candidate extension
+- `docs/COMPLETION_SPEC.md` — schema documentation + priority table
+- `crates/gc-suggest/tests/static_suggestions_proptest.rs` — invariant fuzzer
+- Fig schema reference: <https://fig.io/api/interfaces/Suggestion>

--- a/docs/adr/0004-static-arg-suggestions.md
+++ b/docs/adr/0004-static-arg-suggestions.md
@@ -94,6 +94,10 @@ surface even when the user is filling a flag argument or past `--`.
 
 ### Neutral
 
+- **Visibility note.** `SuggestionEntry`, `SuggestionObject`, every field on
+  both, and `ArgSpec.suggestions` ship as `pub(crate)` (the Decision block
+  above shows `pub` for schema clarity); the source-level docstrings carry
+  the rationale.
 - **`insertValue`, `displayName`, `replaceValue`, `icon`, `isDangerous`.**
   Deserialized but ignored in v1 — the engine has no cursor-positioning
   insertion API to honor `insertValue`. Tracked separately for v2.


### PR DESCRIPTION
## Summary

- Strongly-typed `Vec<SuggestionEntry>` replaces `Option<serde_json::Value>` for `ArgSpec.suggestions` — ~54% of bundled Fig specs (384/709) carry static enum-like completions that were previously parsed and discarded.
- New `SuggestionKind::EnumValue` at base priority **65**, slotting between `Subcommand`/`ProviderValue` (70) and `EnvVar` (50). Independent frecency bucket (`key_tag = "enum"`).
- Static suggestions surface in the candidate set **unconditionally** — they are arg-position values, not commands, so they appear even when `suppress_commands` is true (`preceding_flag_has_args` or past `--`).
- Empty-name entries pruned with warning at load time; `hidden: true` entries silently dropped; unknown `type` strings warn once at load time and fall back to `EnumValue`.

Acceptance examples now work:
- `git archive --format=` → `tar`, `zip`
- `tar c --atime-preserve ` → `replace`, `system`

## Plan deviation worth flagging

Wiring `static_suggestions` into the engine surfaced a latent bug in `resolve_spec`: positional-arg generators were being collected even when the user was filling a flag's argument (`pip install -r ` was leaking pip's positional package-name generators into the `-r` filepaths slot). Fixed in the same change by guarding positional collection behind `if !preceding_flag_has_args`. Out of scope for the original spec but a strict semantic improvement; covered by existing tests after the fix.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (workspace-wide)
- [x] `cargo test --workspace` — all green (485 in `gc-suggest`, 1234+ workspace-wide, plus a new proptest binary at 256 cases)
- [x] `cargo bench --no-run -p gc-suggest` — bench compiles
- [x] `ghost-complete validate-specs` over the embedded spec set — no NEW failures vs master baseline (6 pre-existing failures: `index.json`, `next.json`, `pnpx.json` — converter issues unrelated to this change)
- [x] Manual integration test: synthetic spec with both `generators: [git_branches]` and `suggestions: ["HEAD"]` confirms static + dynamic coexistence

## SPEC

The plan/spec docs live under `docs/plans/` (gitignored). Inlining the SPEC here for review:

> # Static \`args.suggestions\` Runtime Support — Design Spec
>
> **Status:** Draft  •  **Owner:** silnoreki21345@gmail.com  •  **Date:** 2026-04-27
>
> ## Problem
>
> 384 of 709 bundled Fig specs (~54%) carry \`args.suggestions\` arrays — static enum-like completions such as \`git archive --format=tar|zip\`, \`tar --atime-preserve replace|system\`, \`curl --request GET|POST|...\`. Today the field is parsed as \`Option<serde_json::Value>\` and discarded. Users typing \`git archive --format=\` get nothing where they should get \`tar\`/\`zip\`.
>
> ## Goals
>
> 1. Surface every \`args.suggestions\` entry (positional and option-arg) as a ranked candidate in the popup.
> 2. Honor Fig's \`name | name[]\`, \`description\`, \`type\`, \`priority\`, and \`hidden\` fields.
> 3. Strongly-typed deserializer — replace \`Option<serde_json::Value>\` with a validated \`Vec<SuggestionEntry>\`.
> 4. No regression on \`<50ms\` keystroke target, \`<10MB\` idle memory, or \`~25MB\` binary size.
> 5. Backwards-compatible: malformed \`suggestions\` blocks degrade to "ignored" (warning logged), never break spec loading.
>
> ## Non-Goals (v1)
>
> - \`insertValue\` cursor placement — no cursor-positioning insertion API. Deferred.
> - \`replaceValue\`, \`displayName\`, \`isDangerous\`, \`icon\` — orthogonal to ranking.
> - \`generators\` *inside* a \`Suggestion\` (Fig allows nested) — out of scope.
> - \`deprecated\` styling — entry is kept, not visually marked.
> - Converter changes — \`tools/fig-converter/\` untouched.
>
> ## type → SuggestionKind mapping
>
> | Fig \`type\` | \`SuggestionKind\` |
> | ----------- | ------------------ |
> | \`subcommand\` | Subcommand |
> | \`option\` | Flag |
> | \`file\` | FilePath |
> | \`folder\` | Directory |
> | \`arg\`, \`special\`, \`shortcut\`, \`mixin\`, \`auto-execute\`, missing | EnumValue (new) |
>
> Unknown \`type\` strings warn at load time and fall back to \`EnumValue\`.
>
> ## SuggestionKind extension
>
> Add \`SuggestionKind::EnumValue\` at base **65**. Slots between \`Subcommand\`/\`ProviderValue\` (70) and \`EnvVar\` (50). \`key_tag()\` returns \`"enum"\` (own frecency bucket so \`tar\` selected as a \`tar --atime-preserve\` value does not boost \`tar\` selected as a \`git archive --format\` value).
>
> ## Resolution flow
>
> Engine extends \`candidates\` with \`static_suggestions\` **outside** the \`suppress_commands\` guard — they are values for an arg position, not commands, so they must surface even when subcommands/options are suppressed.
>
> ## Acceptance
>
> - [x] \`git archive --format=\` shows \`tar\`, \`zip\` in popup.
> - [x] \`tar --atime-preserve \` shows \`replace\`, \`system\`.
> - [x] All existing benchmarks compile (workspace runs clean).
> - [x] Memory budget bench passes (~37.5 MB measured / 64 MiB cap).
> - [x] All 1412+ specs reload without new warnings beyond the pre-existing 6-spec baseline.
> - [x] Doc deltas reviewed: \`docs/COMPLETION_SPEC.md\`, \`docs/adr/0004-static-arg-suggestions.md\`, \`CHANGELOG.md\`.

## Files of interest

- \`crates/gc-suggest/src/specs.rs\` — \`SuggestionEntry\`, \`SuggestionObject\`, \`collect_static_suggestions\`, validation, \`estimated_heap_bytes\`, \`embedded_specs_under_memory_budget\` test
- \`crates/gc-suggest/src/types.rs\` — \`SuggestionKind::EnumValue\` + invariants test
- \`crates/gc-suggest/src/engine.rs\` — unconditional \`candidates.extend(static_suggestions)\`
- \`crates/gc-overlay/src/render.rs\` — \`kind_icon\` arm for \`EnumValue\`
- \`crates/gc-suggest/tests/static_suggestions_proptest.rs\` — proptest harness (256 cases)
- \`docs/adr/0004-static-arg-suggestions.md\` — full decision rationale