### PR TITLE
feat: add async suggestion feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,7 @@ name = "gc-overlay"
 version = "0.10.0"
 dependencies = [
  "anyhow",
+ "criterion",
  "gc-suggest",
  "gc-terminal",
  "unicode-width",

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -1142,8 +1142,6 @@ max_visible = 5
 
     #[test]
     fn test_feedback_dismiss_ms_zero_is_allowed() {
-        // feedback_dismiss_ms=0 disables auto-dismiss of the feedback popup —
-        // still a valid choice, so it must pass through untouched.
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nfeedback_dismiss_ms = 0").unwrap();
         let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -97,9 +97,7 @@ impl Default for TriggerConfig {
 pub struct PopupConfig {
     pub max_visible: usize,
     pub borders: bool,
-    /// How long terminal Empty/Error feedback remains visible before the
-    /// popup auto-dismisses. `0` disables auto-dismiss. Clamped to
-    /// `[0, 10000]` during normalization. Default: 1200 ms.
+    /// Empty/Error feedback dismiss delay (ms); 0 disables. Clamped to [0, 10000]. Default 1200.
     pub feedback_dismiss_ms: u16,
     /// Whether Loading feedback animates with a spinner. Narrow popups still
     /// fall back to a static ellipsis. Default: true.

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -99,11 +99,9 @@ pub struct PopupConfig {
     pub borders: bool,
     /// Empty/Error feedback dismiss delay (ms); 0 disables. Clamped to [0, 10000]. Default 1200.
     pub feedback_dismiss_ms: u16,
-    /// Whether Loading feedback animates with a spinner. Narrow popups still
-    /// fall back to a static ellipsis. Default: true.
+    /// Animate Loading feedback with a spinner; narrow popups fall back to ellipsis. Default true.
     pub spinner: bool,
-    /// Whether provider names are shown in error feedback. Default: false to
-    /// avoid leaking command/provider names on shared screens.
+    /// Show provider names in error feedback; default false to avoid leaking on shared screens.
     pub show_provider_errors: bool,
     /// Maximum time (ms) the popup will block waiting for a higher-priority
     /// async generator before painting whatever sync results we have. Set

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -97,6 +97,16 @@ impl Default for TriggerConfig {
 pub struct PopupConfig {
     pub max_visible: usize,
     pub borders: bool,
+    /// How long terminal Empty/Error feedback remains visible before the
+    /// popup auto-dismisses. `0` disables auto-dismiss. Clamped to
+    /// `[0, 10000]` during normalization. Default: 1200 ms.
+    pub feedback_dismiss_ms: u16,
+    /// Whether Loading feedback animates with a spinner. Narrow popups still
+    /// fall back to a static ellipsis. Default: true.
+    pub spinner: bool,
+    /// Whether provider names are shown in error feedback. Default: false to
+    /// avoid leaking command/provider names on shared screens.
+    pub show_provider_errors: bool,
     /// Maximum time (ms) the popup will block waiting for a higher-priority
     /// async generator before painting whatever sync results we have. Set
     /// to `0` to disable blocking entirely (paint immediately, merge async
@@ -110,6 +120,9 @@ impl Default for PopupConfig {
         Self {
             max_visible: 10,
             borders: false,
+            feedback_dismiss_ms: 1200,
+            spinner: true,
+            show_provider_errors: false,
             render_block_ms: 80,
         }
     }
@@ -206,6 +219,12 @@ pub struct ThemeConfig {
     pub scrollbar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub border: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feedback_loading: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feedback_empty: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feedback_error: Option<String>,
 }
 
 /// Fully resolved theme — every field is a concrete style string (possibly
@@ -222,6 +241,9 @@ pub struct ResolvedTheme {
     pub item_text: String,
     pub scrollbar: String,
     pub border: String,
+    pub feedback_loading: String,
+    pub feedback_empty: String,
+    pub feedback_error: String,
 }
 
 impl ThemeConfig {
@@ -263,6 +285,9 @@ impl ThemeConfig {
         validate_opt_style("theme.item_text", self.item_text.as_deref())?;
         validate_opt_style("theme.scrollbar", self.scrollbar.as_deref())?;
         validate_opt_style("theme.border", self.border.as_deref())?;
+        validate_opt_style("theme.feedback_loading", self.feedback_loading.as_deref())?;
+        validate_opt_style("theme.feedback_empty", self.feedback_empty.as_deref())?;
+        validate_opt_style("theme.feedback_error", self.feedback_error.as_deref())?;
         Ok(())
     }
 
@@ -285,6 +310,12 @@ impl ThemeConfig {
             item_text: self.item_text.clone().unwrap_or(base.item_text),
             scrollbar: self.scrollbar.clone().unwrap_or(base.scrollbar),
             border: self.border.clone().unwrap_or(base.border),
+            feedback_loading: self
+                .feedback_loading
+                .clone()
+                .unwrap_or(base.feedback_loading),
+            feedback_empty: self.feedback_empty.clone().unwrap_or(base.feedback_empty),
+            feedback_error: self.feedback_error.clone().unwrap_or(base.feedback_error),
         })
     }
 }
@@ -352,6 +383,9 @@ fn preset_values(name: &str) -> Result<ResolvedTheme> {
             item_text: String::new(),
             scrollbar: "dim".into(),
             border: "dim".into(),
+            feedback_loading: "dim".into(),
+            feedback_empty: "dim".into(),
+            feedback_error: "dim fg:#f38ba8".into(),
         },
         "light" => ResolvedTheme {
             selected: "fg:#1e1e2e bg:#dce0e8 bold".into(),
@@ -360,6 +394,9 @@ fn preset_values(name: &str) -> Result<ResolvedTheme> {
             item_text: String::new(),
             scrollbar: "fg:#9ca0b0".into(),
             border: "fg:#9ca0b0".into(),
+            feedback_loading: "fg:#6c6f85".into(),
+            feedback_empty: "fg:#6c6f85".into(),
+            feedback_error: "dim fg:#d20f39".into(),
         },
         "catppuccin" => ResolvedTheme {
             selected: "fg:#cdd6f4 bg:#585b70 bold".into(),
@@ -368,6 +405,9 @@ fn preset_values(name: &str) -> Result<ResolvedTheme> {
             item_text: String::new(),
             scrollbar: "fg:#585b70".into(),
             border: "fg:#585b70".into(),
+            feedback_loading: "fg:#6c7086".into(),
+            feedback_empty: "fg:#6c7086".into(),
+            feedback_error: "dim fg:#f38ba8".into(),
         },
         "material-darker" => ResolvedTheme {
             selected: "fg:#eeffff bg:#424242 bold".into(),
@@ -376,6 +416,9 @@ fn preset_values(name: &str) -> Result<ResolvedTheme> {
             item_text: String::new(),
             scrollbar: "fg:#424242".into(),
             border: "fg:#424242".into(),
+            feedback_loading: "fg:#616161".into(),
+            feedback_empty: "fg:#616161".into(),
+            feedback_error: "dim fg:#ff5370".into(),
         },
         _ => bail!(
             "unknown theme preset: {:?} (valid: dark, light, catppuccin, material-darker)",
@@ -396,6 +439,7 @@ const MAX_VISIBLE_UPPER: usize = 50;
 const MAX_RESULTS_UPPER: usize = 10_000;
 const MAX_RESULTS_DEFAULT: usize = 50;
 const RENDER_BLOCK_MS_UPPER: u16 = 300;
+const FEEDBACK_DISMISS_MS_UPPER: u16 = 10_000;
 
 impl GhostConfig {
     /// Clamp config values to sane bounds, logging warnings when clamping.
@@ -443,6 +487,14 @@ impl GhostConfig {
                 RENDER_BLOCK_MS_UPPER,
             );
             self.popup.render_block_ms = RENDER_BLOCK_MS_UPPER;
+        }
+        if self.popup.feedback_dismiss_ms > FEEDBACK_DISMISS_MS_UPPER {
+            tracing::warn!(
+                "popup.feedback_dismiss_ms={} exceeds maximum {}, clamping",
+                self.popup.feedback_dismiss_ms,
+                FEEDBACK_DISMISS_MS_UPPER,
+            );
+            self.popup.feedback_dismiss_ms = FEEDBACK_DISMISS_MS_UPPER;
         }
     }
 
@@ -563,6 +615,9 @@ mod tests {
         assert_eq!(config.trigger.delay_ms, 150);
         assert!(config.trigger.auto_trigger);
         assert_eq!(config.popup.max_visible, 10);
+        assert_eq!(config.popup.feedback_dismiss_ms, 1200);
+        assert!(config.popup.spinner);
+        assert!(!config.popup.show_provider_errors);
         assert_eq!(config.suggest.max_results, 50);
         assert_eq!(config.suggest.max_history_results, 5);
         assert!(config.suggest.providers.commands);
@@ -583,6 +638,9 @@ mod tests {
         assert_eq!(config.theme.item_text, None);
         assert_eq!(config.theme.scrollbar, None);
         assert_eq!(config.theme.border, None);
+        assert_eq!(config.theme.feedback_loading, None);
+        assert_eq!(config.theme.feedback_empty, None);
+        assert_eq!(config.theme.feedback_error, None);
         assert!(!config.experimental.multi_terminal);
     }
 
@@ -701,10 +759,22 @@ selected = "bold fg:255"
 [theme]
 selected = "fg:255 bg:236"
 description = "dim underline"
+feedback_loading = "bold fg:#89b4fa"
+feedback_empty = "dim fg:244"
+feedback_error = "dim fg:#d20f39"
 "#;
         let config: GhostConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.theme.selected.as_deref(), Some("fg:255 bg:236"));
         assert_eq!(config.theme.description.as_deref(), Some("dim underline"));
+        assert_eq!(
+            config.theme.feedback_loading.as_deref(),
+            Some("bold fg:#89b4fa")
+        );
+        assert_eq!(config.theme.feedback_empty.as_deref(), Some("dim fg:244"));
+        assert_eq!(
+            config.theme.feedback_error.as_deref(),
+            Some("dim fg:#d20f39")
+        );
     }
 
     #[test]
@@ -761,6 +831,44 @@ selected = ""
         assert_eq!(resolved.item_text, "");
         assert_eq!(resolved.scrollbar, "dim");
         assert_eq!(resolved.border, "dim");
+        assert_eq!(resolved.feedback_loading, "dim");
+        assert_eq!(resolved.feedback_empty, "dim");
+        assert_eq!(resolved.feedback_error, "dim fg:#f38ba8");
+    }
+
+    #[test]
+    fn test_feedback_theme_overrides_resolve_and_validate() {
+        let config = ThemeConfig {
+            feedback_loading: Some("bold fg:#89b4fa".into()),
+            feedback_empty: Some("dim".into()),
+            feedback_error: Some("fg:196".into()),
+            ..ThemeConfig::default()
+        };
+        config.validate().unwrap();
+        let resolved = config.resolve().unwrap();
+        assert_eq!(resolved.feedback_loading, "bold fg:#89b4fa");
+        assert_eq!(resolved.feedback_empty, "dim");
+        assert_eq!(resolved.feedback_error, "fg:196");
+    }
+
+    #[test]
+    fn test_feedback_theme_preset_defaults() {
+        let presets = [
+            ("dark", "dim fg:#f38ba8"),
+            ("light", "dim fg:#d20f39"),
+            ("catppuccin", "dim fg:#f38ba8"),
+            ("material-darker", "dim fg:#ff5370"),
+        ];
+        for (preset, error_style) in presets {
+            let config = ThemeConfig {
+                preset: preset.into(),
+                ..ThemeConfig::default()
+            };
+            let resolved = config.resolve().unwrap();
+            assert_eq!(resolved.feedback_loading, resolved.description);
+            assert_eq!(resolved.feedback_empty, resolved.description);
+            assert_eq!(resolved.feedback_error, error_style);
+        }
     }
 
     #[test]
@@ -1010,6 +1118,20 @@ max_visible = 5
         writeln!(tmp, "[popup]\nmax_visible = 0").unwrap();
         let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
         assert_eq!(config.popup.max_visible, 10);
+    }
+
+    #[test]
+    fn test_popup_feedback_knobs_parse_and_clamp() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            tmp,
+            "[popup]\nfeedback_dismiss_ms = 20000\nspinner = false\nshow_provider_errors = true"
+        )
+        .unwrap();
+        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        assert_eq!(config.popup.feedback_dismiss_ms, 10000);
+        assert!(!config.popup.spinner);
+        assert!(config.popup.show_provider_errors);
     }
 
     #[test]

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -1145,6 +1145,16 @@ max_visible = 5
     }
 
     #[test]
+    fn test_feedback_dismiss_ms_zero_is_allowed() {
+        // feedback_dismiss_ms=0 disables auto-dismiss of the feedback popup —
+        // still a valid choice, so it must pass through untouched.
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "[popup]\nfeedback_dismiss_ms = 0").unwrap();
+        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        assert_eq!(config.popup.feedback_dismiss_ms, 0);
+    }
+
+    #[test]
     fn test_diff_unknown_keys_flat_top_level() {
         let loose: toml::Value = toml::from_str("known = 1\nbogus = 2").unwrap();
         let strict: toml::Value = toml::from_str("known = 1").unwrap();

--- a/crates/gc-overlay/Cargo.toml
+++ b/crates/gc-overlay/Cargo.toml
@@ -16,3 +16,8 @@ unicode-width = "0.2.2"
 [dev-dependencies]
 # Enables the `TerminalProfile::for_*()` fixture constructors for tests only.
 gc-terminal = { path = "../gc-terminal", features = ["test-utils"] }
+criterion = { version = "0.8", features = ["html_reports"] }
+
+[[bench]]
+name = "feedback_render"
+harness = false

--- a/crates/gc-overlay/benches/feedback_render.rs
+++ b/crates/gc-overlay/benches/feedback_render.rs
@@ -17,13 +17,32 @@ fn feedback_render(c: &mut Criterion) {
             let mut buf = Vec::with_capacity(128);
             render_indicator_row(
                 &mut buf,
-                &layout,
-                &theme,
-                FeedbackKind::Loading { frame: 3 },
+                black_box(&layout),
+                black_box(&theme),
+                black_box(FeedbackKind::Loading { frame: 3 }),
             );
             black_box(buf);
         });
     });
+
+    c.bench_function(
+        "feedback_render/indicator_row_width_60_varying_frame",
+        |b| {
+            let mut frame: u8 = 0;
+            b.iter(|| {
+                let mut buf = Vec::with_capacity(128);
+                let f = black_box(frame);
+                render_indicator_row(
+                    &mut buf,
+                    black_box(&layout),
+                    black_box(&theme),
+                    black_box(FeedbackKind::Loading { frame: f }),
+                );
+                black_box(buf);
+                frame = frame.wrapping_add(1);
+            });
+        },
+    );
 }
 
 criterion_group!(benches, feedback_render);

--- a/crates/gc-overlay/benches/feedback_render.rs
+++ b/crates/gc-overlay/benches/feedback_render.rs
@@ -1,0 +1,30 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use gc_overlay::{render_indicator_row, FeedbackKind, PopupLayout, PopupTheme};
+use std::hint::black_box;
+
+fn feedback_render(c: &mut Criterion) {
+    let layout = PopupLayout {
+        start_row: 5,
+        start_col: 0,
+        width: 60,
+        height: 4,
+        scroll_deficit: 0,
+    };
+    let theme = PopupTheme::default();
+
+    c.bench_function("feedback_render/indicator_row_width_60", |b| {
+        b.iter(|| {
+            let mut buf = Vec::with_capacity(128);
+            render_indicator_row(
+                &mut buf,
+                &layout,
+                &theme,
+                FeedbackKind::Loading { frame: 3 },
+            );
+            black_box(buf);
+        });
+    });
+}
+
+criterion_group!(benches, feedback_render);
+criterion_main!(benches);

--- a/crates/gc-overlay/src/lib.rs
+++ b/crates/gc-overlay/src/lib.rs
@@ -12,7 +12,9 @@ pub mod types;
 pub(crate) mod util;
 
 pub use frame::{ContentRow, PopupFrame, PopupRow, ScrollbarCell, SpanStyle, StyledSpan};
-pub use render::{clear_popup, parse_style, render_popup, PopupTheme};
+pub use render::{
+    clear_popup, parse_style, render_indicator_row, render_popup, FeedbackKind, PopupTheme,
+};
 pub use types::{
     OverlayState, PopupLayout, DEFAULT_MAX_POPUP_WIDTH, DEFAULT_MAX_VISIBLE,
     DEFAULT_MIN_POPUP_WIDTH,

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -218,15 +218,7 @@ pub fn render_popup(
     // Adjust cursor for prior scroll (parser doesn't know about our scrolling)
     let adj_cursor_row = cursor_row.saturating_sub(prior_deficit);
 
-    // Calculate how much more scrolling is needed.
-    //
-    // When feedback is visible, the indicator occupies exactly 1 extra row
-    // regardless of whether borders are enabled: in the bordered case the
-    // loading row overwrites what would have been the bottom border row and
-    // the bottom border is redrawn one row below, so the popup still grows
-    // by only 1 row beyond its base `layout.height`. The `loading_extra`
-    // value computed during rendering (lines ~336–388) matches this: it is
-    // `1` in every code path where the loading row actually fits.
+    // Indicator occupies exactly 1 row; bordered case shifts bottom border down by 1.
     let space_below = screen_rows.saturating_sub(adj_cursor_row.saturating_add(1));
     let visible_count = suggestions.len().min(effective_max) as u16;
     let loading_extra_deficit: u16 = if feedback.reserves_row() { 1 } else { 0 };
@@ -2244,6 +2236,68 @@ mod tests {
         assert!(
             output.contains("Loading"),
             "loading feedback should include label: {output}"
+        );
+    }
+
+    #[test]
+    fn test_loading_label_uses_ellipsis_when_spinner_disabled() {
+        let mut buf = Vec::new();
+        let layout = PopupLayout {
+            start_row: 5,
+            start_col: 0,
+            width: 60,
+            height: 4,
+            scroll_deficit: 0,
+        };
+        let theme = PopupTheme {
+            spinner: false,
+            ..PopupTheme::default()
+        };
+        render_indicator_row(
+            &mut buf,
+            &layout,
+            &theme,
+            FeedbackKind::Loading { frame: 0 },
+        );
+        let output = String::from_utf8_lossy(&buf);
+        assert!(
+            output.contains('…'),
+            "spinner=false should fall back to ellipsis: {output}"
+        );
+        assert!(
+            !output.contains('⠋'),
+            "spinner=false must not render spinner glyph: {output}"
+        );
+        assert!(
+            output.contains("Loading"),
+            "loading feedback should include label: {output}"
+        );
+    }
+
+    #[test]
+    fn test_loading_label_uses_ellipsis_when_content_width_narrow() {
+        let mut buf = Vec::new();
+        let layout = PopupLayout {
+            start_row: 5,
+            start_col: 0,
+            width: 24,
+            height: 4,
+            scroll_deficit: 0,
+        };
+        render_indicator_row(
+            &mut buf,
+            &layout,
+            &PopupTheme::default(),
+            FeedbackKind::Loading { frame: 0 },
+        );
+        let output = String::from_utf8_lossy(&buf);
+        assert!(
+            output.contains('…'),
+            "narrow content_width should fall back to ellipsis: {output}"
+        );
+        assert!(
+            !output.contains('⠋'),
+            "narrow content_width must not render spinner glyph: {output}"
         );
     }
 

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -488,7 +488,7 @@ fn render_feedback_only_popup(
 ) -> PopupLayout {
     let border_pad: u16 = if theme.borders { 2 } else { 0 };
     let effective_max_w = max_width.min(screen_cols).max(min_width);
-    let width = min_width.clamp(min_width, effective_max_w);
+    let width = min_width.min(effective_max_w);
     let base_height = 1 + border_pad;
     let space_below = screen_rows.saturating_sub(cursor_row.saturating_add(1));
     let new_deficit = base_height.saturating_sub(space_below);
@@ -581,7 +581,7 @@ pub fn render_indicator_row(
     theme: &PopupTheme,
     feedback: FeedbackKind,
 ) {
-    if layout.height == 0 || !feedback.reserves_row() {
+    if layout.height <= u16::from(theme.borders) || !feedback.reserves_row() {
         return;
     }
     let content_width = layout

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -397,8 +397,7 @@ pub fn render_popup(
         }
     }
 
-    // Render feedback indicator row when async generators are in flight or
-    // just completed without ordinary suggestions.
+    // Indicator row: drawn while generators run or after they end with no suggestions.
     let loading_extra = if feedback.reserves_row() {
         let loading_row = bottom_border_row.unwrap_or(layout.start_row + layout.height);
         if loading_row < screen_rows {

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -14,11 +14,16 @@ use crate::util::display_text;
 pub struct PopupTheme {
     pub selected_on: Vec<u8>,
     pub description_on: Vec<u8>,
+    pub feedback_loading_on: Vec<u8>,
+    pub feedback_empty_on: Vec<u8>,
+    pub feedback_error_on: Vec<u8>,
     pub match_highlight_on: Vec<u8>,
     pub item_text_on: Vec<u8>,
     pub scrollbar_on: Vec<u8>,
     pub border_on: Vec<u8>,
     pub borders: bool,
+    pub spinner: bool,
+    pub show_provider_errors: bool,
 }
 
 impl Default for PopupTheme {
@@ -28,14 +33,45 @@ impl Default for PopupTheme {
         Self {
             selected_on: b"\x1b[7m".to_vec(),
             description_on: b"\x1b[2m".to_vec(),
+            feedback_loading_on: b"\x1b[2m".to_vec(),
+            feedback_empty_on: b"\x1b[2m".to_vec(),
+            feedback_error_on: b"\x1b[2;38;2;243;139;168m".to_vec(),
             match_highlight_on: b"\x1b[1m".to_vec(),
             item_text_on: vec![],
             scrollbar_on: b"\x1b[2m".to_vec(),
             border_on: b"\x1b[2m".to_vec(),
             borders: false,
+            spinner: true,
+            show_provider_errors: false,
         }
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeedbackKind {
+    None,
+    Loading { frame: u8 },
+    Empty,
+    Error { provider: String },
+    PartialError { providers: u8 },
+}
+
+impl FeedbackKind {
+    fn reserves_row(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    fn style<'a>(&self, theme: &'a PopupTheme) -> &'a [u8] {
+        match self {
+            Self::None => &[],
+            Self::Loading { .. } => &theme.feedback_loading_on,
+            Self::Empty => &theme.feedback_empty_on,
+            Self::Error { .. } | Self::PartialError { .. } => &theme.feedback_error_on,
+        }
+    }
+}
+
+const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 /// Parse a space-separated style string into a combined ANSI SGR sequence.
 ///
@@ -117,10 +153,10 @@ pub fn render_popup(
     max_width: u16,
     theme: &PopupTheme,
     prior_deficit: u16,
-    loading: bool,
+    feedback: FeedbackKind,
     profile: &TerminalProfile,
 ) -> PopupLayout {
-    if suggestions.is_empty() {
+    if suggestions.is_empty() && !feedback.reserves_row() {
         return PopupLayout {
             start_row: 0,
             start_col: 0,
@@ -140,6 +176,22 @@ pub fn render_popup(
             height: 0,
             scroll_deficit: 0,
         };
+    }
+
+    if suggestions.is_empty() {
+        return render_feedback_only_popup(
+            buf,
+            cursor_row,
+            cursor_col,
+            screen_rows,
+            screen_cols,
+            min_width,
+            max_width,
+            theme,
+            prior_deficit,
+            feedback,
+            profile,
+        );
     }
 
     // Border padding: 2 rows/cols when borders enabled, 0 otherwise
@@ -168,7 +220,7 @@ pub fn render_popup(
 
     // Calculate how much more scrolling is needed.
     //
-    // When `loading`, the loading indicator occupies exactly 1 extra row
+    // When feedback is visible, the indicator occupies exactly 1 extra row
     // regardless of whether borders are enabled: in the bordered case the
     // loading row overwrites what would have been the bottom border row and
     // the bottom border is redrawn one row below, so the popup still grows
@@ -177,7 +229,7 @@ pub fn render_popup(
     // `1` in every code path where the loading row actually fits.
     let space_below = screen_rows.saturating_sub(adj_cursor_row.saturating_add(1));
     let visible_count = suggestions.len().min(effective_max) as u16;
-    let loading_extra_deficit: u16 = if loading { 1 } else { 0 };
+    let loading_extra_deficit: u16 = if feedback.reserves_row() { 1 } else { 0 };
     let total_height_needed = visible_count + border_pad + loading_extra_deficit;
     let new_deficit = total_height_needed.saturating_sub(space_below);
     let total_deficit = prior_deficit + new_deficit;
@@ -353,8 +405,9 @@ pub fn render_popup(
         }
     }
 
-    // Render loading indicator row when async generators are in flight
-    let loading_extra = if loading {
+    // Render feedback indicator row when async generators are in flight or
+    // just completed without ordinary suggestions.
+    let loading_extra = if feedback.reserves_row() {
         let loading_row = bottom_border_row.unwrap_or(layout.start_row + layout.height);
         if loading_row < screen_rows {
             ansi::move_to(buf, loading_row, border_col);
@@ -365,13 +418,7 @@ pub fn render_popup(
                 buf.extend_from_slice("│".as_bytes());
                 ansi::reset(buf);
             }
-            buf.extend_from_slice(&theme.description_on);
-            let label = b"  ...";
-            let _ = buf.write_all(label);
-            let pad = (content_width as usize).saturating_sub(label.len());
-            for _ in 0..pad {
-                let _ = buf.write_all(b" ");
-            }
+            write_indicator_content(buf, content_width, theme, &feedback);
             ansi::reset(buf);
             if theme.borders {
                 if !theme.border_on.is_empty() {
@@ -431,6 +478,218 @@ pub fn render_popup(
         scroll_deficit: total_deficit,
         ..layout
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_feedback_only_popup(
+    buf: &mut Vec<u8>,
+    cursor_row: u16,
+    cursor_col: u16,
+    screen_rows: u16,
+    screen_cols: u16,
+    min_width: u16,
+    max_width: u16,
+    theme: &PopupTheme,
+    prior_deficit: u16,
+    feedback: FeedbackKind,
+    profile: &TerminalProfile,
+) -> PopupLayout {
+    let border_pad: u16 = if theme.borders { 2 } else { 0 };
+    let effective_max_w = max_width.min(screen_cols).max(min_width);
+    let width = min_width.clamp(min_width, effective_max_w);
+    let base_height = 1 + border_pad;
+    let space_below = screen_rows.saturating_sub(cursor_row.saturating_add(1));
+    let new_deficit = base_height.saturating_sub(space_below);
+    let total_deficit = prior_deficit + new_deficit;
+    let final_cursor_row = cursor_row.saturating_sub(total_deficit);
+    let start_row = final_cursor_row + 1;
+    let start_col = if cursor_col + width > screen_cols {
+        screen_cols.saturating_sub(width)
+    } else {
+        cursor_col
+    };
+    let content_width = width.saturating_sub(border_pad);
+    let use_sync = matches!(
+        profile.render_strategy(),
+        gc_terminal::RenderStrategy::Synchronized
+    );
+
+    if use_sync {
+        ansi::begin_sync(buf);
+    }
+    if new_deficit > 0 {
+        ansi::move_to(buf, screen_rows - 1, 0);
+        for _ in 0..new_deficit {
+            buf.push(b'\n');
+        }
+        ansi::move_to(buf, final_cursor_row, cursor_col);
+    }
+    ansi::save_cursor(buf);
+
+    if theme.borders {
+        ansi::move_to(buf, start_row, start_col);
+        if !theme.border_on.is_empty() {
+            buf.extend_from_slice(&theme.border_on);
+        }
+        buf.extend_from_slice("╭".as_bytes());
+        for _ in 0..content_width {
+            buf.extend_from_slice("─".as_bytes());
+        }
+        buf.extend_from_slice("╮".as_bytes());
+        ansi::reset(buf);
+    }
+
+    let content_row = start_row + u16::from(theme.borders);
+    ansi::move_to(buf, content_row, start_col);
+    if theme.borders {
+        if !theme.border_on.is_empty() {
+            buf.extend_from_slice(&theme.border_on);
+        }
+        buf.extend_from_slice("│".as_bytes());
+        ansi::reset(buf);
+    }
+    write_indicator_content(buf, content_width, theme, &feedback);
+    ansi::reset(buf);
+    if theme.borders {
+        if !theme.border_on.is_empty() {
+            buf.extend_from_slice(&theme.border_on);
+        }
+        buf.extend_from_slice("│".as_bytes());
+        ansi::reset(buf);
+
+        ansi::move_to(buf, content_row + 1, start_col);
+        if !theme.border_on.is_empty() {
+            buf.extend_from_slice(&theme.border_on);
+        }
+        buf.extend_from_slice("╰".as_bytes());
+        for _ in 0..content_width {
+            buf.extend_from_slice("─".as_bytes());
+        }
+        buf.extend_from_slice("╯".as_bytes());
+        ansi::reset(buf);
+    }
+
+    ansi::restore_cursor(buf);
+    if use_sync {
+        ansi::end_sync(buf);
+    }
+
+    PopupLayout {
+        start_row,
+        start_col,
+        width,
+        height: base_height,
+        scroll_deficit: total_deficit,
+    }
+}
+
+pub fn render_indicator_row(
+    buf: &mut Vec<u8>,
+    layout: &PopupLayout,
+    theme: &PopupTheme,
+    feedback: FeedbackKind,
+) {
+    if layout.height == 0 || !feedback.reserves_row() {
+        return;
+    }
+    let content_width = layout
+        .width
+        .saturating_sub(if theme.borders { 2 } else { 0 });
+    let row = layout.start_row + layout.height - 1 - u16::from(theme.borders);
+    ansi::save_cursor(buf);
+    ansi::move_to(buf, row, layout.start_col);
+    if theme.borders {
+        if !theme.border_on.is_empty() {
+            buf.extend_from_slice(&theme.border_on);
+        }
+        buf.extend_from_slice("│".as_bytes());
+        ansi::reset(buf);
+    }
+    write_indicator_content(buf, content_width, theme, &feedback);
+    ansi::reset(buf);
+    if theme.borders {
+        if !theme.border_on.is_empty() {
+            buf.extend_from_slice(&theme.border_on);
+        }
+        buf.extend_from_slice("│".as_bytes());
+        ansi::reset(buf);
+    }
+    ansi::restore_cursor(buf);
+}
+
+fn write_indicator_content(
+    buf: &mut Vec<u8>,
+    content_width: u16,
+    theme: &PopupTheme,
+    feedback: &FeedbackKind,
+) {
+    let label = indicator_label(feedback, content_width, theme.spinner);
+    let style = feedback.style(theme);
+    if !style.is_empty() {
+        buf.extend_from_slice(style);
+    }
+    let max_cols = content_width as usize;
+    let label_cols = display_cols(&label);
+    let label_cols = if label_cols <= max_cols {
+        let _ = buf.write_all(label.as_bytes());
+        label_cols
+    } else {
+        let (label, label_cols) = truncate_to_display_cols(&label, max_cols);
+        let _ = buf.write_all(label.as_bytes());
+        label_cols
+    };
+    let pad = (content_width as usize).saturating_sub(label_cols);
+    write_padding(buf, pad);
+}
+
+fn indicator_label(feedback: &FeedbackKind, content_width: u16, spinner: bool) -> String {
+    match feedback {
+        FeedbackKind::None => String::new(),
+        FeedbackKind::Loading { frame } => {
+            let glyph = if spinner && content_width >= 25 {
+                SPINNER_FRAMES[*frame as usize % SPINNER_FRAMES.len()]
+            } else {
+                "…"
+            };
+            format!(" {glyph} Loading")
+        }
+        FeedbackKind::Empty => "  (no matches)".to_string(),
+        FeedbackKind::Error { provider } if provider.is_empty() => {
+            "  ! provider failed".to_string()
+        }
+        FeedbackKind::Error { provider } => {
+            format!("  ! failed: {}", sanitize_display_text(provider))
+        }
+        FeedbackKind::PartialError { providers } => {
+            if *providers == 1 {
+                "  ! 1 provider failed".to_string()
+            } else {
+                format!("  ! {providers} providers failed")
+            }
+        }
+    }
+}
+
+fn display_cols(text: &str) -> usize {
+    if text.is_ascii() {
+        text.len()
+    } else {
+        unicode_width::UnicodeWidthStr::width(text)
+    }
+}
+
+fn truncate_to_display_cols(text: &str, max_cols: usize) -> (String, usize) {
+    let mut out = String::new();
+    let mut cols = 0;
+    for ch in text.chars() {
+        let width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+        if cols + width > max_cols {
+            break;
+        }
+        out.push(ch);
+        cols += width;
+    }
+    (out, cols)
 }
 
 /// Clear the popup area by overwriting with spaces.
@@ -785,7 +1044,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -814,7 +1073,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &iterm2_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -871,7 +1130,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -897,7 +1156,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -927,7 +1186,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1086,7 +1345,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1119,7 +1378,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         assert_eq!(layout.height, 0);
@@ -1197,7 +1456,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1234,7 +1493,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         // No newlines means no scrolling occurred (popup uses CUP, not newlines)
@@ -1265,7 +1524,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             4,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         // No newlines means no scrolling occurred (popup uses CUP, not newlines)
@@ -1296,7 +1555,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         assert_eq!(layout1.scroll_deficit, 4);
@@ -1320,7 +1579,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             4, // prior_deficit from first render
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output2 = String::from_utf8_lossy(&buf2);
@@ -1352,7 +1611,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1388,7 +1647,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         // capped to screen_rows - 1 - 2(borders) = 3 content + 2 borders = 5
@@ -1424,7 +1683,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         // final_cursor = 0, start_row = 1
@@ -1499,7 +1758,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &theme,
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1537,7 +1796,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &theme,
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1567,7 +1826,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &theme,
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1731,7 +1990,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1759,7 +2018,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1797,7 +2056,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1827,7 +2086,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1858,7 +2117,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
 
@@ -1876,7 +2135,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
 
@@ -1912,7 +2171,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &theme,
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -1940,13 +2199,13 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            true,
+            FeedbackKind::Loading { frame: 0 },
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
         assert!(
-            output.contains("..."),
-            "loading=true should produce '...' indicator: {output}"
+            output.contains("Loading"),
+            "loading feedback should produce indicator label: {output}"
         );
         // Height: 3 content + 2 borders + 1 loading extra (loading displaces bottom border,
         // which moves down 1 row, netting 1 extra row beyond layout.height) = 6
@@ -1954,6 +2213,133 @@ mod tests {
             layout.height, 6,
             "loading should increase height by 1 beyond base layout"
         );
+    }
+
+    #[test]
+    fn test_feedback_loading_shows_spinner_frame() {
+        let mut buf = Vec::new();
+        let suggestions = make_suggestions();
+        let state = OverlayState::new();
+        render_popup(
+            &mut buf,
+            &suggestions,
+            &state,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            &PopupTheme::default(),
+            0,
+            FeedbackKind::Loading { frame: 0 },
+            &ghostty_profile(),
+        );
+        let output = String::from_utf8_lossy(&buf);
+        assert!(
+            output.contains('⠋'),
+            "loading feedback should show spinner: {output}"
+        );
+        assert!(
+            output.contains("Loading"),
+            "loading feedback should include label: {output}"
+        );
+    }
+
+    #[test]
+    fn test_feedback_empty_and_error_labels() {
+        let mut empty_buf = Vec::new();
+        let state = OverlayState::new();
+        render_popup(
+            &mut empty_buf,
+            &[],
+            &state,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            &PopupTheme::default(),
+            0,
+            FeedbackKind::Empty,
+            &ghostty_profile(),
+        );
+        assert!(String::from_utf8_lossy(&empty_buf).contains("(no matches)"));
+
+        let mut error_buf = Vec::new();
+        render_popup(
+            &mut error_buf,
+            &[],
+            &state,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            &PopupTheme::default(),
+            0,
+            FeedbackKind::Error {
+                provider: "git".into(),
+            },
+            &ghostty_profile(),
+        );
+        assert!(String::from_utf8_lossy(&error_buf).contains("failed: git"));
+    }
+
+    #[test]
+    fn test_render_indicator_row_is_small() {
+        let mut buf = Vec::new();
+        let layout = PopupLayout {
+            start_row: 5,
+            start_col: 0,
+            width: 60,
+            height: 4,
+            scroll_deficit: 0,
+        };
+        render_indicator_row(
+            &mut buf,
+            &layout,
+            &PopupTheme::default(),
+            FeedbackKind::PartialError { providers: 1 },
+        );
+        assert!(
+            buf.len() <= 200,
+            "indicator repaint too large: {}",
+            buf.len()
+        );
+        assert!(String::from_utf8_lossy(&buf).contains("1 provider failed"));
+    }
+
+    #[test]
+    fn test_feedback_label_clips_to_content_width() {
+        let (label, cols) = truncate_to_display_cols("  ! failed: very-long-provider-name", 18);
+
+        assert_eq!(cols, 18);
+        assert_eq!(label, "  ! failed: very-l");
+
+        let mut buf = Vec::new();
+        let layout = PopupLayout {
+            start_row: 5,
+            start_col: 0,
+            width: 20,
+            height: 4,
+            scroll_deficit: 0,
+        };
+        render_indicator_row(
+            &mut buf,
+            &layout,
+            &bordered_theme(),
+            FeedbackKind::Error {
+                provider: "very-long-provider-name".into(),
+            },
+        );
+        let output = String::from_utf8_lossy(&buf);
+        assert!(!output.contains("provider-name"));
     }
 
     #[test]
@@ -1974,7 +2360,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -2004,7 +2390,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -2039,7 +2425,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &PopupTheme::default(), // borders: false
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         let output = String::from_utf8_lossy(&buf);
@@ -2074,7 +2460,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &PopupTheme::default(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         // 3 content rows, no border padding
@@ -2140,7 +2526,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &PopupTheme::default(), // borders: false
             0,
-            true,
+            FeedbackKind::Loading { frame: 0 },
             &ghostty_profile(),
         );
         // 3 content + 1 loading row, no borders
@@ -2175,7 +2561,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            true,
+            FeedbackKind::Loading { frame: 0 },
             &ghostty_profile(),
         );
         // total_height_needed = 3 content + 2 borders + 1 loading_extra_deficit = 6
@@ -2323,7 +2709,7 @@ mod tests {
             DEFAULT_MAX_POPUP_WIDTH,
             &bordered_theme(),
             0,
-            false,
+            FeedbackKind::None,
             &ghostty_profile(),
         );
         assert!(

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -149,7 +149,12 @@ pub fn spawn_config_watcher(
                 }
             };
 
-            let theme = match build_popup_theme(&resolved_theme, config.popup.borders) {
+            let theme = match build_popup_theme(
+                &resolved_theme,
+                config.popup.borders,
+                config.popup.spinner,
+                config.popup.show_provider_errors,
+            ) {
                 Ok(t) => t,
                 Err(e) => {
                     tracing::warn!("config reload failed (theme styles): {e}");
@@ -180,6 +185,7 @@ pub fn spawn_config_watcher(
                     keybindings,
                     &config.trigger.auto_chars,
                     config.popup.max_visible,
+                    config.popup.feedback_dismiss_ms,
                     config.trigger.auto_trigger,
                 )
             };
@@ -202,12 +208,23 @@ pub fn spawn_config_watcher(
 
 /// Build a `PopupTheme` from a [`gc_config::ResolvedTheme`] (preset merged
 /// with user overrides), parsing each style string.
-fn build_popup_theme(resolved: &gc_config::ResolvedTheme, borders: bool) -> Result<PopupTheme> {
+fn build_popup_theme(
+    resolved: &gc_config::ResolvedTheme,
+    borders: bool,
+    spinner: bool,
+    show_provider_errors: bool,
+) -> Result<PopupTheme> {
     Ok(PopupTheme {
         selected_on: parse_style(&resolved.selected)
             .map_err(|e| anyhow::anyhow!("invalid theme.selected: {e}"))?,
         description_on: parse_style(&resolved.description)
             .map_err(|e| anyhow::anyhow!("invalid theme.description: {e}"))?,
+        feedback_loading_on: parse_style(&resolved.feedback_loading)
+            .map_err(|e| anyhow::anyhow!("invalid theme.feedback_loading: {e}"))?,
+        feedback_empty_on: parse_style(&resolved.feedback_empty)
+            .map_err(|e| anyhow::anyhow!("invalid theme.feedback_empty: {e}"))?,
+        feedback_error_on: parse_style(&resolved.feedback_error)
+            .map_err(|e| anyhow::anyhow!("invalid theme.feedback_error: {e}"))?,
         match_highlight_on: parse_style(&resolved.match_highlight)
             .map_err(|e| anyhow::anyhow!("invalid theme.match_highlight: {e}"))?,
         item_text_on: parse_style(&resolved.item_text)
@@ -217,6 +234,8 @@ fn build_popup_theme(resolved: &gc_config::ResolvedTheme, borders: bool) -> Resu
         border_on: parse_style(&resolved.border)
             .map_err(|e| anyhow::anyhow!("invalid theme.border: {e}"))?,
         borders,
+        spinner,
+        show_provider_errors,
     })
 }
 
@@ -233,8 +252,11 @@ mod tests {
             item_text: String::new(),
             scrollbar: "dim".into(),
             border: "dim".into(),
+            feedback_loading: "dim".into(),
+            feedback_empty: "dim".into(),
+            feedback_error: "dim fg:#f38ba8".into(),
         };
-        let result = build_popup_theme(&resolved, true);
+        let result = build_popup_theme(&resolved, true, true, false);
         assert!(result.is_ok());
         assert!(result.unwrap().borders);
     }

--- a/crates/gc-pty/src/dynamic_result.rs
+++ b/crates/gc-pty/src/dynamic_result.rs
@@ -1,0 +1,89 @@
+use std::fmt;
+
+use gc_suggest::{git::GitQueryKind, providers::ProviderKind, Suggestion};
+
+#[derive(Debug, Clone)]
+pub enum DynamicResult {
+    Loaded {
+        provider: ProviderTag,
+        suggestions: Vec<Suggestion>,
+    },
+    Empty {
+        provider: ProviderTag,
+    },
+    Error {
+        provider: ProviderTag,
+        kind: ErrorKind,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderTag {
+    Script(String),
+    Git(GitQueryKind),
+    Provider(ProviderKind),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorKind {
+    Timeout,
+    SpawnFailed,
+    NonZeroExit(i32),
+    Parse(String),
+    Runtime(String),
+}
+
+impl fmt::Display for ProviderTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Script(command) if command.is_empty() => f.write_str("script"),
+            Self::Script(command) => write!(f, "{command} script"),
+            Self::Git(kind) => write!(f, "git {}", git_kind_name(*kind)),
+            Self::Provider(kind) => f.write_str(kind.type_str()),
+        }
+    }
+}
+
+fn git_kind_name(kind: GitQueryKind) -> &'static str {
+    match kind {
+        GitQueryKind::Branches => "branches",
+        GitQueryKind::Tags => "tags",
+        GitQueryKind::Remotes => "remotes",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gc_suggest::SuggestionKind;
+
+    #[test]
+    fn provider_tag_display_is_stable() {
+        assert_eq!(ProviderTag::Script("git".into()).to_string(), "git script");
+        assert_eq!(
+            ProviderTag::Git(GitQueryKind::Branches).to_string(),
+            "git branches"
+        );
+        assert_eq!(
+            ProviderTag::Provider(ProviderKind::NpmScripts).to_string(),
+            "npm_scripts"
+        );
+    }
+
+    #[test]
+    fn dynamic_result_variants_carry_payloads() {
+        let suggestion = Suggestion {
+            text: "main".into(),
+            kind: SuggestionKind::GitBranch,
+            ..Default::default()
+        };
+        let result = DynamicResult::Loaded {
+            provider: ProviderTag::Git(GitQueryKind::Branches),
+            suggestions: vec![suggestion],
+        };
+        match result {
+            DynamicResult::Loaded { suggestions, .. } => assert_eq!(suggestions.len(), 1),
+            _ => panic!("expected loaded"),
+        }
+    }
+}

--- a/crates/gc-pty/src/dynamic_result.rs
+++ b/crates/gc-pty/src/dynamic_result.rs
@@ -13,7 +13,7 @@ pub enum DynamicResult {
     },
     Error {
         provider: ProviderTag,
-        kind: ErrorKind,
+        message: String,
     },
 }
 
@@ -22,15 +22,6 @@ pub enum ProviderTag {
     Script(String),
     Git(GitQueryKind),
     Provider(ProviderKind),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ErrorKind {
-    Timeout,
-    SpawnFailed,
-    NonZeroExit(i32),
-    Parse(String),
-    Runtime(String),
 }
 
 impl fmt::Display for ProviderTag {

--- a/crates/gc-pty/src/feedback.rs
+++ b/crates/gc-pty/src/feedback.rs
@@ -62,10 +62,7 @@ impl AsyncFeedback {
         )
     }
 
-    /// Decide the terminal feedback variant from the disconnect-time outcome
-    /// without cloning the loaded suggestions vec. Callers pass only the
-    /// boolean of whether any non-empty Loaded results survived, plus the
-    /// failed/empty_count tallies — the loaded vec stays where it is.
+    /// Borrow-only variant of [`Self::terminal_from_aggregation`] — avoids cloning the loaded vec.
     pub fn terminal_for_outcome(
         loaded_non_empty: bool,
         failed: &[String],

--- a/crates/gc-pty/src/feedback.rs
+++ b/crates/gc-pty/src/feedback.rs
@@ -44,7 +44,8 @@ impl AsyncFeedback {
                     }
                 }
                 DynamicResult::Empty { .. } => aggregation.empty_count += 1,
-                DynamicResult::Error { provider, .. } => {
+                DynamicResult::Error { provider, message } => {
+                    tracing::warn!(provider = %provider, "dynamic provider failed: {message}");
                     aggregation.failed.push(provider.to_string())
                 }
             }
@@ -53,17 +54,35 @@ impl AsyncFeedback {
     }
 
     pub fn terminal_from_aggregation(aggregation: &DynamicAggregation, now: Instant) -> Self {
-        if !aggregation.loaded.is_empty() && !aggregation.failed.is_empty() {
+        Self::terminal_for_outcome(
+            !aggregation.loaded.is_empty(),
+            &aggregation.failed,
+            aggregation.empty_count,
+            now,
+        )
+    }
+
+    /// Decide the terminal feedback variant from the disconnect-time outcome
+    /// without cloning the loaded suggestions vec. Callers pass only the
+    /// boolean of whether any non-empty Loaded results survived, plus the
+    /// failed/empty_count tallies — the loaded vec stays where it is.
+    pub fn terminal_for_outcome(
+        loaded_non_empty: bool,
+        failed: &[String],
+        empty_count: usize,
+        now: Instant,
+    ) -> Self {
+        if loaded_non_empty && !failed.is_empty() {
             Self::PartialError {
-                failed: aggregation.failed.clone(),
+                failed: failed.to_vec(),
                 since: now,
             }
-        } else if !aggregation.failed.is_empty() {
+        } else if !failed.is_empty() {
             Self::Error {
-                failed: aggregation.failed.clone(),
+                failed: failed.to_vec(),
                 since: now,
             }
-        } else if aggregation.loaded.is_empty() && aggregation.empty_count > 0 {
+        } else if !loaded_non_empty && empty_count > 0 {
             Self::Empty { since: now }
         } else {
             Self::Idle
@@ -94,7 +113,7 @@ impl AsyncFeedback {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dynamic_result::{ErrorKind, ProviderTag};
+    use crate::dynamic_result::ProviderTag;
     use gc_suggest::{git::GitQueryKind, SuggestionKind};
 
     fn suggestion(text: &str) -> Suggestion {
@@ -117,7 +136,7 @@ mod tests {
             },
             DynamicResult::Error {
                 provider: ProviderTag::Script("git".into()),
-                kind: ErrorKind::Runtime("boom".into()),
+                message: "boom".into(),
             },
         ]);
         assert_eq!(aggregation.loaded.len(), 1);
@@ -136,6 +155,48 @@ mod tests {
         assert!(matches!(
             AsyncFeedback::terminal_from_aggregation(&aggregation, now),
             AsyncFeedback::PartialError { .. }
+        ));
+    }
+
+    #[test]
+    fn terminal_feedback_failed_only_is_error() {
+        let now = Instant::now();
+        let aggregation = DynamicAggregation {
+            loaded: Vec::new(),
+            empty_count: 0,
+            failed: vec!["git branches".into()],
+        };
+        assert!(matches!(
+            AsyncFeedback::terminal_from_aggregation(&aggregation, now),
+            AsyncFeedback::Error { .. }
+        ));
+    }
+
+    #[test]
+    fn terminal_feedback_empty_only_is_empty() {
+        let now = Instant::now();
+        let aggregation = DynamicAggregation {
+            loaded: Vec::new(),
+            empty_count: 1,
+            failed: Vec::new(),
+        };
+        assert!(matches!(
+            AsyncFeedback::terminal_from_aggregation(&aggregation, now),
+            AsyncFeedback::Empty { .. }
+        ));
+    }
+
+    #[test]
+    fn terminal_feedback_all_loaded_is_idle() {
+        let now = Instant::now();
+        let aggregation = DynamicAggregation {
+            loaded: vec![suggestion("main")],
+            empty_count: 0,
+            failed: Vec::new(),
+        };
+        assert!(matches!(
+            AsyncFeedback::terminal_from_aggregation(&aggregation, now),
+            AsyncFeedback::Idle
         ));
     }
 }

--- a/crates/gc-pty/src/feedback.rs
+++ b/crates/gc-pty/src/feedback.rs
@@ -1,0 +1,141 @@
+use std::time::Instant;
+
+use gc_suggest::Suggestion;
+
+use crate::dynamic_result::DynamicResult;
+
+#[derive(Debug, Clone, Default)]
+pub enum AsyncFeedback {
+    #[default]
+    Idle,
+    Loading {
+        spawned_at: Instant,
+    },
+    Empty {
+        since: Instant,
+    },
+    Error {
+        failed: Vec<String>,
+        since: Instant,
+    },
+    PartialError {
+        failed: Vec<String>,
+        since: Instant,
+    },
+}
+
+#[derive(Debug, Default)]
+pub struct DynamicAggregation {
+    pub loaded: Vec<Suggestion>,
+    pub empty_count: usize,
+    pub failed: Vec<String>,
+}
+
+impl AsyncFeedback {
+    pub fn aggregate(results: Vec<DynamicResult>) -> DynamicAggregation {
+        let mut aggregation = DynamicAggregation::default();
+        for result in results {
+            match result {
+                DynamicResult::Loaded { suggestions, .. } => {
+                    if suggestions.is_empty() {
+                        aggregation.empty_count += 1;
+                    } else {
+                        aggregation.loaded.extend(suggestions);
+                    }
+                }
+                DynamicResult::Empty { .. } => aggregation.empty_count += 1,
+                DynamicResult::Error { provider, .. } => {
+                    aggregation.failed.push(provider.to_string())
+                }
+            }
+        }
+        aggregation
+    }
+
+    pub fn terminal_from_aggregation(aggregation: &DynamicAggregation, now: Instant) -> Self {
+        if !aggregation.loaded.is_empty() && !aggregation.failed.is_empty() {
+            Self::PartialError {
+                failed: aggregation.failed.clone(),
+                since: now,
+            }
+        } else if !aggregation.failed.is_empty() {
+            Self::Error {
+                failed: aggregation.failed.clone(),
+                since: now,
+            }
+        } else if aggregation.loaded.is_empty() && aggregation.empty_count > 0 {
+            Self::Empty { since: now }
+        } else {
+            Self::Idle
+        }
+    }
+
+    pub fn is_loading(&self) -> bool {
+        matches!(self, Self::Loading { .. })
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Empty { .. } | Self::Error { .. } | Self::PartialError { .. }
+        )
+    }
+
+    pub fn since(&self) -> Option<Instant> {
+        match self {
+            Self::Empty { since }
+            | Self::Error { since, .. }
+            | Self::PartialError { since, .. } => Some(*since),
+            Self::Idle | Self::Loading { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dynamic_result::{ErrorKind, ProviderTag};
+    use gc_suggest::{git::GitQueryKind, SuggestionKind};
+
+    fn suggestion(text: &str) -> Suggestion {
+        Suggestion {
+            text: text.into(),
+            kind: SuggestionKind::GitBranch,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn aggregate_loaded_empty_and_error() {
+        let aggregation = AsyncFeedback::aggregate(vec![
+            DynamicResult::Loaded {
+                provider: ProviderTag::Git(GitQueryKind::Branches),
+                suggestions: vec![suggestion("main")],
+            },
+            DynamicResult::Empty {
+                provider: ProviderTag::Git(GitQueryKind::Tags),
+            },
+            DynamicResult::Error {
+                provider: ProviderTag::Script("git".into()),
+                kind: ErrorKind::Runtime("boom".into()),
+            },
+        ]);
+        assert_eq!(aggregation.loaded.len(), 1);
+        assert_eq!(aggregation.empty_count, 1);
+        assert_eq!(aggregation.failed, vec!["git script"]);
+    }
+
+    #[test]
+    fn terminal_feedback_prefers_partial_error_with_loaded_results() {
+        let now = Instant::now();
+        let aggregation = DynamicAggregation {
+            loaded: vec![suggestion("main")],
+            empty_count: 0,
+            failed: vec!["git branches".into()],
+        };
+        assert!(matches!(
+            AsyncFeedback::terminal_from_aggregation(&aggregation, now),
+            AsyncFeedback::PartialError { .. }
+        ));
+    }
+}

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -14,8 +14,8 @@ use gc_suggest::{Suggestion, SuggestionEngine};
 use gc_terminal::TerminalProfile;
 use tokio::sync::{mpsc, Notify};
 
-use crate::dynamic_result::{DynamicResult, ErrorKind, ProviderTag};
-use crate::feedback::{AsyncFeedback, DynamicAggregation};
+use crate::dynamic_result::{DynamicResult, ProviderTag};
+use crate::feedback::AsyncFeedback;
 use crate::input::KeyEvent;
 
 /// Resolved keybindings — each action maps to a concrete `KeyEvent`.
@@ -228,6 +228,12 @@ pub struct InputHandler {
     feedback_tick_notify: Arc<Notify>,
     feedback: AsyncFeedback,
     feedback_dismiss_ms: u16,
+    /// Per-batch error/empty tallies that arrived in non-final mpsc batches.
+    /// Drained into the terminal-aggregation call when the dynamic channel
+    /// disconnects, so an Error or Empty message read in an early batch is
+    /// not lost when the next batch contains no Loaded results.
+    pending_failed: Vec<String>,
+    pending_empty_count: usize,
     /// Command context snapshot captured when generators were spawned.
     /// Consulted by `check_merge_staleness` (called from both
     /// `try_merge_dynamic` and `apply_block_result`) to drop stale results
@@ -293,6 +299,8 @@ impl InputHandler {
             feedback_tick_notify: Arc::new(Notify::new()),
             feedback: AsyncFeedback::Idle,
             feedback_dismiss_ms: 1200,
+            pending_failed: Vec::new(),
+            pending_empty_count: 0,
             dynamic_ctx: None,
             terminal_profile,
             scroll_deficit: 0,
@@ -441,6 +449,8 @@ impl InputHandler {
             self.dynamic_rx = None;
             self.dynamic_ctx = None;
             self.feedback = AsyncFeedback::Idle;
+            self.pending_failed.clear();
+            self.pending_empty_count = 0;
             self.trigger_requested = false;
         }
 
@@ -1060,11 +1070,6 @@ impl InputHandler {
 
     /// Apply the result of the bounded-block window after the debounce loop
     /// awaited the async generator outside the mutex lock.
-    ///
-    /// `maybe_async` is `Some(DynamicResult)` if the generator completed
-    /// within the window, or `None` if the timeout fired (in which case the
-    /// caller should restore `rx` via `rx_on_timeout` so `dynamic_merge_loop`
-    /// can deliver the late result).
     #[allow(clippy::too_many_arguments)] // all args are genuinely independent
     pub fn apply_block_result(
         &mut self,
@@ -1115,6 +1120,11 @@ impl InputHandler {
             self.dynamic_task = None;
         }
         let aggregation = AsyncFeedback::aggregate(messages);
+        // Roll the per-batch failed/empty into self.pending_* so a non-final
+        // batch's error reports survive to the disconnect-time terminal feedback
+        // computation.
+        self.pending_failed.extend(aggregation.failed);
+        self.pending_empty_count += aggregation.empty_count;
         if aggregation.loaded.is_empty() {
             if disconnected {
                 self.dynamic_ctx = None;
@@ -1122,16 +1132,25 @@ impl InputHandler {
             let now = std::time::Instant::now();
             self.feedback = if !disconnected {
                 self.feedback.clone()
-            } else if !aggregation.failed.is_empty() && !sync_suggestions.is_empty() {
+            } else if !self.pending_failed.is_empty() && !sync_suggestions.is_empty() {
                 AsyncFeedback::PartialError {
-                    failed: aggregation.failed.clone(),
+                    failed: std::mem::take(&mut self.pending_failed),
                     since: now,
                 }
-            } else if aggregation.empty_count > 0 && !sync_suggestions.is_empty() {
+            } else if self.pending_empty_count > 0 && !sync_suggestions.is_empty() {
                 AsyncFeedback::Idle
             } else {
-                AsyncFeedback::terminal_from_aggregation(&aggregation, now)
+                AsyncFeedback::terminal_for_outcome(
+                    false,
+                    &self.pending_failed,
+                    self.pending_empty_count,
+                    now,
+                )
             };
+            if disconnected {
+                self.pending_failed.clear();
+                self.pending_empty_count = 0;
+            }
             self.feedback_tick_notify.notify_one();
             if self.visible || self.feedback.is_terminal() || self.feedback.is_loading() {
                 self.render(parser, stdout);
@@ -1142,17 +1161,19 @@ impl InputHandler {
         let async_results = aggregation.loaded;
         let now = std::time::Instant::now();
         self.feedback = if disconnected {
-            AsyncFeedback::terminal_from_aggregation(
-                &DynamicAggregation {
-                    loaded: async_results.clone(),
-                    empty_count: aggregation.empty_count,
-                    failed: aggregation.failed.clone(),
-                },
+            AsyncFeedback::terminal_for_outcome(
+                !async_results.is_empty(),
+                &self.pending_failed,
+                self.pending_empty_count,
                 now,
             )
         } else {
             self.feedback.clone()
         };
+        if disconnected {
+            self.pending_failed.clear();
+            self.pending_empty_count = 0;
+        }
         self.feedback_tick_notify.notify_one();
 
         // Re-check that the buffer hasn't drifted while we were awaiting
@@ -1253,6 +1274,8 @@ impl InputHandler {
         self.feedback = AsyncFeedback::Loading {
             spawned_at: std::time::Instant::now(),
         };
+        self.pending_failed.clear();
+        self.pending_empty_count = 0;
         self.feedback_tick_notify.notify_one();
         let engine = Arc::clone(&self.engine);
         let ctx = ctx.clone();
@@ -1267,92 +1290,111 @@ impl InputHandler {
             // every keystroke, and no current provider reads `ctx.env`,
             // so the collected map would be dead weight on the hot path.
             let env = Arc::new(build_env_snapshot(!provider_generators.is_empty()));
-            let provider_ctx = gc_suggest::providers::ProviderCtx {
+            let provider_ctx = Arc::new(gc_suggest::providers::ProviderCtx {
                 cwd: cwd.clone(),
                 env,
                 current_token: ctx.current_word.clone(),
-            };
+            });
 
-            // Run script generators, git generators, and providers concurrently.
-            let (script_res, git_res, provider_res) = tokio::join!(
+            // Resolve script generators, git kinds, and provider kinds
+            // concurrently. Each git/provider kind is dispatched as its own
+            // per-kind helper so a per-kind error or empty result surfaces
+            // as its own DynamicResult and the ProviderTag carries the
+            // actual kind that produced it.
+            let git_engine = Arc::clone(&engine);
+            let git_cwd = cwd.clone();
+            let git_query = ctx.current_word.clone();
+            let git_kinds = git_generators.clone();
+            let git_fut = async move {
+                let mut out = Vec::with_capacity(git_kinds.len());
+                for kind in git_kinds {
+                    let res = git_engine
+                        .resolve_git_kind(kind, &git_cwd, &git_query)
+                        .await;
+                    out.push((kind, res));
+                }
+                out
+            };
+            let provider_engine = Arc::clone(&engine);
+            let provider_query = ctx.current_word.clone();
+            let provider_kinds = provider_generators.clone();
+            let provider_ctx_for_fut = Arc::clone(&provider_ctx);
+            let provider_fut = async move {
+                let mut out = Vec::with_capacity(provider_kinds.len());
+                for kind in provider_kinds {
+                    let res = provider_engine
+                        .resolve_provider_kind(kind, &provider_ctx_for_fut, &provider_query)
+                        .await;
+                    out.push((kind, res));
+                }
+                out
+            };
+            let (script_res, git_results, provider_results) = tokio::join!(
                 engine.run_generators(&script_generators, &ctx, &cwd, timeout),
-                engine.resolve_git(&git_generators, &cwd, &ctx.current_word),
-                engine.resolve_providers(&provider_generators, &provider_ctx, &ctx.current_word,),
+                git_fut,
+                provider_fut,
             );
 
             if !script_generators.is_empty() {
                 let provider = ProviderTag::Script(ctx.command.clone().unwrap_or_default());
-                match script_res {
-                    Ok(results) if results.is_empty() => {
-                        let _ = tx.send(DynamicResult::Empty { provider }).await;
-                    }
-                    Ok(results) => {
-                        let _ = tx
-                            .send(DynamicResult::Loaded {
-                                provider,
-                                suggestions: results,
-                            })
-                            .await;
-                    }
+                let message = match script_res {
+                    Ok(results) if results.is_empty() => DynamicResult::Empty { provider },
+                    Ok(results) => DynamicResult::Loaded {
+                        provider,
+                        suggestions: results,
+                    },
                     Err(e) => {
                         tracing::warn!("dynamic suggestions failed: {e}");
-                        let _ = tx
-                            .send(DynamicResult::Error {
-                                provider,
-                                kind: ErrorKind::Runtime(e.to_string()),
-                            })
-                            .await;
+                        DynamicResult::Error {
+                            provider,
+                            message: e.to_string(),
+                        }
                     }
+                };
+                if tx.send(message).await.is_err() {
+                    return;
                 }
             }
-            if !git_generators.is_empty() {
-                let provider = ProviderTag::Git(git_generators[0]);
-                match git_res {
-                    Ok(results) if results.is_empty() => {
-                        let _ = tx.send(DynamicResult::Empty { provider }).await;
-                    }
-                    Ok(results) => {
-                        let _ = tx
-                            .send(DynamicResult::Loaded {
-                                provider,
-                                suggestions: results,
-                            })
-                            .await;
-                    }
+
+            for (kind, result) in git_results {
+                let provider = ProviderTag::Git(kind);
+                let message = match result {
+                    Ok(results) if results.is_empty() => DynamicResult::Empty { provider },
+                    Ok(results) => DynamicResult::Loaded {
+                        provider,
+                        suggestions: results,
+                    },
                     Err(e) => {
-                        tracing::warn!("git suggestions failed: {e}");
-                        let _ = tx
-                            .send(DynamicResult::Error {
-                                provider,
-                                kind: ErrorKind::Runtime(e.to_string()),
-                            })
-                            .await;
+                        tracing::warn!("git suggestions failed ({kind:?}): {e}");
+                        DynamicResult::Error {
+                            provider,
+                            message: e.to_string(),
+                        }
                     }
+                };
+                if tx.send(message).await.is_err() {
+                    return;
                 }
             }
-            if !provider_generators.is_empty() {
-                let provider = ProviderTag::Provider(provider_generators[0]);
-                match provider_res {
-                    Ok(results) if results.is_empty() => {
-                        let _ = tx.send(DynamicResult::Empty { provider }).await;
-                    }
-                    Ok(results) => {
-                        let _ = tx
-                            .send(DynamicResult::Loaded {
-                                provider,
-                                suggestions: results,
-                            })
-                            .await;
-                    }
+
+            for (kind, result) in provider_results {
+                let provider = ProviderTag::Provider(kind);
+                let message = match result {
+                    Ok(results) if results.is_empty() => DynamicResult::Empty { provider },
+                    Ok(results) => DynamicResult::Loaded {
+                        provider,
+                        suggestions: results,
+                    },
                     Err(e) => {
-                        tracing::warn!("provider suggestions failed: {e}");
-                        let _ = tx
-                            .send(DynamicResult::Error {
-                                provider,
-                                kind: ErrorKind::Runtime(e.to_string()),
-                            })
-                            .await;
+                        tracing::warn!("provider suggestions failed ({kind:?}): {e}");
+                        DynamicResult::Error {
+                            provider,
+                            message: e.to_string(),
+                        }
                     }
+                };
+                if tx.send(message).await.is_err() {
+                    return;
                 }
             }
             // Drop tx BEFORE notifying so Task E sees Disconnected on
@@ -1446,7 +1488,25 @@ impl InputHandler {
                 self.dynamic_rx = None;
                 self.dynamic_ctx = None;
                 self.dynamic_task = None;
-                self.feedback = AsyncFeedback::Idle;
+                let now = std::time::Instant::now();
+                self.feedback = if !self.pending_failed.is_empty() && !self.suggestions.is_empty() {
+                    AsyncFeedback::PartialError {
+                        failed: std::mem::take(&mut self.pending_failed),
+                        since: now,
+                    }
+                } else if self.pending_empty_count > 0 && !self.suggestions.is_empty() {
+                    AsyncFeedback::Idle
+                } else {
+                    AsyncFeedback::terminal_for_outcome(
+                        false,
+                        &self.pending_failed,
+                        self.pending_empty_count,
+                        now,
+                    )
+                };
+                self.pending_failed.clear();
+                self.pending_empty_count = 0;
+                self.feedback_tick_notify.notify_one();
                 if self.visible {
                     self.render(parser, stdout);
                 }
@@ -1455,6 +1515,11 @@ impl InputHandler {
         }
 
         let aggregation = AsyncFeedback::aggregate(messages);
+        // Roll the per-batch failed/empty into self.pending_* so a non-final
+        // batch's error reports survive to the disconnect-time terminal feedback
+        // computation.
+        self.pending_failed.extend(aggregation.failed);
+        self.pending_empty_count += aggregation.empty_count;
 
         if disconnected {
             self.dynamic_rx = None;
@@ -1468,18 +1533,25 @@ impl InputHandler {
             let now = std::time::Instant::now();
             self.feedback = if !disconnected {
                 self.feedback.clone()
-            } else if !aggregation.failed.is_empty() && !self.suggestions.is_empty() {
+            } else if !self.pending_failed.is_empty() && !self.suggestions.is_empty() {
                 AsyncFeedback::PartialError {
-                    failed: aggregation.failed.clone(),
+                    failed: std::mem::take(&mut self.pending_failed),
                     since: now,
                 }
-            } else if aggregation.empty_count > 0 && !self.suggestions.is_empty() {
+            } else if self.pending_empty_count > 0 && !self.suggestions.is_empty() {
                 AsyncFeedback::Idle
-            } else if !aggregation.failed.is_empty() || aggregation.empty_count > 0 {
-                AsyncFeedback::terminal_from_aggregation(&aggregation, now)
             } else {
-                AsyncFeedback::Idle
+                AsyncFeedback::terminal_for_outcome(
+                    false,
+                    &self.pending_failed,
+                    self.pending_empty_count,
+                    now,
+                )
             };
+            if disconnected {
+                self.pending_failed.clear();
+                self.pending_empty_count = 0;
+            }
             self.feedback_tick_notify.notify_one();
             self.render(parser, stdout);
             return !matches!(self.feedback, AsyncFeedback::Idle);
@@ -1490,17 +1562,19 @@ impl InputHandler {
             let now = std::time::Instant::now();
             let previous_feedback = self.feedback.clone();
             self.feedback = if disconnected {
-                AsyncFeedback::terminal_from_aggregation(
-                    &DynamicAggregation {
-                        loaded: dynamic_results.clone(),
-                        empty_count: aggregation.empty_count,
-                        failed: aggregation.failed.clone(),
-                    },
+                AsyncFeedback::terminal_for_outcome(
+                    !dynamic_results.is_empty(),
+                    &self.pending_failed,
+                    self.pending_empty_count,
                     now,
                 )
             } else {
                 previous_feedback
             };
+            if disconnected {
+                self.pending_failed.clear();
+                self.pending_empty_count = 0;
+            }
             self.feedback_tick_notify.notify_one();
             if disconnected {
                 self.dynamic_rx = None;
@@ -1511,25 +1585,15 @@ impl InputHandler {
                 // cleanup guarantees.
                 self.dynamic_task = None;
             }
-            // Note: `spawn_generators` only sends when the result is
-            // non-empty, so the empty-Ok case is unreachable in
-            // production. The "all generators returned empty" path is
-            // handled by the Disconnected arm below (tx is dropped
-            // without sending). See the regression test
-            // `test_try_merge_dynamic_disconnected_rerenders_to_clear_loading`.
             let current_word = match self.check_merge_staleness(parser) {
                 MergeFreshness::Fresh { current_word } => current_word,
                 MergeFreshness::Stale => {
-                    // Don't merge. If the popup is visible from the
-                    // mixed static+async path, static suggestions stay
-                    // but we must repaint so the loading indicator
-                    // clears (same reasoning as the empty-results
-                    // branch above). If not visible (async-only path),
-                    // nothing happens.
                     self.dynamic_rx = None;
                     self.dynamic_ctx = None;
                     self.dynamic_task = None;
                     self.feedback = AsyncFeedback::Idle;
+                    self.pending_failed.clear();
+                    self.pending_empty_count = 0;
                     if self.visible {
                         self.render(parser, stdout);
                     }
@@ -1687,13 +1751,21 @@ impl InputHandler {
                 }
             }
             AsyncFeedback::Empty { .. } => FeedbackKind::Empty,
-            AsyncFeedback::Error { failed, .. } => FeedbackKind::Error {
-                provider: if self.theme.show_provider_errors {
-                    failed.first().cloned().unwrap_or_default()
+            AsyncFeedback::Error { failed, .. } => {
+                if failed.len() > 1 {
+                    FeedbackKind::PartialError {
+                        providers: failed.len().min(u8::MAX as usize) as u8,
+                    }
                 } else {
-                    String::new()
-                },
-            },
+                    FeedbackKind::Error {
+                        provider: if self.theme.show_provider_errors {
+                            failed.first().cloned().unwrap_or_default()
+                        } else {
+                            String::new()
+                        },
+                    }
+                }
+            }
             AsyncFeedback::PartialError { failed, .. } => FeedbackKind::PartialError {
                 providers: failed.len().min(u8::MAX as usize) as u8,
             },
@@ -1724,6 +1796,39 @@ impl InputHandler {
         if since.elapsed() < std::time::Duration::from_millis(self.feedback_dismiss_ms as u64) {
             return false;
         }
+        // PartialError means some providers succeeded — the popup currently
+        // shows real merged suggestions plus an indicator row. Demote to Idle
+        // and clear just the indicator row so the suggestions stay visible.
+        if matches!(self.feedback, AsyncFeedback::PartialError { .. })
+            && !self.suggestions.is_empty()
+        {
+            self.feedback = AsyncFeedback::Idle;
+            if let Some(mut layout) = self.last_layout.clone() {
+                // Clear the indicator row: it sits at
+                // start_row + height - 1 - borders. Replace it with spaces
+                // and shrink the cached layout height by one so subsequent
+                // dismiss/clear_popup calls don't miss-target a row.
+                if layout.height > 0 {
+                    let indicator_row =
+                        layout.start_row + layout.height - 1 - u16::from(self.theme.borders);
+                    let mut buf = Vec::with_capacity(layout.width as usize + 16);
+                    buf.extend_from_slice(b"\x1b[s"); // save cursor
+                    let _ = write!(
+                        &mut buf,
+                        "\x1b[{};{}H",
+                        indicator_row + 1,
+                        layout.start_col + 1
+                    );
+                    buf.extend(std::iter::repeat_n(b' ', layout.width as usize));
+                    buf.extend_from_slice(b"\x1b[u"); // restore cursor
+                    let _ = stdout.write_all(&buf);
+                    let _ = stdout.flush();
+                    layout.height -= 1;
+                    self.last_layout = Some(layout);
+                }
+            }
+            return true;
+        }
         self.feedback = AsyncFeedback::Idle;
         self.dismiss(stdout);
         true
@@ -1748,6 +1853,8 @@ impl InputHandler {
         self.dynamic_rx = None;
         self.dynamic_ctx = None;
         self.feedback = AsyncFeedback::Idle;
+        self.pending_failed.clear();
+        self.pending_empty_count = 0;
         // Invalidate the idempotency guard so the next trigger (e.g. after
         // ESC-then-retrigger on the same buffer) runs a fresh suggest_sync
         // instead of short-circuiting.
@@ -1863,6 +1970,8 @@ impl InputHandler {
             handle.abort();
         }
         self.feedback = AsyncFeedback::Idle;
+        self.pending_failed.clear();
+        self.pending_empty_count = 0;
     }
 
     /// Abort any in-flight dynamic generator task and clear the spawn-time
@@ -1877,6 +1986,8 @@ impl InputHandler {
         self.dynamic_ctx = None;
         self.dynamic_rx = None;
         self.feedback = AsyncFeedback::Idle;
+        self.pending_failed.clear();
+        self.pending_empty_count = 0;
     }
 
     /// Flush unsaved frecency records to disk. Call on proxy shutdown.
@@ -2543,6 +2654,8 @@ mod tests {
             feedback_tick_notify: Arc::new(Notify::new()),
             feedback: AsyncFeedback::Idle,
             feedback_dismiss_ms: 1200,
+            pending_failed: Vec::new(),
+            pending_empty_count: 0,
             dynamic_ctx: None,
             terminal_profile: TerminalProfile::for_ghostty(),
             scroll_deficit: 0,
@@ -3461,5 +3574,246 @@ mod tests {
         let kept = merge_dedup_against(&[], incoming);
         let texts: Vec<&str> = kept.iter().map(|s| s.text.as_str()).collect();
         assert_eq!(texts, vec!["main", "dev"]);
+    }
+
+    // --- clear_expired_feedback state machine ---
+
+    #[test]
+    fn test_clear_expired_feedback_returns_false_when_idle() {
+        let mut handler = make_visible_handler(Vec::new()).with_feedback_dismiss_ms(1200);
+        handler.feedback = AsyncFeedback::Idle;
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(!handler.clear_expired_feedback(&mut buf));
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_clear_expired_feedback_returns_false_when_loading() {
+        let mut handler = make_visible_handler(Vec::new()).with_feedback_dismiss_ms(1200);
+        handler.feedback = AsyncFeedback::Loading {
+            spawned_at: std::time::Instant::now(),
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(!handler.clear_expired_feedback(&mut buf));
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_clear_expired_feedback_returns_false_when_dismiss_disabled() {
+        let mut handler = make_visible_handler(Vec::new()).with_feedback_dismiss_ms(0);
+        handler.feedback = AsyncFeedback::Empty {
+            since: std::time::Instant::now() - std::time::Duration::from_secs(10),
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(!handler.clear_expired_feedback(&mut buf));
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_clear_expired_feedback_returns_false_when_not_yet_expired() {
+        let mut handler = make_visible_handler(Vec::new()).with_feedback_dismiss_ms(10_000);
+        handler.feedback = AsyncFeedback::Empty {
+            since: std::time::Instant::now(),
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(!handler.clear_expired_feedback(&mut buf));
+        assert!(handler.visible);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_clear_expired_feedback_dismisses_on_expired_empty() {
+        let mut handler = make_visible_handler(Vec::new()).with_feedback_dismiss_ms(1200);
+        handler.feedback = AsyncFeedback::Empty {
+            since: std::time::Instant::now() - std::time::Duration::from_millis(2000),
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(handler.clear_expired_feedback(&mut buf));
+        assert!(!handler.visible);
+        assert!(matches!(handler.feedback, AsyncFeedback::Idle));
+    }
+
+    #[test]
+    fn test_clear_expired_feedback_partial_error_with_suggestions_demotes_to_idle() {
+        // Regression: when feedback is PartialError and the popup currently
+        // has merged suggestions, expiring the feedback must NOT dismiss the
+        // popup. The suggestions are real user-visible state — drop only the
+        // indicator row and demote feedback to Idle.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "main".into(),
+            kind: SuggestionKind::GitBranch,
+            ..Default::default()
+        }])
+        .with_feedback_dismiss_ms(1200);
+        handler.feedback = AsyncFeedback::PartialError {
+            failed: vec!["git script".into()],
+            since: std::time::Instant::now() - std::time::Duration::from_millis(2000),
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(handler.clear_expired_feedback(&mut buf));
+        assert!(handler.visible, "popup must stay visible");
+        assert_eq!(handler.suggestions.len(), 1, "suggestions must survive");
+        assert!(matches!(handler.feedback, AsyncFeedback::Idle));
+    }
+
+    // --- try_merge_dynamic disconnect branches ---
+
+    #[test]
+    fn test_try_merge_dynamic_error_only_disconnect_yields_error() {
+        let mut handler = make_visible_handler(Vec::new());
+        let base_ctx = gc_buffer::parse_command_context("", 0);
+        handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
+
+        let (tx, rx) = mpsc::channel::<DynamicResult>(1);
+        tx.try_send(DynamicResult::Error {
+            provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+            message: "boom".into(),
+        })
+        .unwrap();
+        drop(tx);
+        handler.dynamic_rx = Some(rx);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        handler.try_merge_dynamic(&parser, &mut buf);
+
+        match handler.feedback_kind() {
+            AsyncFeedback::Error { failed, .. } => {
+                assert_eq!(failed.len(), 1, "single failed provider expected");
+            }
+            other => panic!("expected Error feedback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_try_merge_dynamic_partial_error_with_static_present() {
+        // Pre-seed a static suggestion, then deliver one Loaded + one Error
+        // with a final disconnect. PartialError must result.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "--flag".into(),
+            kind: SuggestionKind::Flag,
+            source: SuggestionSource::Spec,
+            ..Default::default()
+        }]);
+        let base_ctx = gc_buffer::parse_command_context("", 0);
+        handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
+
+        let (tx, rx) = mpsc::channel::<DynamicResult>(2);
+        tx.try_send(DynamicResult::Loaded {
+            provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+            suggestions: vec![Suggestion {
+                text: "main".into(),
+                kind: SuggestionKind::GitBranch,
+                source: SuggestionSource::Git,
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+        tx.try_send(DynamicResult::Error {
+            provider: ProviderTag::Script("npm".into()),
+            message: "oops".into(),
+        })
+        .unwrap();
+        drop(tx);
+        handler.dynamic_rx = Some(rx);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        handler.try_merge_dynamic(&parser, &mut buf);
+
+        match handler.feedback_kind() {
+            AsyncFeedback::PartialError { failed, .. } => {
+                assert_eq!(failed.len(), 1);
+            }
+            other => panic!("expected PartialError feedback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_try_merge_dynamic_empty_only_with_no_static_yields_empty() {
+        let mut handler = make_visible_handler(Vec::new());
+        let base_ctx = gc_buffer::parse_command_context("", 0);
+        handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
+
+        let (tx, rx) = mpsc::channel::<DynamicResult>(1);
+        tx.try_send(DynamicResult::Empty {
+            provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+        })
+        .unwrap();
+        drop(tx);
+        handler.dynamic_rx = Some(rx);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        handler.try_merge_dynamic(&parser, &mut buf);
+
+        assert!(matches!(
+            handler.feedback_kind(),
+            AsyncFeedback::Empty { .. }
+        ));
+    }
+
+    // --- current_feedback_kind redaction and Error → PartialError fallthrough ---
+
+    #[test]
+    fn test_current_feedback_kind_redacts_provider_when_disabled() {
+        let mut handler = make_handler();
+        handler.theme.show_provider_errors = false;
+        handler.feedback = AsyncFeedback::Error {
+            failed: vec!["git script".into()],
+            since: std::time::Instant::now(),
+        };
+        match handler.current_feedback_kind() {
+            gc_overlay::FeedbackKind::Error { provider } => {
+                assert_eq!(provider, "", "provider must be redacted");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_current_feedback_kind_surfaces_provider_when_enabled() {
+        let mut handler = make_handler();
+        handler.theme.show_provider_errors = true;
+        handler.feedback = AsyncFeedback::Error {
+            failed: vec!["git script".into()],
+            since: std::time::Instant::now(),
+        };
+        match handler.current_feedback_kind() {
+            gc_overlay::FeedbackKind::Error { provider } => {
+                assert_eq!(provider, "git script");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_current_feedback_kind_multi_failed_falls_through_to_partial_error() {
+        let mut handler = make_handler();
+        handler.feedback = AsyncFeedback::Error {
+            failed: vec!["a".into(), "b".into(), "c".into()],
+            since: std::time::Instant::now(),
+        };
+        match handler.current_feedback_kind() {
+            gc_overlay::FeedbackKind::PartialError { providers } => {
+                assert_eq!(providers, 3);
+            }
+            other => panic!("expected PartialError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_current_feedback_kind_partial_error_clamps_at_u8_max() {
+        let mut handler = make_handler();
+        handler.feedback = AsyncFeedback::PartialError {
+            failed: (0..300).map(|i| format!("p{i}")).collect(),
+            since: std::time::Instant::now(),
+        };
+        match handler.current_feedback_kind() {
+            gc_overlay::FeedbackKind::PartialError { providers } => {
+                assert_eq!(providers, u8::MAX);
+            }
+            other => panic!("expected PartialError, got {other:?}"),
+        }
     }
 }

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -8,12 +8,14 @@ use gc_overlay::types::{
     OverlayState, PopupLayout, DEFAULT_MAX_POPUP_WIDTH, DEFAULT_MAX_VISIBLE,
     DEFAULT_MIN_POPUP_WIDTH,
 };
-use gc_overlay::{clear_popup, render_popup, PopupTheme};
+use gc_overlay::{clear_popup, render_indicator_row, render_popup, FeedbackKind, PopupTheme};
 use gc_parser::TerminalParser;
 use gc_suggest::{Suggestion, SuggestionEngine};
 use gc_terminal::TerminalProfile;
 use tokio::sync::{mpsc, Notify};
 
+use crate::dynamic_result::{DynamicResult, ErrorKind, ProviderTag};
+use crate::feedback::{AsyncFeedback, DynamicAggregation};
 use crate::input::KeyEvent;
 
 /// Resolved keybindings — each action maps to a concrete `KeyEvent`.
@@ -182,7 +184,7 @@ pub enum TriggerPrepared {
     /// `apply_block_result` under the handler lock.
     NeedsBlock {
         /// Receiver to `await` for the async generator's results.
-        rx: mpsc::Receiver<Vec<Suggestion>>,
+        rx: mpsc::Receiver<DynamicResult>,
         /// Sync-only suggestions already painted. Used for merging.
         sync_suggestions: Vec<Suggestion>,
         /// Maximum wait duration.
@@ -220,9 +222,12 @@ pub struct InputHandler {
     /// Populated via [`InputHandler::with_suggest_config`] during builder
     /// phase, defaulting to [`DEFAULT_GENERATOR_TIMEOUT_MS`] when unset.
     generator_timeout_ms: u64,
-    dynamic_rx: Option<mpsc::Receiver<Vec<Suggestion>>>,
+    dynamic_rx: Option<mpsc::Receiver<DynamicResult>>,
     dynamic_task: Option<tokio::task::JoinHandle<()>>,
     dynamic_notify: Arc<Notify>,
+    feedback_tick_notify: Arc<Notify>,
+    feedback: AsyncFeedback,
+    feedback_dismiss_ms: u16,
     /// Command context snapshot captured when generators were spawned.
     /// Consulted by `check_merge_staleness` (called from both
     /// `try_merge_dynamic` and `apply_block_result`) to drop stale results
@@ -285,6 +290,9 @@ impl InputHandler {
             dynamic_rx: None,
             dynamic_task: None,
             dynamic_notify: Arc::new(Notify::new()),
+            feedback_tick_notify: Arc::new(Notify::new()),
+            feedback: AsyncFeedback::Idle,
+            feedback_dismiss_ms: 1200,
             dynamic_ctx: None,
             terminal_profile,
             scroll_deficit: 0,
@@ -299,8 +307,17 @@ impl InputHandler {
         Arc::clone(&self.dynamic_notify)
     }
 
+    pub fn feedback_tick_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.feedback_tick_notify)
+    }
+
     pub fn with_popup_config(mut self, max_visible: usize) -> Self {
         self.max_visible = max_visible;
+        self
+    }
+
+    pub fn with_feedback_dismiss_ms(mut self, ms: u16) -> Self {
+        self.feedback_dismiss_ms = ms;
         self
     }
 
@@ -399,6 +416,7 @@ impl InputHandler {
         keybindings: Keybindings,
         trigger_chars: &[char],
         max_visible: usize,
+        feedback_dismiss_ms: u16,
         auto_trigger: bool,
     ) -> Vec<u8> {
         let mut cleanup = Vec::new();
@@ -422,6 +440,7 @@ impl InputHandler {
             }
             self.dynamic_rx = None;
             self.dynamic_ctx = None;
+            self.feedback = AsyncFeedback::Idle;
             self.trigger_requested = false;
         }
 
@@ -429,6 +448,7 @@ impl InputHandler {
         self.keybindings = keybindings;
         self.trigger_chars = trigger_chars.to_vec();
         self.max_visible = max_visible;
+        self.feedback_dismiss_ms = feedback_dismiss_ms;
         self.auto_trigger = auto_trigger;
 
         cleanup
@@ -459,7 +479,7 @@ impl InputHandler {
     /// allows `dynamic_merge_loop` to pick up the result when the generator
     /// eventually completes.
     #[doc(hidden)]
-    pub fn restore_dynamic_rx(&mut self, rx: mpsc::Receiver<Vec<Suggestion>>) {
+    pub fn restore_dynamic_rx(&mut self, rx: mpsc::Receiver<DynamicResult>) {
         self.dynamic_rx = Some(rx);
     }
 
@@ -477,8 +497,13 @@ impl InputHandler {
 
     /// Takes the `dynamic_rx` channel out of the handler, leaving `None`.
     #[doc(hidden)]
-    pub fn take_dynamic_rx(&mut self) -> Option<mpsc::Receiver<Vec<Suggestion>>> {
+    pub fn take_dynamic_rx(&mut self) -> Option<mpsc::Receiver<DynamicResult>> {
         self.dynamic_rx.take()
+    }
+
+    #[doc(hidden)]
+    pub fn feedback_kind(&self) -> &AsyncFeedback {
+        &self.feedback
     }
 
     /// Returns the current suggestions slice (read-only).
@@ -829,6 +854,7 @@ impl InputHandler {
         }
         self.dynamic_rx = None;
         self.dynamic_ctx = None;
+        self.feedback = AsyncFeedback::Idle;
 
         self.buffer_generation = self.buffer_generation.wrapping_add(1);
 
@@ -954,6 +980,7 @@ impl InputHandler {
         }
         self.dynamic_rx = None;
         self.dynamic_ctx = None;
+        self.feedback = AsyncFeedback::Idle;
         self.buffer_generation = self.buffer_generation.wrapping_add(1);
 
         let result = match self.engine.suggest_sync(&ctx, &cwd, &buffer) {
@@ -1034,7 +1061,7 @@ impl InputHandler {
     /// Apply the result of the bounded-block window after the debounce loop
     /// awaited the async generator outside the mutex lock.
     ///
-    /// `maybe_async` is `Some(Vec<Suggestion>)` if the generator completed
+    /// `maybe_async` is `Some(DynamicResult)` if the generator completed
     /// within the window, or `None` if the timeout fired (in which case the
     /// caller should restore `rx` via `rx_on_timeout` so `dynamic_merge_loop`
     /// can deliver the late result).
@@ -1043,8 +1070,9 @@ impl InputHandler {
         &mut self,
         parser: &Arc<Mutex<TerminalParser>>,
         stdout: &mut Vec<u8>,
-        maybe_async: Option<Vec<Suggestion>>,
-        rx_on_timeout: Option<mpsc::Receiver<Vec<Suggestion>>>,
+        maybe_async: Option<DynamicResult>,
+        rx_after_recv: Option<mpsc::Receiver<DynamicResult>>,
+        rx_on_timeout: Option<mpsc::Receiver<DynamicResult>>,
         sync_suggestions: Vec<Suggestion>,
         cursor_row: u16,
         cursor_col: u16,
@@ -1065,25 +1093,67 @@ impl InputHandler {
             return;
         }
 
-        // Generator finished (sent results, sent empty, or disconnected).
-        // Cleanup the task handle now; `check_merge_staleness` clears
-        // `dynamic_ctx` after it consults it, so leave that alone here.
-        self.dynamic_task = None;
-
-        let async_results = match maybe_async {
-            Some(items) if !items.is_empty() => items,
-            _ => {
-                // Generator returned nothing. Clear ctx and repaint to clear
-                // the loading indicator (mirrors try_merge_dynamic's
-                // Disconnected arm).
-                self.dynamic_ctx = None;
-                if self.visible {
-                    self.render(parser, stdout);
+        let mut messages = maybe_async.into_iter().collect::<Vec<_>>();
+        let mut disconnected = rx_after_recv.is_none();
+        if let Some(mut rx) = rx_after_recv {
+            loop {
+                match rx.try_recv() {
+                    Ok(message) => messages.push(message),
+                    Err(mpsc::error::TryRecvError::Empty) => {
+                        self.dynamic_rx = Some(rx);
+                        break;
+                    }
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        disconnected = true;
+                        break;
+                    }
                 }
-                self.last_trigger_fingerprint = Some(fingerprint);
-                return;
             }
+        }
+        if disconnected {
+            self.dynamic_rx = None;
+            self.dynamic_task = None;
+        }
+        let aggregation = AsyncFeedback::aggregate(messages);
+        if aggregation.loaded.is_empty() {
+            if disconnected {
+                self.dynamic_ctx = None;
+            }
+            let now = std::time::Instant::now();
+            self.feedback = if !disconnected {
+                self.feedback.clone()
+            } else if !aggregation.failed.is_empty() && !sync_suggestions.is_empty() {
+                AsyncFeedback::PartialError {
+                    failed: aggregation.failed.clone(),
+                    since: now,
+                }
+            } else if aggregation.empty_count > 0 && !sync_suggestions.is_empty() {
+                AsyncFeedback::Idle
+            } else {
+                AsyncFeedback::terminal_from_aggregation(&aggregation, now)
+            };
+            self.feedback_tick_notify.notify_one();
+            if self.visible || self.feedback.is_terminal() || self.feedback.is_loading() {
+                self.render(parser, stdout);
+            }
+            self.last_trigger_fingerprint = Some(fingerprint);
+            return;
+        }
+        let async_results = aggregation.loaded;
+        let now = std::time::Instant::now();
+        self.feedback = if disconnected {
+            AsyncFeedback::terminal_from_aggregation(
+                &DynamicAggregation {
+                    loaded: async_results.clone(),
+                    empty_count: aggregation.empty_count,
+                    failed: aggregation.failed.clone(),
+                },
+                now,
+            )
+        } else {
+            self.feedback.clone()
         };
+        self.feedback_tick_notify.notify_one();
 
         // Re-check that the buffer hasn't drifted while we were awaiting
         // the generator. The captured `cursor_row` / `cursor_col` /
@@ -1093,6 +1163,10 @@ impl InputHandler {
         let live_word = match self.check_merge_staleness(parser) {
             MergeFreshness::Fresh { current_word } => current_word,
             MergeFreshness::Stale => {
+                self.dynamic_rx = None;
+                self.dynamic_ctx = None;
+                self.dynamic_task = None;
+                self.feedback = AsyncFeedback::Idle;
                 if self.visible {
                     self.render(parser, stdout);
                 }
@@ -1126,6 +1200,9 @@ impl InputHandler {
         self.suggestions = all;
         self.overlay.reset();
         self.visible = true;
+        if disconnected {
+            self.dynamic_ctx = None;
+        }
         // Render against the live cursor/screen geometry: when the buffer
         // drifted (live_word differs from spawn-time current_word) the
         // captured cursor row is no longer where the prompt sits.
@@ -1171,16 +1248,18 @@ impl InputHandler {
         });
         self.dynamic_ctx = Some(DynamicCtxSnapshot::capture(ctx, uses_current_word));
         self.spawned_generation = self.buffer_generation;
-        let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
+        let (tx, rx) = mpsc::channel::<DynamicResult>(8);
         self.dynamic_rx = Some(rx);
+        self.feedback = AsyncFeedback::Loading {
+            spawned_at: std::time::Instant::now(),
+        };
+        self.feedback_tick_notify.notify_one();
         let engine = Arc::clone(&self.engine);
         let ctx = ctx.clone();
         let cwd = cwd.to_path_buf();
         let timeout = self.generator_timeout_ms;
         let notify = Arc::clone(&self.dynamic_notify);
         let handle = tokio::spawn(async move {
-            let mut all_results = Vec::new();
-
             // Build ProviderCtx once — the env snapshot is shared across
             // every provider in this resolution pass. Skip the
             // `std::env::vars().collect()` walk when no provider is
@@ -1201,21 +1280,80 @@ impl InputHandler {
                 engine.resolve_providers(&provider_generators, &provider_ctx, &ctx.current_word,),
             );
 
-            match script_res {
-                Ok(results) => all_results.extend(results),
-                Err(e) => tracing::warn!("dynamic suggestions failed: {e}"),
+            if !script_generators.is_empty() {
+                let provider = ProviderTag::Script(ctx.command.clone().unwrap_or_default());
+                match script_res {
+                    Ok(results) if results.is_empty() => {
+                        let _ = tx.send(DynamicResult::Empty { provider }).await;
+                    }
+                    Ok(results) => {
+                        let _ = tx
+                            .send(DynamicResult::Loaded {
+                                provider,
+                                suggestions: results,
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        tracing::warn!("dynamic suggestions failed: {e}");
+                        let _ = tx
+                            .send(DynamicResult::Error {
+                                provider,
+                                kind: ErrorKind::Runtime(e.to_string()),
+                            })
+                            .await;
+                    }
+                }
             }
-            match git_res {
-                Ok(results) => all_results.extend(results),
-                Err(e) => tracing::warn!("git suggestions failed: {e}"),
+            if !git_generators.is_empty() {
+                let provider = ProviderTag::Git(git_generators[0]);
+                match git_res {
+                    Ok(results) if results.is_empty() => {
+                        let _ = tx.send(DynamicResult::Empty { provider }).await;
+                    }
+                    Ok(results) => {
+                        let _ = tx
+                            .send(DynamicResult::Loaded {
+                                provider,
+                                suggestions: results,
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        tracing::warn!("git suggestions failed: {e}");
+                        let _ = tx
+                            .send(DynamicResult::Error {
+                                provider,
+                                kind: ErrorKind::Runtime(e.to_string()),
+                            })
+                            .await;
+                    }
+                }
             }
-            match provider_res {
-                Ok(results) => all_results.extend(results),
-                Err(e) => tracing::warn!("provider suggestions failed: {e}"),
-            }
-
-            if !all_results.is_empty() {
-                let _ = tx.send(all_results).await;
+            if !provider_generators.is_empty() {
+                let provider = ProviderTag::Provider(provider_generators[0]);
+                match provider_res {
+                    Ok(results) if results.is_empty() => {
+                        let _ = tx.send(DynamicResult::Empty { provider }).await;
+                    }
+                    Ok(results) => {
+                        let _ = tx
+                            .send(DynamicResult::Loaded {
+                                provider,
+                                suggestions: results,
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        tracing::warn!("provider suggestions failed: {e}");
+                        let _ = tx
+                            .send(DynamicResult::Error {
+                                provider,
+                                kind: ErrorKind::Runtime(e.to_string()),
+                            })
+                            .await;
+                    }
+                }
             }
             // Drop tx BEFORE notifying so Task E sees Disconnected on
             // the first try_recv after wake. Otherwise on a multi-threaded
@@ -1271,7 +1409,6 @@ impl InputHandler {
             Some(spawned) => spawned.is_stale_against(&current_ctx),
             None => true,
         };
-        self.dynamic_ctx = None;
         if stale {
             return MergeFreshness::Stale;
         }
@@ -1285,13 +1422,87 @@ impl InputHandler {
         parser: &Arc<Mutex<TerminalParser>>,
         stdout: &mut dyn Write,
     ) -> bool {
-        let rx = match self.dynamic_rx.as_mut() {
-            Some(rx) => rx,
-            None => return false,
-        };
+        let mut messages = Vec::new();
+        let mut disconnected = false;
+        {
+            let rx = match self.dynamic_rx.as_mut() {
+                Some(rx) => rx,
+                None => return false,
+            };
+            loop {
+                match rx.try_recv() {
+                    Ok(message) => messages.push(message),
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        disconnected = true;
+                        break;
+                    }
+                }
+            }
+        }
 
-        match rx.try_recv() {
-            Ok(dynamic_results) => {
+        if messages.is_empty() {
+            if disconnected {
+                self.dynamic_rx = None;
+                self.dynamic_ctx = None;
+                self.dynamic_task = None;
+                self.feedback = AsyncFeedback::Idle;
+                if self.visible {
+                    self.render(parser, stdout);
+                }
+            }
+            return false;
+        }
+
+        let aggregation = AsyncFeedback::aggregate(messages);
+
+        if disconnected {
+            self.dynamic_rx = None;
+            self.dynamic_task = None;
+        }
+
+        if aggregation.loaded.is_empty() {
+            if disconnected {
+                self.dynamic_ctx = None;
+            }
+            let now = std::time::Instant::now();
+            self.feedback = if !disconnected {
+                self.feedback.clone()
+            } else if !aggregation.failed.is_empty() && !self.suggestions.is_empty() {
+                AsyncFeedback::PartialError {
+                    failed: aggregation.failed.clone(),
+                    since: now,
+                }
+            } else if aggregation.empty_count > 0 && !self.suggestions.is_empty() {
+                AsyncFeedback::Idle
+            } else if !aggregation.failed.is_empty() || aggregation.empty_count > 0 {
+                AsyncFeedback::terminal_from_aggregation(&aggregation, now)
+            } else {
+                AsyncFeedback::Idle
+            };
+            self.feedback_tick_notify.notify_one();
+            self.render(parser, stdout);
+            return !matches!(self.feedback, AsyncFeedback::Idle);
+        }
+
+        {
+            let dynamic_results = aggregation.loaded;
+            let now = std::time::Instant::now();
+            let previous_feedback = self.feedback.clone();
+            self.feedback = if disconnected {
+                AsyncFeedback::terminal_from_aggregation(
+                    &DynamicAggregation {
+                        loaded: dynamic_results.clone(),
+                        empty_count: aggregation.empty_count,
+                        failed: aggregation.failed.clone(),
+                    },
+                    now,
+                )
+            } else {
+                previous_feedback
+            };
+            self.feedback_tick_notify.notify_one();
+            if disconnected {
                 self.dynamic_rx = None;
                 // The generator task has completed (it sent its results and
                 // dropped tx). The JoinHandle is now a no-op for `.abort()`
@@ -1299,120 +1510,108 @@ impl InputHandler {
                 // on an already-completed handle for their orphan-task
                 // cleanup guarantees.
                 self.dynamic_task = None;
-                // Note: `spawn_generators` only sends when the result is
-                // non-empty, so the empty-Ok case is unreachable in
-                // production. The "all generators returned empty" path is
-                // handled by the Disconnected arm below (tx is dropped
-                // without sending). See the regression test
-                // `test_try_merge_dynamic_disconnected_rerenders_to_clear_loading`.
-                let current_word = match self.check_merge_staleness(parser) {
-                    MergeFreshness::Fresh { current_word } => current_word,
-                    MergeFreshness::Stale => {
-                        // Don't merge. If the popup is visible from the
-                        // mixed static+async path, static suggestions stay
-                        // but we must repaint so the loading indicator
-                        // clears (same reasoning as the empty-results
-                        // branch above). If not visible (async-only path),
-                        // nothing happens.
-                        if self.visible {
-                            self.render(parser, stdout);
-                        }
-                        return false;
+            }
+            // Note: `spawn_generators` only sends when the result is
+            // non-empty, so the empty-Ok case is unreachable in
+            // production. The "all generators returned empty" path is
+            // handled by the Disconnected arm below (tx is dropped
+            // without sending). See the regression test
+            // `test_try_merge_dynamic_disconnected_rerenders_to_clear_loading`.
+            let current_word = match self.check_merge_staleness(parser) {
+                MergeFreshness::Fresh { current_word } => current_word,
+                MergeFreshness::Stale => {
+                    // Don't merge. If the popup is visible from the
+                    // mixed static+async path, static suggestions stay
+                    // but we must repaint so the loading indicator
+                    // clears (same reasoning as the empty-results
+                    // branch above). If not visible (async-only path),
+                    // nothing happens.
+                    self.dynamic_rx = None;
+                    self.dynamic_ctx = None;
+                    self.dynamic_task = None;
+                    self.feedback = AsyncFeedback::Idle;
+                    if self.visible {
+                        self.render(parser, stdout);
                     }
-                    MergeFreshness::PoisonedLock => return false,
-                };
-
-                // Activate popup if it wasn't visible yet (async-only path:
-                // no static suggestions, generators produced the results).
-                if !self.visible {
-                    self.visible = true;
-                    self.overlay.reset();
+                    return false;
                 }
+                MergeFreshness::PoisonedLock => return false,
+            };
 
-                let extras = merge_dedup_against(&self.suggestions, dynamic_results);
-                self.suggestions.extend(extras);
-                let merged = std::mem::take(&mut self.suggestions);
-                // Merge-time rank: when the user has a non-empty query, filter
-                // the pool to matches sorted by relevance and cap at
-                // `max_visible * 5` (generous headroom over what's rendered).
-                //
-                // When the spawn-time query is empty (user triggered on space
-                // then hasn't typed yet), `fuzzy::rank("", pool, N)` takes the
-                // empty-query fast path in `gc_suggest::fuzzy::rank` which
-                // sorts by kind priority and then alphabetically, then
-                // truncates to N. For single-kind dynamic pools (e.g. git
-                // branches from `resolve_git`), kind priority is uniform, so
-                // the effective result is "first N branches alphabetically"
-                // — dropping any candidate past alphabetic position ~50. A
-                // branch named `zzz-hotfix-critical` in a 5000-branch monorepo
-                // would be silently evicted at merge time, and the subsequent
-                // keystroke-driven re-rank could never recover it because the
-                // full pool is gone.
-                //
-                // Instead, when merging with an empty query, keep the full
-                // pool untruncated. The render path slices
-                // `&suggestions[scroll_offset..scroll_offset + content_height]`
-                // where `content_height` is capped by the visible viewport,
-                // so a large `self.suggestions` is cheap to render — only the
-                // on-screen window is formatted per frame. The next keystroke
-                // that arrives with a non-empty query will trigger a fresh
-                // `suggest_sync` cycle; any retained-but-not-yet-merged
-                // dynamic pool is bounded upstream by
-                // `gc_suggest::engine::MAX_DYNAMIC_CANDIDATES` (1000 for
-                // non-empty spawns; for empty spawns the engine also leaves
-                // it unbounded and relies on realistic provider sizes —
-                // typically <5k items; nucleo handles 10k in <1ms per the
-                // CLAUDE.md perf target).
-                //
-                // Option B future mitigation (not needed yet): stash the raw
-                // untruncated pool in a separate field (e.g. `dynamic_raw`)
-                // and re-rank from it on every keystroke. That eliminates
-                // the pathological-provider case entirely. Deferred until a
-                // real-world report of a >10k-item provider.
-                self.suggestions = if current_word.is_empty() {
-                    // Sort by kind priority so dynamic arrivals (git branches,
-                    // tags, remotes — effective priorities 80/75/70) land above
-                    // any sync residuals (flags=30, files=20, history=10).
-                    // Without this, the extend above leaves branches glued to
-                    // the tail of the sync pool on `git checkout <TAB>`.
-                    let mut m = merged;
-                    m.sort_by(|a, b| {
-                        gc_suggest::priority::effective(b)
-                            .cmp(&gc_suggest::priority::effective(a))
-                            .then_with(|| a.text.cmp(&b.text))
-                    });
-                    m
-                } else {
-                    gc_suggest::fuzzy::rank(&current_word, merged, self.max_visible * 5)
-                };
-
-                if self.suggestions.is_empty() {
-                    self.dismiss(stdout);
-                    return true;
-                }
-
-                self.render(parser, stdout);
-                true
+            // Activate popup if it wasn't visible yet (async-only path:
+            // no static suggestions, generators produced the results).
+            if !self.visible {
+                self.visible = true;
+                self.overlay.reset();
             }
-            Err(mpsc::error::TryRecvError::Empty) => false,
-            Err(mpsc::error::TryRecvError::Disconnected) => {
-                // Generator task exited without sending (e.g. all
-                // generators returned empty, or the task was aborted).
-                // Clear dynamic_rx AND repaint so the loading indicator
-                // goes away — otherwise on an idle shell the spinner
-                // stays visually stuck forever.
-                // Also clear dynamic_task: the task is already done (tx
-                // dropped), so its JoinHandle is effectively a no-op for
-                // `.abort()`. Leaving it Some would make dismiss()/trigger()'s
-                // abort calls look meaningful when they're not.
-                self.dynamic_rx = None;
+
+            let extras = merge_dedup_against(&self.suggestions, dynamic_results);
+            self.suggestions.extend(extras);
+            let merged = std::mem::take(&mut self.suggestions);
+            // Merge-time rank: when the user has a non-empty query, filter
+            // the pool to matches sorted by relevance and cap at
+            // `max_visible * 5` (generous headroom over what's rendered).
+            //
+            // When the spawn-time query is empty (user triggered on space
+            // then hasn't typed yet), `fuzzy::rank("", pool, N)` takes the
+            // empty-query fast path in `gc_suggest::fuzzy::rank` which
+            // sorts by kind priority and then alphabetically, then
+            // truncates to N. For single-kind dynamic pools (e.g. git
+            // branches from `resolve_git`), kind priority is uniform, so
+            // the effective result is "first N branches alphabetically"
+            // — dropping any candidate past alphabetic position ~50. A
+            // branch named `zzz-hotfix-critical` in a 5000-branch monorepo
+            // would be silently evicted at merge time, and the subsequent
+            // keystroke-driven re-rank could never recover it because the
+            // full pool is gone.
+            //
+            // Instead, when merging with an empty query, keep the full
+            // pool untruncated. The render path slices
+            // `&suggestions[scroll_offset..scroll_offset + content_height]`
+            // where `content_height` is capped by the visible viewport,
+            // so a large `self.suggestions` is cheap to render — only the
+            // on-screen window is formatted per frame. The next keystroke
+            // that arrives with a non-empty query will trigger a fresh
+            // `suggest_sync` cycle; any retained-but-not-yet-merged
+            // dynamic pool is bounded upstream by
+            // `gc_suggest::engine::MAX_DYNAMIC_CANDIDATES` (1000 for
+            // non-empty spawns; for empty spawns the engine also leaves
+            // it unbounded and relies on realistic provider sizes —
+            // typically <5k items; nucleo handles 10k in <1ms per the
+            // CLAUDE.md perf target).
+            //
+            // Option B future mitigation (not needed yet): stash the raw
+            // untruncated pool in a separate field (e.g. `dynamic_raw`)
+            // and re-rank from it on every keystroke. That eliminates
+            // the pathological-provider case entirely. Deferred until a
+            // real-world report of a >10k-item provider.
+            self.suggestions = if current_word.is_empty() {
+                // Sort by kind priority so dynamic arrivals (git branches,
+                // tags, remotes — effective priorities 80/75/70) land above
+                // any sync residuals (flags=30, files=20, history=10).
+                // Without this, the extend above leaves branches glued to
+                // the tail of the sync pool on `git checkout <TAB>`.
+                let mut m = merged;
+                m.sort_by(|a, b| {
+                    gc_suggest::priority::effective(b)
+                        .cmp(&gc_suggest::priority::effective(a))
+                        .then_with(|| a.text.cmp(&b.text))
+                });
+                m
+            } else {
+                gc_suggest::fuzzy::rank(&current_word, merged, self.max_visible * 5)
+            };
+
+            if self.suggestions.is_empty() {
+                self.dismiss(stdout);
+                return true;
+            }
+            if disconnected {
                 self.dynamic_ctx = None;
-                self.dynamic_task = None;
-                if self.visible {
-                    self.render(parser, stdout);
-                }
-                false
             }
+
+            self.render(parser, stdout);
+            true
         }
     }
 
@@ -1455,7 +1654,7 @@ impl InputHandler {
             clear_popup(&mut buf, layout, &self.terminal_profile);
         }
 
-        let loading = self.dynamic_rx.is_some();
+        let feedback = self.current_feedback_kind();
         let layout = render_popup(
             &mut buf,
             &self.suggestions,
@@ -1469,13 +1668,65 @@ impl InputHandler {
             DEFAULT_MAX_POPUP_WIDTH,
             &self.theme,
             self.scroll_deficit,
-            loading,
+            feedback,
             &self.terminal_profile,
         );
         let _ = stdout.write_all(&buf);
         let _ = stdout.flush();
         self.scroll_deficit = layout.scroll_deficit;
         self.last_layout = Some(layout);
+    }
+
+    fn current_feedback_kind(&self) -> FeedbackKind {
+        match &self.feedback {
+            AsyncFeedback::Idle => FeedbackKind::None,
+            AsyncFeedback::Loading { spawned_at } => {
+                let elapsed_ms = spawned_at.elapsed().as_millis() as u64;
+                FeedbackKind::Loading {
+                    frame: ((elapsed_ms / 80) % 10) as u8,
+                }
+            }
+            AsyncFeedback::Empty { .. } => FeedbackKind::Empty,
+            AsyncFeedback::Error { failed, .. } => FeedbackKind::Error {
+                provider: if self.theme.show_provider_errors {
+                    failed.first().cloned().unwrap_or_default()
+                } else {
+                    String::new()
+                },
+            },
+            AsyncFeedback::PartialError { failed, .. } => FeedbackKind::PartialError {
+                providers: failed.len().min(u8::MAX as usize) as u8,
+            },
+        }
+    }
+
+    pub fn render_indicator_only(&mut self, stdout: &mut dyn Write) {
+        let Some(layout) = self.last_layout.clone() else {
+            return;
+        };
+        let feedback = self.current_feedback_kind();
+        let mut buf = Vec::new();
+        render_indicator_row(&mut buf, &layout, &self.theme, feedback);
+        let _ = stdout.write_all(&buf);
+        let _ = stdout.flush();
+    }
+
+    pub fn clear_expired_feedback(&mut self, stdout: &mut dyn Write) -> bool {
+        if self.feedback_dismiss_ms == 0 {
+            return false;
+        }
+        if !self.feedback.is_terminal() {
+            return false;
+        }
+        let Some(since) = self.feedback.since() else {
+            return false;
+        };
+        if since.elapsed() < std::time::Duration::from_millis(self.feedback_dismiss_ms as u64) {
+            return false;
+        }
+        self.feedback = AsyncFeedback::Idle;
+        self.dismiss(stdout);
+        true
     }
 
     fn dismiss(&mut self, stdout: &mut dyn Write) {
@@ -1496,6 +1747,7 @@ impl InputHandler {
         }
         self.dynamic_rx = None;
         self.dynamic_ctx = None;
+        self.feedback = AsyncFeedback::Idle;
         // Invalidate the idempotency guard so the next trigger (e.g. after
         // ESC-then-retrigger on the same buffer) runs a fresh suggest_sync
         // instead of short-circuiting.
@@ -1610,6 +1862,7 @@ impl InputHandler {
         if let Some(handle) = self.dynamic_task.take() {
             handle.abort();
         }
+        self.feedback = AsyncFeedback::Idle;
     }
 
     /// Abort any in-flight dynamic generator task and clear the spawn-time
@@ -1622,6 +1875,8 @@ impl InputHandler {
             handle.abort();
         }
         self.dynamic_ctx = None;
+        self.dynamic_rx = None;
+        self.feedback = AsyncFeedback::Idle;
     }
 
     /// Flush unsaved frecency records to disk. Call on proxy shutdown.
@@ -1850,21 +2105,24 @@ mod tests {
         let base_ctx = gc_buffer::parse_command_context("", 0);
         handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
 
-        let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
-        tx.try_send(vec![
-            Suggestion {
-                text: "main".to_string(),
-                kind: SuggestionKind::GitBranch,
-                source: SuggestionSource::Git,
-                ..Default::default()
-            },
-            Suggestion {
-                text: "v1.0".to_string(),
-                kind: SuggestionKind::GitTag,
-                source: SuggestionSource::Git,
-                ..Default::default()
-            },
-        ])
+        let (tx, rx) = mpsc::channel::<DynamicResult>(1);
+        tx.try_send(DynamicResult::Loaded {
+            provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+            suggestions: vec![
+                Suggestion {
+                    text: "main".to_string(),
+                    kind: SuggestionKind::GitBranch,
+                    source: SuggestionSource::Git,
+                    ..Default::default()
+                },
+                Suggestion {
+                    text: "v1.0".to_string(),
+                    kind: SuggestionKind::GitTag,
+                    source: SuggestionSource::Git,
+                    ..Default::default()
+                },
+            ],
+        })
         .unwrap();
         drop(tx);
         handler.dynamic_rx = Some(rx);
@@ -1908,21 +2166,24 @@ mod tests {
         let base_ctx = gc_buffer::parse_command_context("", 0);
         handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
 
-        let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
-        tx.try_send(vec![
-            Suggestion {
-                text: "zeta".to_string(),
-                kind: SuggestionKind::GitBranch,
-                source: SuggestionSource::Git,
-                ..Default::default()
-            },
-            Suggestion {
-                text: "alpha".to_string(),
-                kind: SuggestionKind::GitBranch,
-                source: SuggestionSource::Git,
-                ..Default::default()
-            },
-        ])
+        let (tx, rx) = mpsc::channel::<DynamicResult>(1);
+        tx.try_send(DynamicResult::Loaded {
+            provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+            suggestions: vec![
+                Suggestion {
+                    text: "zeta".to_string(),
+                    kind: SuggestionKind::GitBranch,
+                    source: SuggestionSource::Git,
+                    ..Default::default()
+                },
+                Suggestion {
+                    text: "alpha".to_string(),
+                    kind: SuggestionKind::GitBranch,
+                    source: SuggestionSource::Git,
+                    ..Default::default()
+                },
+            ],
+        })
         .unwrap();
         drop(tx);
         handler.dynamic_rx = Some(rx);
@@ -1951,6 +2212,68 @@ mod tests {
     }
 
     #[test]
+    fn test_try_merge_dynamic_keeps_open_receiver_for_later_batches() {
+        let mut handler = make_visible_handler(Vec::new());
+        let base_ctx = gc_buffer::parse_command_context("", 0);
+        handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
+        handler.spawned_generation = handler.buffer_generation;
+
+        let (tx, rx) = mpsc::channel::<DynamicResult>(2);
+        tx.try_send(DynamicResult::Loaded {
+            provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+            suggestions: vec![Suggestion {
+                text: "main".to_string(),
+                kind: SuggestionKind::GitBranch,
+                source: SuggestionSource::Git,
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+        handler.dynamic_rx = Some(rx);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        assert!(handler.try_merge_dynamic(&parser, &mut buf));
+        assert!(
+            handler.dynamic_rx.is_some(),
+            "open receiver must stay installed for later dynamic batches"
+        );
+        assert!(
+            handler.dynamic_ctx.is_some(),
+            "fresh context must survive until the dynamic channel disconnects"
+        );
+
+        tx.try_send(DynamicResult::Loaded {
+            provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Tags),
+            suggestions: vec![Suggestion {
+                text: "v1.0".to_string(),
+                kind: SuggestionKind::GitTag,
+                source: SuggestionSource::Git,
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+        drop(tx);
+
+        let mut buf = Vec::new();
+        assert!(handler.try_merge_dynamic(&parser, &mut buf));
+        let texts: Vec<&str> = handler
+            .suggestions
+            .iter()
+            .map(|s| s.text.as_str())
+            .collect();
+        assert_eq!(texts, vec!["main", "v1.0"]);
+        assert!(
+            handler.dynamic_rx.is_none(),
+            "receiver should clear after the final disconnected batch"
+        );
+        assert!(
+            handler.dynamic_ctx.is_none(),
+            "context should clear after the final disconnected batch"
+        );
+    }
+
+    #[test]
     fn test_try_merge_dynamic_disconnected_rerenders_to_clear_loading() {
         // Regression: when the dynamic channel disconnects (generator task
         // finished without sending, or was aborted), `try_merge_dynamic`
@@ -1967,7 +2290,7 @@ mod tests {
 
         // Closed receiver: drop tx immediately so try_recv returns
         // Disconnected on the first call.
-        let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
+        let (tx, rx) = mpsc::channel::<DynamicResult>(1);
         drop(tx);
         handler.dynamic_rx = Some(rx);
 
@@ -2217,6 +2540,9 @@ mod tests {
             dynamic_rx: None,
             dynamic_task: None,
             dynamic_notify: Arc::new(Notify::new()),
+            feedback_tick_notify: Arc::new(Notify::new()),
+            feedback: AsyncFeedback::Idle,
+            feedback_dismiss_ms: 1200,
             dynamic_ctx: None,
             terminal_profile: TerminalProfile::for_ghostty(),
             scroll_deficit: 0,
@@ -2579,14 +2905,26 @@ mod tests {
         let new_theme = PopupTheme {
             selected_on: vec![0x1B, b'[', b'1', b'm'],
             description_on: vec![0x1B, b'[', b'2', b'm'],
+            feedback_loading_on: vec![0x1B, b'[', b'2', b'm'],
+            feedback_empty_on: vec![0x1B, b'[', b'2', b'm'],
+            feedback_error_on: vec![0x1B, b'[', b'3', b'1', b'm'],
             match_highlight_on: vec![0x1B, b'[', b'4', b'm'],
             item_text_on: vec![],
             scrollbar_on: vec![0x1B, b'[', b'2', b'm'],
             border_on: vec![0x1B, b'[', b'2', b'm'],
             borders: true,
+            spinner: true,
+            show_provider_errors: false,
         };
 
-        handler.update_config(new_theme, Keybindings::default(), &[' ', '/'], 15, true);
+        handler.update_config(
+            new_theme,
+            Keybindings::default(),
+            &[' ', '/'],
+            15,
+            1200,
+            true,
+        );
 
         assert_eq!(handler.theme.selected_on, vec![0x1B, b'[', b'1', b'm']);
         assert_eq!(handler.theme.description_on, vec![0x1B, b'[', b'2', b'm']);
@@ -2605,7 +2943,14 @@ mod tests {
             trigger: KeyEvent::Tab,
         };
 
-        handler.update_config(PopupTheme::default(), new_kb.clone(), &[' ', '/'], 10, true);
+        handler.update_config(
+            PopupTheme::default(),
+            new_kb.clone(),
+            &[' ', '/'],
+            10,
+            1200,
+            true,
+        );
 
         assert_eq!(handler.keybindings, new_kb);
     }
@@ -2619,6 +2964,7 @@ mod tests {
             Keybindings::default(),
             &['@', '#'],
             20,
+            1200,
             true,
         );
 
@@ -2634,6 +2980,7 @@ mod tests {
             Keybindings::default(),
             &['@', '#', '!'],
             10,
+            1200,
             true,
         );
 
@@ -2685,6 +3032,7 @@ mod tests {
             Keybindings::default(),
             &[' ', '/', '-', '.'],
             10,
+            1200,
             false,
         );
 
@@ -2706,6 +3054,7 @@ mod tests {
             Keybindings::default(),
             &[' ', '/', '-', '.'],
             10,
+            1200,
             false,
         );
 
@@ -2733,6 +3082,7 @@ mod tests {
             Keybindings::default(),
             &[' ', '/', '-', '.'],
             10,
+            1200,
             false,
         );
 
@@ -2761,6 +3111,7 @@ mod tests {
             Keybindings::default(),
             &[' ', '/', '-', '.'],
             10,
+            1200,
             true,
         );
 
@@ -2964,7 +3315,7 @@ mod tests {
         }]);
 
         // Populate dynamic state as if generators were in flight.
-        let (_tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
+        let (_tx, rx) = mpsc::channel::<DynamicResult>(1);
         handler.dynamic_rx = Some(rx);
         handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(
             &ctx("git", &["checkout"], None, 2, ""),
@@ -3010,7 +3361,7 @@ mod tests {
 
         // Populate in-flight dynamic state mimicking a prior trigger that
         // spawned generators against a different command.
-        let (_tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
+        let (_tx, rx) = mpsc::channel::<DynamicResult>(1);
         handler.dynamic_rx = Some(rx);
         handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(
             &ctx("old-cmd", &[], None, 0, ""),

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -228,10 +228,7 @@ pub struct InputHandler {
     feedback_tick_notify: Arc<Notify>,
     feedback: AsyncFeedback,
     feedback_dismiss_ms: u16,
-    /// Per-batch error/empty tallies that arrived in non-final mpsc batches.
-    /// Drained into the terminal-aggregation call when the dynamic channel
-    /// disconnects, so an Error or Empty message read in an early batch is
-    /// not lost when the next batch contains no Loaded results.
+    /// Carries non-final-batch error/empty counts to the disconnect-time terminal computation.
     pending_failed: Vec<String>,
     pending_empty_count: usize,
     /// Command context snapshot captured when generators were spawned.
@@ -865,6 +862,8 @@ impl InputHandler {
         self.dynamic_rx = None;
         self.dynamic_ctx = None;
         self.feedback = AsyncFeedback::Idle;
+        self.pending_failed.clear();
+        self.pending_empty_count = 0;
 
         self.buffer_generation = self.buffer_generation.wrapping_add(1);
 
@@ -991,6 +990,8 @@ impl InputHandler {
         self.dynamic_rx = None;
         self.dynamic_ctx = None;
         self.feedback = AsyncFeedback::Idle;
+        self.pending_failed.clear();
+        self.pending_empty_count = 0;
         self.buffer_generation = self.buffer_generation.wrapping_add(1);
 
         let result = match self.engine.suggest_sync(&ctx, &cwd, &buffer) {
@@ -1120,9 +1121,6 @@ impl InputHandler {
             self.dynamic_task = None;
         }
         let aggregation = AsyncFeedback::aggregate(messages);
-        // Roll the per-batch failed/empty into self.pending_* so a non-final
-        // batch's error reports survive to the disconnect-time terminal feedback
-        // computation.
         self.pending_failed.extend(aggregation.failed);
         self.pending_empty_count += aggregation.empty_count;
         if aggregation.loaded.is_empty() {
@@ -1188,6 +1186,8 @@ impl InputHandler {
                 self.dynamic_ctx = None;
                 self.dynamic_task = None;
                 self.feedback = AsyncFeedback::Idle;
+                self.pending_failed.clear();
+                self.pending_empty_count = 0;
                 if self.visible {
                     self.render(parser, stdout);
                 }
@@ -1296,11 +1296,7 @@ impl InputHandler {
                 current_token: ctx.current_word.clone(),
             });
 
-            // Resolve script generators, git kinds, and provider kinds
-            // concurrently. Each git/provider kind is dispatched as its own
-            // per-kind helper so a per-kind error or empty result surfaces
-            // as its own DynamicResult and the ProviderTag carries the
-            // actual kind that produced it.
+            // Per-kind dispatch so each git/provider failure surfaces with its own ProviderTag.
             let git_engine = Arc::clone(&engine);
             let git_cwd = cwd.clone();
             let git_query = ctx.current_word.clone();
@@ -1515,9 +1511,6 @@ impl InputHandler {
         }
 
         let aggregation = AsyncFeedback::aggregate(messages);
-        // Roll the per-batch failed/empty into self.pending_* so a non-final
-        // batch's error reports survive to the disconnect-time terminal feedback
-        // computation.
         self.pending_failed.extend(aggregation.failed);
         self.pending_empty_count += aggregation.empty_count;
 
@@ -1796,23 +1789,18 @@ impl InputHandler {
         if since.elapsed() < std::time::Duration::from_millis(self.feedback_dismiss_ms as u64) {
             return false;
         }
-        // PartialError means some providers succeeded — the popup currently
-        // shows real merged suggestions plus an indicator row. Demote to Idle
-        // and clear just the indicator row so the suggestions stay visible.
+        // PartialError + suggestions present: drop only the indicator row, not the popup.
         if matches!(self.feedback, AsyncFeedback::PartialError { .. })
             && !self.suggestions.is_empty()
         {
             self.feedback = AsyncFeedback::Idle;
             if let Some(mut layout) = self.last_layout.clone() {
-                // Clear the indicator row: it sits at
-                // start_row + height - 1 - borders. Replace it with spaces
-                // and shrink the cached layout height by one so subsequent
-                // dismiss/clear_popup calls don't miss-target a row.
                 if layout.height > 0 {
-                    let indicator_row =
-                        layout.start_row + layout.height - 1 - u16::from(self.theme.borders);
-                    let mut buf = Vec::with_capacity(layout.width as usize + 16);
+                    let borders = self.theme.borders;
+                    let indicator_row = layout.start_row + layout.height - 1 - u16::from(borders);
+                    let mut buf = Vec::with_capacity(layout.width as usize * 4 + 64);
                     buf.extend_from_slice(b"\x1b[s"); // save cursor
+                                                      // Clear the indicator row.
                     let _ = write!(
                         &mut buf,
                         "\x1b[{};{}H",
@@ -1820,9 +1808,41 @@ impl InputHandler {
                         layout.start_col + 1
                     );
                     buf.extend(std::iter::repeat_n(b' ', layout.width as usize));
+                    if borders {
+                        // The bottom border was displaced one row below the indicator
+                        // (render.rs draws it at loading_row + 1). Clear that displaced
+                        // row and redraw the border at the indicator row so the popup
+                        // remains a closed box and a later clear_popup catches every
+                        // painted row.
+                        let displaced_border_row = layout.start_row + layout.height - 1;
+                        let _ = write!(
+                            &mut buf,
+                            "\x1b[{};{}H",
+                            displaced_border_row + 1,
+                            layout.start_col + 1
+                        );
+                        buf.extend(std::iter::repeat_n(b' ', layout.width as usize));
+                        let _ = write!(
+                            &mut buf,
+                            "\x1b[{};{}H",
+                            indicator_row + 1,
+                            layout.start_col + 1
+                        );
+                        if !self.theme.border_on.is_empty() {
+                            buf.extend_from_slice(&self.theme.border_on);
+                        }
+                        buf.extend_from_slice("╰".as_bytes());
+                        let content_width = layout.width.saturating_sub(2);
+                        for _ in 0..content_width {
+                            buf.extend_from_slice("─".as_bytes());
+                        }
+                        buf.extend_from_slice("╯".as_bytes());
+                        buf.extend_from_slice(b"\x1b[0m");
+                    }
                     buf.extend_from_slice(b"\x1b[u"); // restore cursor
                     let _ = stdout.write_all(&buf);
                     let _ = stdout.flush();
+                    // Shrink cached height so a later dismiss/clear_popup targets the right row.
                     layout.height -= 1;
                     self.last_layout = Some(layout);
                 }
@@ -3635,10 +3655,7 @@ mod tests {
 
     #[test]
     fn test_clear_expired_feedback_partial_error_with_suggestions_demotes_to_idle() {
-        // Regression: when feedback is PartialError and the popup currently
-        // has merged suggestions, expiring the feedback must NOT dismiss the
-        // popup. The suggestions are real user-visible state — drop only the
-        // indicator row and demote feedback to Idle.
+        // Regression: PartialError expiry with merged suggestions must keep popup visible.
         let mut handler = make_visible_handler(vec![Suggestion {
             text: "main".into(),
             kind: SuggestionKind::GitBranch,
@@ -3654,6 +3671,193 @@ mod tests {
         assert!(handler.visible, "popup must stay visible");
         assert_eq!(handler.suggestions.len(), 1, "suggestions must survive");
         assert!(matches!(handler.feedback, AsyncFeedback::Idle));
+    }
+
+    #[test]
+    fn test_clear_expired_feedback_bordered_partial_error_paints_displaced_border_row() {
+        // Regression: with a bordered theme the indicator row REPLACES the
+        // would-be bottom border and the bottom border is displaced one row
+        // below. After demote-to-Idle, the cached layout shrinks by one.
+        // clear_expired_feedback must clear that displaced border row AND
+        // redraw a new bottom border at the shrunk-bottom position so the
+        // popup is a closed box and a later clear_popup catches every
+        // painted row.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "main".into(),
+            kind: SuggestionKind::GitBranch,
+            ..Default::default()
+        }])
+        .with_feedback_dismiss_ms(1200);
+        handler.theme = PopupTheme {
+            borders: true,
+            ..PopupTheme::default()
+        };
+        // Simulate the layout that render_popup returns for a bordered popup
+        // with a feedback indicator: start_row = 5, height = original 3
+        // (top_border + 1 content + bottom_border) + 1 loading_extra = 4.
+        // Painted rows are start_row..start_row+height = 5..9 (rows 5,6,7,8).
+        handler.last_layout = Some(PopupLayout {
+            start_row: 5,
+            start_col: 10,
+            width: 20,
+            height: 4,
+            scroll_deficit: 0,
+        });
+        handler.feedback = AsyncFeedback::PartialError {
+            failed: vec!["git script".into()],
+            since: std::time::Instant::now() - std::time::Duration::from_millis(2000),
+        };
+
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(handler.clear_expired_feedback(&mut buf));
+        assert!(matches!(handler.feedback, AsyncFeedback::Idle));
+
+        let painted = String::from_utf8_lossy(&buf).into_owned();
+        // Cursor moves to the indicator row (start_row + height - 2 = 7,
+        // 1-based = 8) and to the displaced bottom-border row (start_row +
+        // height - 1 = 8, 1-based = 9). Both rows must be addressed.
+        assert!(
+            painted.contains("\x1b[8;11H"),
+            "indicator row must be addressed: {painted:?}"
+        );
+        assert!(
+            painted.contains("\x1b[9;11H"),
+            "displaced bottom-border row must be cleared: {painted:?}"
+        );
+        // A new bottom border must be drawn at the shrunk-bottom position.
+        assert!(
+            painted.contains('╰') && painted.contains('╯'),
+            "bottom border must be redrawn at the new position: {painted:?}"
+        );
+
+        // The cached layout shrinks by one. A subsequent clear_popup must
+        // erase rows 5..8 — covering the new bottom border row at row 7
+        // (1-based row 8). The displaced row at start_row+old_height-1
+        // (= row 8, 1-based 9) was already wiped above and is now outside
+        // the shrunk layout, which is the correct invariant.
+        let shrunk = handler.last_layout.clone().expect("layout retained");
+        assert_eq!(shrunk.height, 3);
+        let mut clear_buf: Vec<u8> = Vec::new();
+        clear_popup(&mut clear_buf, &shrunk, &handler.terminal_profile);
+        let clear_text = String::from_utf8_lossy(&clear_buf).into_owned();
+        // Rows 5,6,7 must be addressed by clear_popup (1-based 6,7,8).
+        for row_1based in [6_u16, 7, 8] {
+            let needle = format!("\x1b[{row_1based};11H");
+            assert!(
+                clear_text.contains(&needle),
+                "clear_popup must address row {row_1based}: {clear_text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_pending_failed_accumulates_across_two_try_merge_dynamic_calls() {
+        // Cross-batch accumulation: an Error in batch 1 must survive into
+        // the disconnect-time terminal feedback computed in batch 2.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "--flag".into(),
+            kind: SuggestionKind::Flag,
+            source: SuggestionSource::Spec,
+            ..Default::default()
+        }]);
+        let base_ctx = gc_buffer::parse_command_context("", 0);
+        handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
+        handler.feedback = AsyncFeedback::Loading {
+            spawned_at: std::time::Instant::now(),
+        };
+
+        let (tx, rx) = mpsc::channel::<DynamicResult>(2);
+        // Batch 1: send Error only, do NOT drop tx — channel is still open.
+        tx.try_send(DynamicResult::Error {
+            provider: ProviderTag::Script("npm".into()),
+            message: "oops".into(),
+        })
+        .unwrap();
+        handler.dynamic_rx = Some(rx);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        handler.try_merge_dynamic(&parser, &mut buf);
+
+        // After batch 1: pending_failed has the npm error, feedback still Loading.
+        assert_eq!(handler.pending_failed.len(), 1);
+        assert!(handler.feedback.is_loading());
+
+        // Batch 2: send Loaded then drop tx so the channel disconnects.
+        tx.try_send(DynamicResult::Loaded {
+            provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+            suggestions: vec![Suggestion {
+                text: "main".into(),
+                kind: SuggestionKind::GitBranch,
+                source: SuggestionSource::Git,
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+        drop(tx);
+        handler.try_merge_dynamic(&parser, &mut buf);
+
+        // After batch 2 + disconnect: PartialError with the npm error from
+        // batch 1 must have survived.
+        match handler.feedback_kind() {
+            AsyncFeedback::PartialError { failed, .. } => {
+                assert_eq!(failed.len(), 1, "batch-1 error must survive batch-2");
+            }
+            other => panic!("expected PartialError feedback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_pending_empty_count_accumulates_across_two_try_merge_dynamic_calls() {
+        // Symmetric variant of the cross-batch accumulation test, for empty.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "--flag".into(),
+            kind: SuggestionKind::Flag,
+            source: SuggestionSource::Spec,
+            ..Default::default()
+        }]);
+        let base_ctx = gc_buffer::parse_command_context("", 0);
+        handler.dynamic_ctx = Some(DynamicCtxSnapshot::capture(&base_ctx, false));
+        handler.feedback = AsyncFeedback::Loading {
+            spawned_at: std::time::Instant::now(),
+        };
+
+        let (tx, rx) = mpsc::channel::<DynamicResult>(2);
+        // Batch 1: Empty only, channel still open.
+        tx.try_send(DynamicResult::Empty {
+            provider: ProviderTag::Script("npm".into()),
+        })
+        .unwrap();
+        handler.dynamic_rx = Some(rx);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        handler.try_merge_dynamic(&parser, &mut buf);
+
+        assert_eq!(handler.pending_empty_count, 1);
+        assert!(handler.feedback.is_loading());
+
+        // Batch 2: Loaded then drop tx.
+        tx.try_send(DynamicResult::Loaded {
+            provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+            suggestions: vec![Suggestion {
+                text: "main".into(),
+                kind: SuggestionKind::GitBranch,
+                source: SuggestionSource::Git,
+                ..Default::default()
+            }],
+        })
+        .unwrap();
+        drop(tx);
+        handler.try_merge_dynamic(&parser, &mut buf);
+
+        // After disconnect with both Loaded results AND a batch-1 empty:
+        // terminal_for_outcome with had_results=true + no failed but empty>0
+        // resolves to Idle (suggestions came through). We assert the empty
+        // was OBSERVED by the terminal computation by checking the pending
+        // counters were drained at disconnect.
+        assert_eq!(handler.pending_empty_count, 0, "drained on disconnect");
+        assert_eq!(handler.pending_failed.len(), 0, "no errors accumulated");
     }
 
     // --- try_merge_dynamic disconnect branches ---

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -1604,49 +1604,9 @@ impl InputHandler {
             let extras = merge_dedup_against(&self.suggestions, dynamic_results);
             self.suggestions.extend(extras);
             let merged = std::mem::take(&mut self.suggestions);
-            // Merge-time rank: when the user has a non-empty query, filter
-            // the pool to matches sorted by relevance and cap at
-            // `max_visible * 5` (generous headroom over what's rendered).
-            //
-            // When the spawn-time query is empty (user triggered on space
-            // then hasn't typed yet), `fuzzy::rank("", pool, N)` takes the
-            // empty-query fast path in `gc_suggest::fuzzy::rank` which
-            // sorts by kind priority and then alphabetically, then
-            // truncates to N. For single-kind dynamic pools (e.g. git
-            // branches from `resolve_git`), kind priority is uniform, so
-            // the effective result is "first N branches alphabetically"
-            // — dropping any candidate past alphabetic position ~50. A
-            // branch named `zzz-hotfix-critical` in a 5000-branch monorepo
-            // would be silently evicted at merge time, and the subsequent
-            // keystroke-driven re-rank could never recover it because the
-            // full pool is gone.
-            //
-            // Instead, when merging with an empty query, keep the full
-            // pool untruncated. The render path slices
-            // `&suggestions[scroll_offset..scroll_offset + content_height]`
-            // where `content_height` is capped by the visible viewport,
-            // so a large `self.suggestions` is cheap to render — only the
-            // on-screen window is formatted per frame. The next keystroke
-            // that arrives with a non-empty query will trigger a fresh
-            // `suggest_sync` cycle; any retained-but-not-yet-merged
-            // dynamic pool is bounded upstream by
-            // `gc_suggest::engine::MAX_DYNAMIC_CANDIDATES` (1000 for
-            // non-empty spawns; for empty spawns the engine also leaves
-            // it unbounded and relies on realistic provider sizes —
-            // typically <5k items; nucleo handles 10k in <1ms per the
-            // CLAUDE.md perf target).
-            //
-            // Option B future mitigation (not needed yet): stash the raw
-            // untruncated pool in a separate field (e.g. `dynamic_raw`)
-            // and re-rank from it on every keystroke. That eliminates
-            // the pathological-provider case entirely. Deferred until a
-            // real-world report of a >10k-item provider.
+            // Empty query: keep the full pool untruncated so a non-empty re-rank can still recover late candidates.
             self.suggestions = if current_word.is_empty() {
-                // Sort by kind priority so dynamic arrivals (git branches,
-                // tags, remotes — effective priorities 80/75/70) land above
-                // any sync residuals (flags=30, files=20, history=10).
-                // Without this, the extend above leaves branches glued to
-                // the tail of the sync pool on `git checkout <TAB>`.
+                // Re-sort so higher-priority dynamic arrivals outrank residual sync items.
                 let mut m = merged;
                 m.sort_by(|a, b| {
                     gc_suggest::priority::effective(b)

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -874,8 +874,6 @@ impl InputHandler {
                 self.suggestions = result.suggestions;
                 self.overlay.reset();
                 self.visible = true;
-                self.render_at(stdout, cursor_row, cursor_col, screen_rows, screen_cols);
-                self.last_trigger_fingerprint = Some(fingerprint);
                 self.spawn_generators(
                     result.script_generators,
                     result.git_generators,
@@ -883,6 +881,8 @@ impl InputHandler {
                     &ctx,
                     &cwd,
                 );
+                self.render_at(stdout, cursor_row, cursor_col, screen_rows, screen_cols);
+                self.last_trigger_fingerprint = Some(fingerprint);
             }
             Ok(result) => {
                 let has_async = !result.script_generators.is_empty()
@@ -1809,11 +1809,6 @@ impl InputHandler {
                     );
                     buf.extend(std::iter::repeat_n(b' ', layout.width as usize));
                     if borders {
-                        // The bottom border was displaced one row below the indicator
-                        // (render.rs draws it at loading_row + 1). Clear that displaced
-                        // row and redraw the border at the indicator row so the popup
-                        // remains a closed box and a later clear_popup catches every
-                        // painted row.
                         let displaced_border_row = layout.start_row + layout.height - 1;
                         let _ = write!(
                             &mut buf,
@@ -3520,6 +3515,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_trigger_static_with_async_reserves_indicator_row_in_cached_layout() {
+        let specs_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
+        if !specs_dir.exists() {
+            return;
+        }
+        let engine = SuggestionEngine::new(&[specs_dir]).unwrap();
+        let mut handler = make_handler();
+        handler.engine = Arc::new(engine);
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        {
+            let mut p = parser.lock().unwrap();
+            p.state_mut()
+                .predict_command_buffer("git checkout ".to_string(), 13);
+        }
+
+        let mut stdout = Vec::new();
+        handler.trigger(&parser, &mut stdout);
+
+        let layout = handler
+            .last_layout
+            .clone()
+            .expect("trigger must paint a layout when static suggestions are present");
+        assert!(
+            handler.feedback.is_loading(),
+            "spawn_generators must run before render_at so feedback=Loading at paint time"
+        );
+        let visible_count = handler.suggestions.len().min(handler.max_visible) as u16;
+        assert!(
+            visible_count >= 1,
+            "git checkout must yield static suggestions"
+        );
+        assert_eq!(
+            layout.height,
+            visible_count + 1,
+            "cached layout must reserve the indicator row (visible={visible_count}, height={})",
+            layout.height,
+        );
+    }
+
+    #[tokio::test]
     async fn test_abort_dynamic_task_and_clear_ctx_clears_both_fields() {
         let mut handler = make_handler();
         handler.dynamic_task = Some(tokio::spawn(async {
@@ -3675,13 +3711,6 @@ mod tests {
 
     #[test]
     fn test_clear_expired_feedback_bordered_partial_error_paints_displaced_border_row() {
-        // Regression: with a bordered theme the indicator row REPLACES the
-        // would-be bottom border and the bottom border is displaced one row
-        // below. After demote-to-Idle, the cached layout shrinks by one.
-        // clear_expired_feedback must clear that displaced border row AND
-        // redraw a new bottom border at the shrunk-bottom position so the
-        // popup is a closed box and a later clear_popup catches every
-        // painted row.
         let mut handler = make_visible_handler(vec![Suggestion {
             text: "main".into(),
             kind: SuggestionKind::GitBranch,
@@ -3692,10 +3721,6 @@ mod tests {
             borders: true,
             ..PopupTheme::default()
         };
-        // Simulate the layout that render_popup returns for a bordered popup
-        // with a feedback indicator: start_row = 5, height = original 3
-        // (top_border + 1 content + bottom_border) + 1 loading_extra = 4.
-        // Painted rows are start_row..start_row+height = 5..9 (rows 5,6,7,8).
         handler.last_layout = Some(PopupLayout {
             start_row: 5,
             start_col: 10,
@@ -3713,9 +3738,6 @@ mod tests {
         assert!(matches!(handler.feedback, AsyncFeedback::Idle));
 
         let painted = String::from_utf8_lossy(&buf).into_owned();
-        // Cursor moves to the indicator row (start_row + height - 2 = 7,
-        // 1-based = 8) and to the displaced bottom-border row (start_row +
-        // height - 1 = 8, 1-based = 9). Both rows must be addressed.
         assert!(
             painted.contains("\x1b[8;11H"),
             "indicator row must be addressed: {painted:?}"
@@ -3730,11 +3752,6 @@ mod tests {
             "bottom border must be redrawn at the new position: {painted:?}"
         );
 
-        // The cached layout shrinks by one. A subsequent clear_popup must
-        // erase rows 5..8 — covering the new bottom border row at row 7
-        // (1-based row 8). The displaced row at start_row+old_height-1
-        // (= row 8, 1-based 9) was already wiped above and is now outside
-        // the shrunk layout, which is the correct invariant.
         let shrunk = handler.last_layout.clone().expect("layout retained");
         assert_eq!(shrunk.height, 3);
         let mut clear_buf: Vec<u8> = Vec::new();
@@ -3851,11 +3868,6 @@ mod tests {
         drop(tx);
         handler.try_merge_dynamic(&parser, &mut buf);
 
-        // After disconnect with both Loaded results AND a batch-1 empty:
-        // terminal_for_outcome with had_results=true + no failed but empty>0
-        // resolves to Idle (suggestions came through). We assert the empty
-        // was OBSERVED by the terminal computation by checking the pending
-        // counters were drained at disconnect.
         assert_eq!(handler.pending_empty_count, 0, "drained on disconnect");
         assert_eq!(handler.pending_failed.len(), 0, "no errors accumulated");
     }

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -228,7 +228,6 @@ pub struct InputHandler {
     feedback_tick_notify: Arc<Notify>,
     feedback: AsyncFeedback,
     feedback_dismiss_ms: u16,
-    /// Carries non-final-batch error/empty counts to the disconnect-time terminal computation.
     pending_failed: Vec<String>,
     pending_empty_count: usize,
     /// Command context snapshot captured when generators were spawned.
@@ -1800,7 +1799,6 @@ impl InputHandler {
                     let indicator_row = layout.start_row + layout.height - 1 - u16::from(borders);
                     let mut buf = Vec::with_capacity(layout.width as usize * 4 + 64);
                     buf.extend_from_slice(b"\x1b[s"); // save cursor
-                                                      // Clear the indicator row.
                     let _ = write!(
                         &mut buf,
                         "\x1b[{};{}H",

--- a/crates/gc-pty/src/lib.rs
+++ b/crates/gc-pty/src/lib.rs
@@ -5,6 +5,8 @@
 //! for popup navigation.
 
 mod config_watch;
+pub mod dynamic_result;
+pub mod feedback;
 pub mod handler;
 pub mod input;
 mod proxy;

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -953,12 +953,13 @@ async fn dynamic_merge_loop(
 async fn feedback_tick_loop(notify: Arc<Notify>, handler: Arc<Mutex<InputHandler>>) {
     loop {
         notify.notified().await;
-        let mut interval = tokio::time::interval(Duration::from_millis(80));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut next_ms: u64 = 0;
         loop {
-            interval.tick().await;
-            let mut stdout = std::io::stdout().lock();
-            let (keep_running, next_ms) = {
+            if next_ms > 0 {
+                tokio::time::sleep(Duration::from_millis(next_ms)).await;
+            }
+            let mut render_buf: Vec<u8> = Vec::new();
+            let keep_running = {
                 let mut h = match handler.lock() {
                     Ok(h) => h,
                     Err(e) => {
@@ -967,20 +968,29 @@ async fn feedback_tick_loop(notify: Arc<Notify>, handler: Arc<Mutex<InputHandler
                     }
                 };
                 if h.feedback_kind().is_loading() {
-                    h.render_indicator_only(&mut stdout);
-                    (true, 80)
-                } else if h.clear_expired_feedback(&mut stdout) {
-                    (false, 200)
+                    h.render_indicator_only(&mut render_buf);
+                    next_ms = 80;
+                    true
+                } else if h.clear_expired_feedback(&mut render_buf) {
+                    next_ms = 200;
+                    false
                 } else {
-                    (h.feedback_kind().since().is_some(), 200)
+                    next_ms = 200;
+                    h.feedback_kind().since().is_some()
                 }
             };
-            let _ = stdout.flush();
+            if !render_buf.is_empty() {
+                let mut stdout = std::io::stdout().lock();
+                if stdout.write_all(&render_buf).is_err() {
+                    break;
+                }
+                if stdout.flush().is_err() {
+                    break;
+                }
+            }
             if !keep_running {
                 break;
             }
-            interval = tokio::time::interval(Duration::from_millis(next_ms));
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         }
     }
 }

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -156,6 +156,12 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             .context("invalid theme.selected style")?,
         description_on: parse_style(&resolved_theme.description)
             .context("invalid theme.description style")?,
+        feedback_loading_on: parse_style(&resolved_theme.feedback_loading)
+            .context("invalid theme.feedback_loading style")?,
+        feedback_empty_on: parse_style(&resolved_theme.feedback_empty)
+            .context("invalid theme.feedback_empty style")?,
+        feedback_error_on: parse_style(&resolved_theme.feedback_error)
+            .context("invalid theme.feedback_error style")?,
         match_highlight_on: parse_style(&resolved_theme.match_highlight)
             .context("invalid theme.match_highlight style")?,
         item_text_on: parse_style(&resolved_theme.item_text)
@@ -164,6 +170,8 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             .context("invalid theme.scrollbar style")?,
         border_on: parse_style(&resolved_theme.border).context("invalid theme.border style")?,
         borders: config.popup.borders,
+        spinner: config.popup.spinner,
+        show_provider_errors: config.popup.show_provider_errors,
     };
 
     // Initialize suggestion handler with config
@@ -179,6 +187,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
         h.with_keybindings(keybindings)
             .with_theme(theme)
             .with_popup_config(config.popup.max_visible)
+            .with_feedback_dismiss_ms(config.popup.feedback_dismiss_ms)
             .with_trigger_chars(&config.trigger.auto_chars)
             .with_auto_trigger(config.trigger.auto_trigger)
             .with_render_block_ms(config.popup.render_block_ms as u64)
@@ -241,6 +250,21 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let parser_for_merge = Arc::clone(&parser);
     let merge_handle = tokio::spawn(async move {
         dynamic_merge_loop(dynamic_notify, handler_for_merge, parser_for_merge).await;
+    });
+
+    let feedback_notify = {
+        let h = match handler.lock() {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!("handler mutex poisoned during feedback setup: {e}");
+                anyhow::bail!("handler mutex poisoned during feedback setup — cannot start proxy");
+            }
+        };
+        h.feedback_tick_notify()
+    };
+    let handler_for_feedback = Arc::clone(&handler);
+    let feedback_handle = tokio::spawn(async move {
+        feedback_tick_loop(feedback_notify, handler_for_feedback).await;
     });
 
     // Channel to signal that one of the I/O tasks has finished
@@ -656,6 +680,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     stdin_handle.abort();
     stdout_handle.abort();
     merge_handle.abort();
+    feedback_handle.abort();
     if let Some(h) = debounce_handle {
         h.abort();
     }
@@ -834,14 +859,14 @@ async fn debounce_loop(
             // 3. New keystroke arrives (debounce notify) → abort the wait entirely.
             //    The outer debounce loop will re-fire trigger for the new buffer
             //    and overwrite `dynamic_rx` anyway, so we simply drop rx here.
-            let (maybe_async, rx_on_timeout) = tokio::select! {
+            let (maybe_async, rx_after_recv, rx_on_timeout) = tokio::select! {
                 maybe_result = rx.recv() => {
                     // Generator completed within the window (or sent empty).
-                    (maybe_result, None)
+                    (maybe_result, Some(rx), None)
                 }
                 _ = tokio::time::sleep(timeout_dur) => {
                     // Timeout: restore rx so dynamic_merge_loop can merge later.
-                    (None, Some(rx))
+                    (None, None, Some(rx))
                 }
                 _ = notify.notified() => {
                     // Keystroke supersedes. Abort the orphaned generator
@@ -876,6 +901,7 @@ async fn debounce_loop(
                     &parser,
                     &mut render_buf2,
                     maybe_async,
+                    rx_after_recv,
                     rx_on_timeout,
                     sync_suggestions,
                     cursor_row,
@@ -920,6 +946,41 @@ async fn dynamic_merge_loop(
             let mut stdout = std::io::stdout().lock();
             let _ = stdout.write_all(&render_buf);
             let _ = stdout.flush();
+        }
+    }
+}
+
+async fn feedback_tick_loop(notify: Arc<Notify>, handler: Arc<Mutex<InputHandler>>) {
+    loop {
+        notify.notified().await;
+        let mut interval = tokio::time::interval(Duration::from_millis(80));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            let mut stdout = std::io::stdout().lock();
+            let (keep_running, next_ms) = {
+                let mut h = match handler.lock() {
+                    Ok(h) => h,
+                    Err(e) => {
+                        tracing::warn!("feedback tick skipped (handler lock poisoned): {e}");
+                        break;
+                    }
+                };
+                if h.feedback_kind().is_loading() {
+                    h.render_indicator_only(&mut stdout);
+                    (true, 80)
+                } else if h.clear_expired_feedback(&mut stdout) {
+                    (false, 200)
+                } else {
+                    (h.feedback_kind().since().is_some(), 200)
+                }
+            };
+            let _ = stdout.flush();
+            if !keep_running {
+                break;
+            }
+            interval = tokio::time::interval(Duration::from_millis(next_ms));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         }
     }
 }

--- a/crates/gc-pty/tests/async_timing.rs
+++ b/crates/gc-pty/tests/async_timing.rs
@@ -13,9 +13,23 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use gc_pty::dynamic_result::{DynamicResult, ProviderTag};
 use gc_pty::handler::InputHandler;
 use gc_suggest::types::{Suggestion, SuggestionKind, SuggestionSource};
 use tokio::sync::mpsc;
+
+fn loaded(items: Vec<Suggestion>) -> DynamicResult {
+    DynamicResult::Loaded {
+        provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+        suggestions: items,
+    }
+}
+
+fn empty_result() -> DynamicResult {
+    DynamicResult::Empty {
+        provider: ProviderTag::Git(gc_suggest::git::GitQueryKind::Branches),
+    }
+}
 
 // NOTE: gc_terminal::TerminalProfile::for_ghostty() is only available in
 // dev/test builds via the "test-utils" feature (declared in gc-pty's
@@ -55,13 +69,13 @@ fn make_handler_with_delayed_rx(
     // Prime dynamic_ctx so the staleness check in try_merge_dynamic passes.
     handler.prime_dynamic_ctx_for_empty_buffer();
 
-    let (tx, rx) = mpsc::channel::<Vec<Suggestion>>(1);
+    let (tx, rx) = mpsc::channel::<DynamicResult>(1);
     handler.restore_dynamic_rx(rx);
 
     // Spawn a task that sends async_items after `delay`.
     let sender = tokio::spawn(async move {
         tokio::time::sleep(delay).await;
-        let _ = tx.send(async_items).await;
+        let _ = tx.send(loaded(async_items)).await;
     });
 
     (handler, sender)
@@ -118,7 +132,7 @@ async fn fast_async_arrives_before_block_window() {
     let timeout_dur = Duration::from_millis(80);
 
     // Mirror what debounce_loop does in Phase 2.
-    let (maybe_async, rx_on_timeout): (Option<Vec<Suggestion>>, Option<mpsc::Receiver<_>>) = {
+    let (maybe_async, rx_on_timeout): (Option<DynamicResult>, Option<mpsc::Receiver<_>>) = {
         let mut rx = rx;
         tokio::select! {
             maybe_result = rx.recv() => (maybe_result, None),
@@ -140,7 +154,12 @@ async fn fast_async_arrives_before_block_window() {
     );
 
     let async_results = maybe_async.unwrap();
-    assert_eq!(async_results.len(), 2, "expected 2 branch suggestions");
+    match &async_results {
+        DynamicResult::Loaded { suggestions, .. } => {
+            assert_eq!(suggestions.len(), 2, "expected 2 branch suggestions")
+        }
+        other => panic!("expected loaded result, got {other:?}"),
+    }
 
     // Now call apply_block_result.
     let parser = make_parser();
@@ -149,6 +168,7 @@ async fn fast_async_arrives_before_block_window() {
         &parser,
         &mut render_buf,
         Some(async_results),
+        None,
         None,
         sync_suggestions.clone(),
         0,
@@ -187,6 +207,70 @@ async fn fast_async_arrives_before_block_window() {
     sender_task.await.unwrap();
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_result_keeps_receiver_when_more_batches_may_arrive() {
+    let mut handler = make_test_handler(80);
+    handler.set_buffer_generation(1);
+    handler.set_spawned_generation(1);
+    handler.prime_dynamic_ctx_for_empty_buffer();
+
+    let (tx, mut rx) = mpsc::channel::<DynamicResult>(2);
+    tx.send(loaded(vec![branch_suggestion("main")]))
+        .await
+        .unwrap();
+    let first = rx.recv().await.expect("first dynamic batch");
+
+    let parser = make_parser();
+    let mut render_buf = Vec::new();
+    handler.apply_block_result(
+        &parser,
+        &mut render_buf,
+        Some(first),
+        Some(rx),
+        None,
+        vec![flag_suggestion("--verbose")],
+        0,
+        0,
+        24,
+        80,
+        (0, 0),
+        "",
+    );
+
+    assert!(
+        handler.has_dynamic_rx(),
+        "open receiver must be restored after a partial bounded-block batch"
+    );
+    assert!(
+        handler
+            .current_suggestions()
+            .iter()
+            .any(|s| s.text == "main"),
+        "first batch should still merge immediately"
+    );
+
+    tx.send(loaded(vec![branch_suggestion("dev")]))
+        .await
+        .unwrap();
+    drop(tx);
+    let mut render_buf = Vec::new();
+    assert!(handler.try_merge_dynamic(&parser, &mut render_buf));
+
+    let texts: Vec<&str> = handler
+        .current_suggestions()
+        .iter()
+        .map(|s| s.text.as_str())
+        .collect();
+    assert!(
+        texts.contains(&"main") && texts.contains(&"dev"),
+        "later dynamic batches must not be lost: {texts:?}"
+    );
+    assert!(
+        !handler.has_dynamic_rx(),
+        "receiver clears once the final batch disconnects"
+    );
+}
+
 // ── Test 2 ───────────────────────────────────────────────────────────────────
 
 /// Generator returns at 200 ms; render_block_ms = 80 ms.
@@ -207,7 +291,7 @@ async fn slow_async_falls_through_then_merges_on_arrival() {
     let start = Instant::now();
     let timeout_dur = Duration::from_millis(80);
 
-    let (maybe_async, rx_on_timeout): (Option<Vec<Suggestion>>, Option<mpsc::Receiver<_>>) = {
+    let (maybe_async, rx_on_timeout): (Option<DynamicResult>, Option<mpsc::Receiver<_>>) = {
         let mut rx = rx;
         tokio::select! {
             maybe_result = rx.recv() => (maybe_result, None),
@@ -241,6 +325,7 @@ async fn slow_async_falls_through_then_merges_on_arrival() {
         &parser,
         &mut render_buf,
         None, // timeout: no async results
+        None,
         rx_restored,
         sync_suggestions,
         0,
@@ -415,7 +500,8 @@ async fn fast_async_with_typed_query_refilters_pool() {
     handler.apply_block_result(
         &parser,
         &mut render_buf,
-        Some(async_items),
+        Some(loaded(async_items)),
+        None,
         None,
         sync_suggestions,
         0,
@@ -474,7 +560,8 @@ async fn empty_async_result_clears_loading_state() {
     handler.apply_block_result(
         &parser,
         &mut render_buf,
-        Some(Vec::new()),
+        Some(empty_result()),
+        None,
         None,
         Vec::new(),
         0,
@@ -617,7 +704,8 @@ async fn stale_async_result_dropped_when_buffer_drifted() {
     handler.apply_block_result(
         &parser,
         &mut render_buf,
-        Some(vec![branch_suggestion("main")]),
+        Some(loaded(vec![branch_suggestion("main")])),
+        None,
         None,
         Vec::new(),
         0,
@@ -668,7 +756,8 @@ async fn stale_generation_drops_async_result() {
     handler.apply_block_result(
         &parser,
         &mut render_buf,
-        Some(vec![branch_suggestion("main")]),
+        Some(loaded(vec![branch_suggestion("main")])),
+        None,
         None,
         Vec::new(),
         0,

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -626,10 +626,7 @@ impl SuggestionEngine {
         Ok(fuzzy::rank(query, all, MAX_DYNAMIC_CANDIDATES))
     }
 
-    /// Resolve a single git query kind asynchronously. The per-kind variant
-    /// of [`Self::resolve_git`]: surfaces the underlying error to the caller
-    /// instead of swallowing it into an empty vec, so the handler's async
-    /// feedback layer can report which specific git generator failed.
+    /// Per-kind variant of [`Self::resolve_git`] that surfaces errors instead of swallowing.
     pub async fn resolve_git_kind(
         &self,
         kind: git::GitQueryKind,
@@ -643,10 +640,7 @@ impl SuggestionEngine {
         Ok(fuzzy::rank(query, suggestions, MAX_DYNAMIC_CANDIDATES))
     }
 
-    /// Resolve a single native provider kind asynchronously. The per-kind
-    /// variant of [`Self::resolve_providers`]: surfaces the underlying error
-    /// to the caller instead of logging-and-swallowing, so the handler's
-    /// async feedback layer can report which specific provider failed.
+    /// Per-kind variant of [`Self::resolve_providers`] that surfaces errors instead of logging-and-swallowing.
     pub async fn resolve_provider_kind(
         &self,
         kind: ProviderKind,
@@ -658,7 +652,10 @@ impl SuggestionEngine {
                 cwd = %ctx.cwd.display(),
                 "provider cwd is relative; skipping provider resolution"
             );
-            return Ok(Vec::new());
+            return Err(anyhow::anyhow!(
+                "provider cwd is relative: {}",
+                ctx.cwd.display()
+            ));
         }
         let suggestions = providers::resolve(kind, ctx).await?;
         if query.is_empty() {

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -626,6 +626,47 @@ impl SuggestionEngine {
         Ok(fuzzy::rank(query, all, MAX_DYNAMIC_CANDIDATES))
     }
 
+    /// Resolve a single git query kind asynchronously. The per-kind variant
+    /// of [`Self::resolve_git`]: surfaces the underlying error to the caller
+    /// instead of swallowing it into an empty vec, so the handler's async
+    /// feedback layer can report which specific git generator failed.
+    pub async fn resolve_git_kind(
+        &self,
+        kind: git::GitQueryKind,
+        cwd: &Path,
+        query: &str,
+    ) -> Result<Vec<Suggestion>> {
+        let suggestions = git::git_suggestions(cwd, kind).await?;
+        if query.is_empty() {
+            return Ok(suggestions);
+        }
+        Ok(fuzzy::rank(query, suggestions, MAX_DYNAMIC_CANDIDATES))
+    }
+
+    /// Resolve a single native provider kind asynchronously. The per-kind
+    /// variant of [`Self::resolve_providers`]: surfaces the underlying error
+    /// to the caller instead of logging-and-swallowing, so the handler's
+    /// async feedback layer can report which specific provider failed.
+    pub async fn resolve_provider_kind(
+        &self,
+        kind: ProviderKind,
+        ctx: &ProviderCtx,
+        query: &str,
+    ) -> Result<Vec<Suggestion>> {
+        if !ctx.cwd.is_absolute() {
+            tracing::warn!(
+                cwd = %ctx.cwd.display(),
+                "provider cwd is relative; skipping provider resolution"
+            );
+            return Ok(Vec::new());
+        }
+        let suggestions = providers::resolve(kind, ctx).await?;
+        if query.is_empty() {
+            return Ok(suggestions);
+        }
+        Ok(fuzzy::rank(query, suggestions, MAX_DYNAMIC_CANDIDATES))
+    }
+
     /// Convenience method that resolves the spec and runs script generators.
     /// Prefer `run_generators` in the handler to avoid redundant spec resolution.
     pub async fn suggest_dynamic(

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -2088,6 +2088,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_resolve_provider_kind_relative_cwd_returns_err() {
+        let engine = make_engine();
+        let ctx = crate::providers::ProviderCtx::new_for_test(
+            PathBuf::from("relative/path"),
+            Arc::new(std::collections::HashMap::new()),
+            String::new(),
+        );
+
+        let result = engine
+            .resolve_provider_kind(ProviderKind::CargoWorkspaceMembers, &ctx, "")
+            .await;
+
+        let err = result.expect_err("relative cwd must surface an error to the caller");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("relative") && msg.contains("relative/path"),
+            "error must name both the cause and the offending path, got {msg:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_resolve_providers_empty_slice() {
         // An empty `kinds` slice must no-op cleanly — empty Vec and no
         // panic — for both the empty-query and non-empty-query paths.

--- a/crates/ghost-complete/src/doctor.rs
+++ b/crates/ghost-complete/src/doctor.rs
@@ -162,6 +162,9 @@ fn check_theme(config: &gc_config::GhostConfig) -> CheckResult {
         ("item_text", &resolved.item_text),
         ("scrollbar", &resolved.scrollbar),
         ("border", &resolved.border),
+        ("feedback_loading", &resolved.feedback_loading),
+        ("feedback_empty", &resolved.feedback_empty),
+        ("feedback_error", &resolved.feedback_error),
     ];
 
     let mut errors = Vec::new();

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -28,6 +28,9 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # [popup]
 # max_visible = 10
 # borders = false  # Set to true to enable rounded borders around the popup
+# feedback_dismiss_ms = 1200  # Empty/error feedback auto-dismiss delay; 0 disables
+# spinner = true  # Animate async Loading feedback in wide popups
+# show_provider_errors = false  # Set true to show provider names in error feedback
 
 # [suggest]
 # max_results = 50
@@ -56,6 +59,9 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # item_text = \"\"
 # scrollbar = \"dim\"
 # border = \"dim\"
+# feedback_loading = \"dim\"
+# feedback_empty = \"dim\"
+# feedback_error = \"dim fg:#f38ba8\"
 
 # [experimental]
 # multi_terminal = false  # Set to true to enable unsupported/unknown terminals

--- a/crates/ghost-complete/src/tui/fields.rs
+++ b/crates/ghost-complete/src/tui/fields.rs
@@ -105,6 +105,30 @@ pub fn all_fields() -> Vec<FieldMeta> {
             reload: ReloadBehavior::Live,
             help: "Draw box-drawing borders around the popup",
         },
+        FieldMeta {
+            section: "popup",
+            key: "feedback_dismiss_ms",
+            field_type: FieldType::U64,
+            default: "1200",
+            reload: ReloadBehavior::Live,
+            help: "Milliseconds before Empty/Error feedback auto-dismisses",
+        },
+        FieldMeta {
+            section: "popup",
+            key: "spinner",
+            field_type: FieldType::Bool,
+            default: "true",
+            reload: ReloadBehavior::Live,
+            help: "Animate async Loading feedback",
+        },
+        FieldMeta {
+            section: "popup",
+            key: "show_provider_errors",
+            field_type: FieldType::Bool,
+            default: "false",
+            reload: ReloadBehavior::Live,
+            help: "Show provider names in error feedback",
+        },
         // suggest
         FieldMeta {
             section: "suggest",
@@ -268,6 +292,30 @@ pub fn all_fields() -> Vec<FieldMeta> {
             default: "",
             reload: ReloadBehavior::Live,
             help: "Style for popup borders",
+        },
+        FieldMeta {
+            section: "theme",
+            key: "feedback_loading",
+            field_type: FieldType::StyleString,
+            default: "",
+            reload: ReloadBehavior::Live,
+            help: "Style for Loading feedback",
+        },
+        FieldMeta {
+            section: "theme",
+            key: "feedback_empty",
+            field_type: FieldType::StyleString,
+            default: "",
+            reload: ReloadBehavior::Live,
+            help: "Style for Empty feedback",
+        },
+        FieldMeta {
+            section: "theme",
+            key: "feedback_error",
+            field_type: FieldType::StyleString,
+            default: "",
+            reload: ReloadBehavior::Live,
+            help: "Style for provider Error feedback",
         },
         // paths
         FieldMeta {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -331,7 +331,7 @@ match_highlight = "underline"
 | `[trigger]` | `auto_chars` | Yes |
 | `[trigger]` | `delay_ms` | No |
 | `[trigger]` | `auto_trigger` | Yes |
-| `[popup]` | `max_visible` | Yes |
+| `[popup]` | `max_visible`, `borders`, `feedback_dismiss_ms`, `spinner`, `show_provider_errors` | Yes |
 | `[suggest]` | All fields | No |
 | `[suggest.providers]` | All fields | No |
 | `[paths]` | All fields | No |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -31,11 +31,17 @@ Controls the popup appearance.
 |-------|------|---------|-------------|
 | `max_visible` | integer | `10` | Maximum number of suggestions shown at once |
 | `borders` | bool | `false` | Draw a border around the popup |
+| `feedback_dismiss_ms` | integer | `1200` | Milliseconds to keep Empty/Error feedback visible. Set to `0` to disable auto-dismiss. Values above `10000` are clamped. |
+| `spinner` | bool | `true` | Animate Loading feedback when the popup is wide enough |
+| `show_provider_errors` | bool | `false` | Show provider names in error feedback. Disabled by default for shared-screen privacy. |
 
 ```toml
 [popup]
 max_visible = 10
 borders = false
+feedback_dismiss_ms = 1200
+spinner = true
+show_provider_errors = false
 ```
 
 Popup width is calculated automatically from suggestion content, clamped between 20 and 60 columns.
@@ -134,24 +140,28 @@ Customize popup colors and styles. Values are space-separated SGR token strings.
 | `item_text` | string | (from preset) | Style for non-selected item text |
 | `scrollbar` | string | (from preset) | Style for the scrollbar track |
 | `border` | string | (from preset) | Style for the popup border |
+| `feedback_loading` | string | (from preset) | Style for Loading feedback |
+| `feedback_empty` | string | (from preset) | Style for Empty feedback |
+| `feedback_error` | string | (from preset) | Style for provider Error feedback |
 
 ```toml
 [theme]
 preset = "catppuccin"
 # Override individual fields from the preset:
 match_highlight = "underline"
+feedback_error = "dim fg:#d20f39"
 ```
 
 #### Presets
 
-| Preset | Selected | Description | Match Highlight | Item Text | Scrollbar | Border |
-|--------|----------|-------------|-----------------|-----------|-----------|--------|
-| `dark` | `reverse` | `dim` | `bold` | *(none)* | `dim` | `dim` |
-| `light` | `fg:#1e1e2e bg:#dce0e8 bold` | `fg:#6c6f85` | `fg:#d20f39 bold` | *(none)* | `fg:#9ca0b0` | `fg:#9ca0b0` |
-| `catppuccin` | `fg:#cdd6f4 bg:#585b70 bold` | `fg:#6c7086` | `fg:#f9e2af bold` | *(none)* | `fg:#585b70` | `fg:#585b70` |
-| `material-darker` | `fg:#eeffff bg:#424242 bold` | `fg:#616161` | `fg:#ffcb6b bold` | *(none)* | `fg:#424242` | `fg:#424242` |
+| Preset | Selected | Description | Match Highlight | Item Text | Scrollbar | Border | Feedback Error |
+|--------|----------|-------------|-----------------|-----------|-----------|--------|----------------|
+| `dark` | `reverse` | `dim` | `bold` | *(none)* | `dim` | `dim` | `dim fg:#f38ba8` |
+| `light` | `fg:#1e1e2e bg:#dce0e8 bold` | `fg:#6c6f85` | `fg:#d20f39 bold` | *(none)* | `fg:#9ca0b0` | `fg:#9ca0b0` | `dim fg:#d20f39` |
+| `catppuccin` | `fg:#cdd6f4 bg:#585b70 bold` | `fg:#6c7086` | `fg:#f9e2af bold` | *(none)* | `fg:#585b70` | `fg:#585b70` | `dim fg:#f38ba8` |
+| `material-darker` | `fg:#eeffff bg:#424242 bold` | `fg:#616161` | `fg:#ffcb6b bold` | *(none)* | `fg:#424242` | `fg:#424242` | `dim fg:#ff5370` |
 
-All presets leave `item_text` unstyled (default terminal foreground). Override it to colorize non-selected items.
+All presets leave `item_text` unstyled (default terminal foreground). `feedback_loading` and `feedback_empty` inherit `description` by default. Override `item_text` to colorize non-selected items.
 
 #### Style String Syntax
 


### PR DESCRIPTION
## What

Adds async suggestion feedback states to the popup:

- loading spinner/ellipsis while dynamic generators are pending
- empty, provider error, and partial-error feedback rows
- configurable popup feedback behavior and theme styles
- cheap indicator-row repaint path plus a Criterion benchmark
- regression coverage for dynamic channel draining, feedback expiry, and label clipping

## Why

Async generators could leave users without clear feedback while results were pending or when providers returned no matches/errors. This makes the async lifecycle visible without repainting the full popup on every spinner tick.

## Testing

- [x] `cargo test` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manually tested in Ghostty with zsh

Additional checks:

- [x] `cargo check --all-targets`
- [x] `git diff --check`
- [x] `cargo bench -p gc-overlay --bench feedback_render -- --sample-size 10` (`indicator_row_width_60` around 120 ns)

Note: `cargo run -- --config <repo-specs-config> validate-specs --json` still fails on existing spec data issues unrelated to this PR: parse failures in `index`, `next`, and `pnpx`, with warnings in `lsof`, `micro`, and `remotion`.
