### PR TITLE
feat: Add popup page navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Popup navigation: PageUp, PageDown, Home, and End jump by page or to the
+  ends while the popup is visible.
 - Local-project completion providers for `make` targets, `npm run` scripts,
   and `cargo -p` workspace members. Pure Rust file parsers — no JS runtime,
   no `make`/`npm`/`cargo` shellout — with mtime-keyed caching (with

--- a/crates/gc-overlay/src/types.rs
+++ b/crates/gc-overlay/src/types.rs
@@ -69,19 +69,19 @@ impl OverlayState {
 
     pub fn move_page_down(&mut self, total_items: usize, max_visible: usize) {
         let max_visible = max_visible.max(1);
+        if total_items == 0 {
+            self.reset();
+            return;
+        }
+
         match self.selected {
             None if total_items > 0 => {
                 self.selected = Some(0);
             }
             None => {}
             Some(n) => {
-                let Some(last) = total_items.checked_sub(1) else {
-                    return;
-                };
+                let last = total_items - 1;
                 let new = n.saturating_add(max_visible).min(last);
-                if new == n {
-                    return;
-                }
 
                 self.selected = Some(new);
                 if new >= self.scroll_offset + max_visible {
@@ -304,6 +304,16 @@ mod tests {
     }
 
     #[test]
+    fn test_page_down_empty_list_clears_stale_state() {
+        let mut state = OverlayState::new();
+        state.selected = Some(4);
+        state.scroll_offset = 2;
+        state.move_page_down(0, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, None);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
     fn test_page_down_clamps_at_last() {
         let mut state = OverlayState::new();
         state.selected = Some(48);
@@ -321,6 +331,16 @@ mod tests {
         state.move_page_down(50, DEFAULT_MAX_VISIBLE);
         assert_eq!(state.selected, Some(49));
         assert_eq!(state.scroll_offset, 40);
+    }
+
+    #[test]
+    fn test_page_down_at_last_after_viewport_shrink_keeps_selected_visible() {
+        let mut state = OverlayState::new();
+        state.selected = Some(49);
+        state.scroll_offset = 40;
+        state.move_page_down(50, 5);
+        assert_eq!(state.selected, Some(49));
+        assert_eq!(state.scroll_offset, 45);
     }
 
     #[test]

--- a/crates/gc-overlay/src/types.rs
+++ b/crates/gc-overlay/src/types.rs
@@ -33,6 +33,7 @@ impl OverlayState {
     }
 
     pub fn move_down(&mut self, total_items: usize, max_visible: usize) {
+        let max_visible = max_visible.max(1);
         match self.selected {
             None if total_items > 0 => {
                 self.selected = Some(0);
@@ -46,9 +47,11 @@ impl OverlayState {
             }
             _ => {}
         }
+        self.keep_selected_visible(max_visible);
     }
 
     pub fn move_page_up(&mut self, max_visible: usize) {
+        let max_visible = max_visible.max(1);
         match self.selected {
             Some(0) => {
                 self.selected = None;
@@ -61,9 +64,11 @@ impl OverlayState {
             }
             None => {}
         }
+        self.keep_selected_visible(max_visible);
     }
 
     pub fn move_page_down(&mut self, total_items: usize, max_visible: usize) {
+        let max_visible = max_visible.max(1);
         match self.selected {
             None if total_items > 0 => {
                 self.selected = Some(0);
@@ -87,6 +92,7 @@ impl OverlayState {
                     .min(total_items.saturating_sub(max_visible));
             }
         }
+        self.keep_selected_visible(max_visible);
     }
 
     pub fn move_home(&mut self, total_items: usize) {
@@ -99,17 +105,34 @@ impl OverlayState {
     }
 
     pub fn move_end(&mut self, total_items: usize, max_visible: usize) {
+        let max_visible = max_visible.max(1);
         let Some(last) = total_items.checked_sub(1) else {
             return;
         };
 
         self.selected = Some(last);
         self.scroll_offset = total_items.saturating_sub(max_visible);
+        self.keep_selected_visible(max_visible);
     }
 
     pub fn reset(&mut self) {
         self.selected = None;
         self.scroll_offset = 0;
+    }
+
+    fn keep_selected_visible(&mut self, visible_count: usize) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+
+        if selected < self.scroll_offset {
+            self.scroll_offset = selected;
+        } else if selected >= self.scroll_offset.saturating_add(visible_count) {
+            self.scroll_offset = selected + 1 - visible_count;
+        }
+
+        debug_assert!(self.scroll_offset <= selected);
+        debug_assert!(selected < self.scroll_offset.saturating_add(visible_count));
     }
 }
 

--- a/crates/gc-overlay/src/types.rs
+++ b/crates/gc-overlay/src/types.rs
@@ -48,6 +48,65 @@ impl OverlayState {
         }
     }
 
+    pub fn move_page_up(&mut self, max_visible: usize) {
+        match self.selected {
+            Some(0) => {
+                self.selected = None;
+                self.scroll_offset = 0;
+            }
+            Some(n) => {
+                let new = n.saturating_sub(max_visible);
+                self.selected = Some(new);
+                self.scroll_offset = self.scroll_offset.min(new);
+            }
+            None => {}
+        }
+    }
+
+    pub fn move_page_down(&mut self, total_items: usize, max_visible: usize) {
+        match self.selected {
+            None if total_items > 0 => {
+                self.selected = Some(0);
+            }
+            None => {}
+            Some(n) => {
+                let Some(last) = total_items.checked_sub(1) else {
+                    return;
+                };
+                let new = n.saturating_add(max_visible).min(last);
+                if new == n {
+                    return;
+                }
+
+                self.selected = Some(new);
+                if new >= self.scroll_offset + max_visible {
+                    self.scroll_offset = new + 1 - max_visible;
+                }
+                self.scroll_offset = self
+                    .scroll_offset
+                    .min(total_items.saturating_sub(max_visible));
+            }
+        }
+    }
+
+    pub fn move_home(&mut self, total_items: usize) {
+        if total_items == 0 {
+            return;
+        }
+
+        self.selected = Some(0);
+        self.scroll_offset = 0;
+    }
+
+    pub fn move_end(&mut self, total_items: usize, max_visible: usize) {
+        let Some(last) = total_items.checked_sub(1) else {
+            return;
+        };
+
+        self.selected = Some(last);
+        self.scroll_offset = total_items.saturating_sub(max_visible);
+    }
+
     pub fn reset(&mut self) {
         self.selected = None;
         self.scroll_offset = 0;
@@ -154,6 +213,180 @@ mod tests {
         state.move_up();
         assert_eq!(state.selected, Some(4));
         assert_eq!(state.scroll_offset, 4);
+    }
+
+    #[test]
+    fn test_page_up_from_none_is_noop() {
+        let mut state = OverlayState::new();
+        state.move_page_up(DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, None);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_page_up_below_max_visible_clamps_to_zero() {
+        let mut state = OverlayState::new();
+        state.selected = Some(3);
+        state.scroll_offset = 1;
+        state.move_page_up(DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, Some(0));
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_page_up_at_zero_deselects() {
+        let mut state = OverlayState::new();
+        state.selected = Some(0);
+        state.scroll_offset = 5;
+        state.move_page_up(DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, None);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_page_up_full_page_step() {
+        let mut state = OverlayState::new();
+        state.selected = Some(15);
+        state.scroll_offset = 6;
+        state.move_page_up(DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, Some(5));
+        assert_eq!(state.scroll_offset, 5);
+    }
+
+    #[test]
+    fn test_page_up_keeps_invariant() {
+        let mut state = OverlayState::new();
+        state.selected = Some(25);
+        state.scroll_offset = 16;
+        state.move_page_up(DEFAULT_MAX_VISIBLE);
+        let selected = state.selected.unwrap();
+        assert!(state.scroll_offset <= selected);
+        assert!(selected < state.scroll_offset + DEFAULT_MAX_VISIBLE);
+    }
+
+    #[test]
+    fn test_page_down_from_none_selects_zero() {
+        let mut state = OverlayState::new();
+        state.move_page_down(50, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, Some(0));
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_page_down_empty_list_is_noop() {
+        let mut state = OverlayState::new();
+        state.move_page_down(0, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, None);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_page_down_clamps_at_last() {
+        let mut state = OverlayState::new();
+        state.selected = Some(48);
+        state.scroll_offset = 40;
+        state.move_page_down(50, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, Some(49));
+        assert_eq!(state.scroll_offset, 40);
+    }
+
+    #[test]
+    fn test_page_down_at_last_is_noop() {
+        let mut state = OverlayState::new();
+        state.selected = Some(49);
+        state.scroll_offset = 40;
+        state.move_page_down(50, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, Some(49));
+        assert_eq!(state.scroll_offset, 40);
+    }
+
+    #[test]
+    fn test_page_down_full_step_scrolls_viewport() {
+        let mut state = OverlayState::new();
+        state.selected = Some(5);
+        state.scroll_offset = 0;
+        state.move_page_down(100, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, Some(15));
+        assert_eq!(state.scroll_offset, 6);
+    }
+
+    #[test]
+    fn test_page_down_short_list_no_viewport_change() {
+        let mut state = OverlayState::new();
+        state.selected = Some(2);
+        state.move_page_down(5, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, Some(4));
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_page_down_keeps_invariant() {
+        let mut state = OverlayState::new();
+        state.selected = Some(25);
+        state.scroll_offset = 16;
+        state.move_page_down(100, DEFAULT_MAX_VISIBLE);
+        let selected = state.selected.unwrap();
+        assert!(state.scroll_offset <= selected);
+        assert!(selected < state.scroll_offset + DEFAULT_MAX_VISIBLE);
+    }
+
+    #[test]
+    fn test_home_empty_list_is_noop() {
+        let mut state = OverlayState::new();
+        state.move_home(0);
+        assert_eq!(state.selected, None);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_home_from_none_selects_zero() {
+        let mut state = OverlayState::new();
+        state.move_home(50);
+        assert_eq!(state.selected, Some(0));
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_home_from_middle_resets_scroll() {
+        let mut state = OverlayState::new();
+        state.selected = Some(20);
+        state.scroll_offset = 11;
+        state.move_home(50);
+        assert_eq!(state.selected, Some(0));
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_end_empty_list_is_noop() {
+        let mut state = OverlayState::new();
+        state.move_end(0, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, None);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_end_from_none_selects_last() {
+        let mut state = OverlayState::new();
+        state.move_end(50, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, Some(49));
+        assert_eq!(state.scroll_offset, 40);
+    }
+
+    #[test]
+    fn test_end_short_list_no_scroll() {
+        let mut state = OverlayState::new();
+        state.move_end(5, DEFAULT_MAX_VISIBLE);
+        assert_eq!(state.selected, Some(4));
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_end_keeps_invariant() {
+        let mut state = OverlayState::new();
+        state.move_end(50, DEFAULT_MAX_VISIBLE);
+        let selected = state.selected.unwrap();
+        assert!(state.scroll_offset <= selected);
+        assert!(selected < state.scroll_offset + DEFAULT_MAX_VISIBLE);
     }
 
     #[test]

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -633,12 +633,12 @@ impl InputHandler {
                 self.render(parser, stdout);
                 return Vec::new();
             }
-            KeyEvent::Home => {
+            KeyEvent::Home | KeyEvent::HomeCsiTilde | KeyEvent::HomeSs3 => {
                 self.overlay.move_home(self.suggestions.len());
                 self.render(parser, stdout);
                 return Vec::new();
             }
-            KeyEvent::End => {
+            KeyEvent::End | KeyEvent::EndCsiTilde | KeyEvent::EndSs3 => {
                 self.overlay
                     .move_end(self.suggestions.len(), self.max_visible);
                 self.render(parser, stdout);
@@ -2084,7 +2084,11 @@ pub fn key_to_bytes(key: &KeyEvent) -> Vec<u8> {
         KeyEvent::PageUp => vec![0x1B, b'[', b'5', b'~'],
         KeyEvent::PageDown => vec![0x1B, b'[', b'6', b'~'],
         KeyEvent::Home => vec![0x1B, b'[', b'H'],
+        KeyEvent::HomeCsiTilde => vec![0x1B, b'[', b'1', b'~'],
+        KeyEvent::HomeSs3 => vec![0x1B, b'O', b'H'],
         KeyEvent::End => vec![0x1B, b'[', b'F'],
+        KeyEvent::EndCsiTilde => vec![0x1B, b'[', b'4', b'~'],
+        KeyEvent::EndSs3 => vec![0x1B, b'O', b'F'],
         KeyEvent::CtrlSpace => vec![0x00],
         KeyEvent::CtrlSlash => vec![0x1F],
         KeyEvent::Backspace => vec![0x7F],
@@ -2159,11 +2163,15 @@ mod tests {
     #[test]
     fn test_key_to_bytes_home_round_trip() {
         assert_eq!(key_to_bytes(&KeyEvent::Home), b"\x1B[H");
+        assert_eq!(key_to_bytes(&KeyEvent::HomeCsiTilde), b"\x1B[1~");
+        assert_eq!(key_to_bytes(&KeyEvent::HomeSs3), b"\x1BOH");
     }
 
     #[test]
     fn test_key_to_bytes_end_round_trip() {
         assert_eq!(key_to_bytes(&KeyEvent::End), b"\x1B[F");
+        assert_eq!(key_to_bytes(&KeyEvent::EndCsiTilde), b"\x1B[4~");
+        assert_eq!(key_to_bytes(&KeyEvent::EndSs3), b"\x1BOF");
     }
 
     #[test]
@@ -2190,7 +2198,11 @@ mod tests {
             KeyEvent::PageUp,
             KeyEvent::PageDown,
             KeyEvent::Home,
+            KeyEvent::HomeCsiTilde,
+            KeyEvent::HomeSs3,
             KeyEvent::End,
+            KeyEvent::EndCsiTilde,
+            KeyEvent::EndSs3,
             KeyEvent::CtrlSpace,
             KeyEvent::CtrlSlash,
             KeyEvent::Backspace,
@@ -2837,12 +2849,32 @@ mod tests {
     }
 
     #[test]
+    fn test_hidden_home_end_alternate_encodings_forward_verbatim() {
+        for raw in [b"\x1B[1~".as_slice(), b"\x1B[4~", b"\x1BOH", b"\x1BOF"] {
+            let events = crate::input::parse_keys(raw);
+            assert_eq!(events.len(), 1, "expected one parsed event for {raw:?}");
+
+            let mut handler = make_handler();
+            let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+            let mut buf = Vec::new();
+
+            let result = handler.process_key(&events[0], &parser, &mut buf);
+
+            assert_eq!(result, raw, "hidden popup must forward {raw:?} unchanged");
+        }
+    }
+
+    #[test]
     fn test_page_navigation_does_not_dismiss_popup() {
         for key in [
             KeyEvent::PageUp,
             KeyEvent::PageDown,
             KeyEvent::Home,
+            KeyEvent::HomeCsiTilde,
+            KeyEvent::HomeSs3,
             KeyEvent::End,
+            KeyEvent::EndCsiTilde,
+            KeyEvent::EndSs3,
         ] {
             let mut handler = make_visible_handler(numbered_suggestions(50));
             handler.overlay.selected = Some(5);

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -621,6 +621,32 @@ impl InputHandler {
             return Vec::new();
         }
 
+        match key {
+            KeyEvent::PageUp => {
+                self.overlay.move_page_up(self.max_visible);
+                self.render(parser, stdout);
+                return Vec::new();
+            }
+            KeyEvent::PageDown => {
+                self.overlay
+                    .move_page_down(self.suggestions.len(), self.max_visible);
+                self.render(parser, stdout);
+                return Vec::new();
+            }
+            KeyEvent::Home => {
+                self.overlay.move_home(self.suggestions.len());
+                self.render(parser, stdout);
+                return Vec::new();
+            }
+            KeyEvent::End => {
+                self.overlay
+                    .move_end(self.suggestions.len(), self.max_visible);
+                self.render(parser, stdout);
+                return Vec::new();
+            }
+            _ => {}
+        }
+
         // Structural keys — not configurable
         match key {
             KeyEvent::ArrowLeft | KeyEvent::ArrowRight => {
@@ -2055,6 +2081,10 @@ pub fn key_to_bytes(key: &KeyEvent) -> Vec<u8> {
         KeyEvent::ArrowDown => vec![0x1B, b'[', b'B'],
         KeyEvent::ArrowRight => vec![0x1B, b'[', b'C'],
         KeyEvent::ArrowLeft => vec![0x1B, b'[', b'D'],
+        KeyEvent::PageUp => vec![0x1B, b'[', b'5', b'~'],
+        KeyEvent::PageDown => vec![0x1B, b'[', b'6', b'~'],
+        KeyEvent::Home => vec![0x1B, b'[', b'H'],
+        KeyEvent::End => vec![0x1B, b'[', b'F'],
         KeyEvent::CtrlSpace => vec![0x00],
         KeyEvent::CtrlSlash => vec![0x1F],
         KeyEvent::Backspace => vec![0x7F],
@@ -2117,6 +2147,26 @@ mod tests {
     }
 
     #[test]
+    fn test_key_to_bytes_page_up_round_trip() {
+        assert_eq!(key_to_bytes(&KeyEvent::PageUp), b"\x1B[5~");
+    }
+
+    #[test]
+    fn test_key_to_bytes_page_down_round_trip() {
+        assert_eq!(key_to_bytes(&KeyEvent::PageDown), b"\x1B[6~");
+    }
+
+    #[test]
+    fn test_key_to_bytes_home_round_trip() {
+        assert_eq!(key_to_bytes(&KeyEvent::Home), b"\x1B[H");
+    }
+
+    #[test]
+    fn test_key_to_bytes_end_round_trip() {
+        assert_eq!(key_to_bytes(&KeyEvent::End), b"\x1B[F");
+    }
+
+    #[test]
     fn test_key_to_bytes_printable() {
         assert_eq!(key_to_bytes(&KeyEvent::Printable('x')), vec![b'x']);
     }
@@ -2137,6 +2187,10 @@ mod tests {
             KeyEvent::ArrowDown,
             KeyEvent::ArrowLeft,
             KeyEvent::ArrowRight,
+            KeyEvent::PageUp,
+            KeyEvent::PageDown,
+            KeyEvent::Home,
+            KeyEvent::End,
             KeyEvent::CtrlSpace,
             KeyEvent::CtrlSlash,
             KeyEvent::Backspace,
@@ -2654,11 +2708,170 @@ mod tests {
         h
     }
 
+    fn numbered_suggestions(count: usize) -> Vec<Suggestion> {
+        (0..count)
+            .map(|n| Suggestion {
+                text: format!("item-{n}"),
+                kind: SuggestionKind::Command,
+                source: SuggestionSource::Spec,
+                ..Default::default()
+            })
+            .collect()
+    }
+
     /// Test builder: visible handler with a single selected suggestion.
     fn make_selected_handler(suggestion: Suggestion) -> InputHandler {
         let mut h = make_visible_handler(vec![suggestion]);
         h.overlay.selected = Some(0);
         h
+    }
+
+    #[test]
+    fn test_page_down_when_visible_advances_selection() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.overlay.selected = Some(5);
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::PageDown, &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert_eq!(handler.overlay.selected, Some(15));
+    }
+
+    #[test]
+    fn test_page_up_when_visible_retreats_selection() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.overlay.selected = Some(15);
+        handler.overlay.scroll_offset = 6;
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::PageUp, &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert_eq!(handler.overlay.selected, Some(5));
+    }
+
+    #[test]
+    fn test_home_when_visible_jumps_to_zero() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.overlay.selected = Some(20);
+        handler.overlay.scroll_offset = 11;
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::Home, &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert_eq!(handler.overlay.selected, Some(0));
+        assert_eq!(handler.overlay.scroll_offset, 0);
+    }
+
+    #[test]
+    fn test_end_when_visible_jumps_to_last() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::End, &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert_eq!(handler.overlay.selected, Some(49));
+        assert_eq!(handler.overlay.scroll_offset, 40);
+    }
+
+    #[test]
+    fn test_page_down_intercepted_when_visible_returns_empty_bytes() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::PageDown, &parser, &mut buf);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_page_down_when_hidden_forwards_bytes() {
+        let mut handler = make_handler();
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::PageDown, &parser, &mut buf);
+
+        assert_eq!(result, b"\x1B[6~");
+    }
+
+    #[test]
+    fn test_page_up_when_hidden_forwards_bytes() {
+        let mut handler = make_handler();
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::PageUp, &parser, &mut buf);
+
+        assert_eq!(result, b"\x1B[5~");
+    }
+
+    #[test]
+    fn test_home_when_hidden_forwards_bytes() {
+        let mut handler = make_handler();
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::Home, &parser, &mut buf);
+
+        assert_eq!(result, b"\x1B[H");
+    }
+
+    #[test]
+    fn test_end_when_hidden_forwards_bytes() {
+        let mut handler = make_handler();
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::End, &parser, &mut buf);
+
+        assert_eq!(result, b"\x1B[F");
+    }
+
+    #[test]
+    fn test_page_navigation_does_not_dismiss_popup() {
+        for key in [
+            KeyEvent::PageUp,
+            KeyEvent::PageDown,
+            KeyEvent::Home,
+            KeyEvent::End,
+        ] {
+            let mut handler = make_visible_handler(numbered_suggestions(50));
+            handler.overlay.selected = Some(5);
+            let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+            let mut buf = Vec::new();
+
+            handler.process_key(&key, &parser, &mut buf);
+
+            assert!(handler.visible, "{key:?} should not dismiss popup");
+        }
+    }
+
+    #[test]
+    fn test_page_down_then_accept_uses_new_selection() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.overlay.selected = Some(5);
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let page_result = handler.process_key(&KeyEvent::PageDown, &parser, &mut buf);
+        assert!(page_result.is_empty());
+
+        let accept_result = handler.process_key(&KeyEvent::Tab, &parser, &mut buf);
+        let accepted = String::from_utf8_lossy(&accept_result);
+
+        assert!(
+            accepted.contains("item-15"),
+            "expected accept to use paged selection, got {accepted:?}"
+        );
     }
 
     #[test]

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -586,6 +586,8 @@ impl InputHandler {
         parser: &Arc<Mutex<TerminalParser>>,
         stdout: &mut dyn Write,
     ) -> Vec<u8> {
+        let visible_rows = self.effective_navigation_visible_rows(parser);
+
         // Configurable actions checked first via if-chain
         if key == &self.keybindings.navigate_up {
             self.overlay.move_up();
@@ -593,8 +595,7 @@ impl InputHandler {
             return Vec::new();
         }
         if key == &self.keybindings.navigate_down {
-            self.overlay
-                .move_down(self.suggestions.len(), self.max_visible);
+            self.overlay.move_down(self.suggestions.len(), visible_rows);
             self.render(parser, stdout);
             return Vec::new();
         }
@@ -623,13 +624,13 @@ impl InputHandler {
 
         match key {
             KeyEvent::PageUp => {
-                self.overlay.move_page_up(self.max_visible);
+                self.overlay.move_page_up(visible_rows);
                 self.render(parser, stdout);
                 return Vec::new();
             }
             KeyEvent::PageDown => {
                 self.overlay
-                    .move_page_down(self.suggestions.len(), self.max_visible);
+                    .move_page_down(self.suggestions.len(), visible_rows);
                 self.render(parser, stdout);
                 return Vec::new();
             }
@@ -639,8 +640,7 @@ impl InputHandler {
                 return Vec::new();
             }
             KeyEvent::End | KeyEvent::EndCsiTilde | KeyEvent::EndSs3 => {
-                self.overlay
-                    .move_end(self.suggestions.len(), self.max_visible);
+                self.overlay.move_end(self.suggestions.len(), visible_rows);
                 self.render(parser, stdout);
                 return Vec::new();
             }
@@ -663,6 +663,30 @@ impl InputHandler {
                 self.dismiss(stdout);
                 key_to_bytes(key)
             }
+        }
+    }
+
+    fn effective_navigation_visible_rows(&self, parser: &Arc<Mutex<TerminalParser>>) -> usize {
+        let border_pad: u16 = if self.theme.borders { 2 } else { 0 };
+        let min_screen = 1 + border_pad;
+
+        let screen_rows = match parser.lock() {
+            Ok(p) => p.state().screen_dimensions().0,
+            Err(e) => {
+                tracing::warn!(
+                    "parser mutex poisoned while computing popup navigation height: {e} — \
+                     using configured max_visible"
+                );
+                return self.max_visible.max(1);
+            }
+        };
+
+        if screen_rows > min_screen {
+            self.max_visible
+                .min((screen_rows - 1 - border_pad) as usize)
+                .max(1)
+        } else {
+            self.max_visible.max(1)
         }
     }
 
@@ -2749,6 +2773,31 @@ mod tests {
 
         assert!(result.is_empty());
         assert_eq!(handler.overlay.selected, Some(15));
+    }
+
+    #[test]
+    fn test_page_down_uses_effective_popup_height_on_short_terminal() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.overlay.selected = Some(5);
+        handler.overlay.scroll_offset = 0;
+        handler.last_layout = Some(PopupLayout {
+            start_row: 1,
+            start_col: 0,
+            width: 20,
+            height: 3,
+            scroll_deficit: 0,
+        });
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(4, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::PageDown, &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert_eq!(handler.overlay.selected, Some(8));
+        assert_eq!(handler.overlay.scroll_offset, 6);
+        let selected = handler.overlay.selected.unwrap();
+        assert!(handler.overlay.scroll_offset <= selected);
+        assert!(selected < handler.overlay.scroll_offset + 3);
     }
 
     #[test]

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -650,7 +650,7 @@ impl InputHandler {
             _ => {}
         }
 
-        // Structural keys — not configurable
+        // Remaining structural keys/default visible-popup handling.
         match key {
             KeyEvent::ArrowLeft | KeyEvent::ArrowRight => {
                 self.dismiss(stdout);
@@ -2862,6 +2862,40 @@ mod tests {
     }
 
     #[test]
+    fn test_page_down_uses_configured_height_when_borderless_popup_suppressed() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.overlay.selected = Some(5);
+        handler.overlay.scroll_offset = 0;
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(1, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::PageDown, &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert!(handler.visible);
+        assert_eq!(handler.overlay.selected, Some(15));
+        assert_eq!(handler.overlay.scroll_offset, 6);
+    }
+
+    #[test]
+    fn test_end_uses_configured_height_when_bordered_popup_suppressed() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.theme = PopupTheme {
+            borders: true,
+            ..PopupTheme::default()
+        };
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(3, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::End, &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert!(handler.visible);
+        assert_eq!(handler.overlay.selected, Some(49));
+        assert_eq!(handler.overlay.scroll_offset, 40);
+    }
+
+    #[test]
     fn test_page_up_when_visible_retreats_selection() {
         let mut handler = make_visible_handler(numbered_suggestions(50));
         handler.overlay.selected = Some(15);
@@ -2912,6 +2946,28 @@ mod tests {
         let result = handler.process_key(&KeyEvent::PageDown, &parser, &mut buf);
 
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_split_page_up_sequence_is_buffered_until_visible_popup_can_intercept() {
+        let mut key_parser = crate::input::KeyParser::new();
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.overlay.selected = Some(15);
+        handler.overlay.scroll_offset = 6;
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let first_keys = key_parser.parse(b"\x1B[5");
+        assert!(first_keys.is_empty());
+        assert!(handler.visible);
+
+        let second_keys = key_parser.parse(b"~");
+        assert_eq!(second_keys, vec![KeyEvent::PageUp]);
+        let result = handler.process_key(&second_keys[0], &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert!(handler.visible);
+        assert_eq!(handler.overlay.selected, Some(5));
     }
 
     #[test]
@@ -3003,6 +3059,50 @@ mod tests {
         assert!(end_handler.visible);
         assert_eq!(end_handler.overlay.selected, Some(49));
         assert_eq!(end_handler.overlay.scroll_offset, 40);
+    }
+
+    #[test]
+    fn test_visible_home_variants_jump_to_zero() {
+        for key in [
+            KeyEvent::Home,
+            KeyEvent::HomeCsiTilde,
+            KeyEvent::HomeCsi7Tilde,
+            KeyEvent::HomeSs3,
+        ] {
+            let mut handler = make_visible_handler(numbered_suggestions(50));
+            handler.overlay.selected = Some(20);
+            handler.overlay.scroll_offset = 11;
+            let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+            let mut buf = Vec::new();
+
+            let result = handler.process_key(&key, &parser, &mut buf);
+
+            assert!(result.is_empty(), "{key:?} should be intercepted");
+            assert!(handler.visible, "{key:?} should not dismiss popup");
+            assert_eq!(handler.overlay.selected, Some(0), "{key:?}");
+            assert_eq!(handler.overlay.scroll_offset, 0, "{key:?}");
+        }
+    }
+
+    #[test]
+    fn test_visible_end_variants_jump_to_last() {
+        for key in [
+            KeyEvent::End,
+            KeyEvent::EndCsiTilde,
+            KeyEvent::EndCsi8Tilde,
+            KeyEvent::EndSs3,
+        ] {
+            let mut handler = make_visible_handler(numbered_suggestions(50));
+            let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+            let mut buf = Vec::new();
+
+            let result = handler.process_key(&key, &parser, &mut buf);
+
+            assert!(result.is_empty(), "{key:?} should be intercepted");
+            assert!(handler.visible, "{key:?} should not dismiss popup");
+            assert_eq!(handler.overlay.selected, Some(49), "{key:?}");
+            assert_eq!(handler.overlay.scroll_offset, 40, "{key:?}");
+        }
     }
 
     #[test]

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -634,12 +634,15 @@ impl InputHandler {
                 self.render(parser, stdout);
                 return Vec::new();
             }
-            KeyEvent::Home | KeyEvent::HomeCsiTilde | KeyEvent::HomeSs3 => {
+            KeyEvent::Home
+            | KeyEvent::HomeCsiTilde
+            | KeyEvent::HomeCsi7Tilde
+            | KeyEvent::HomeSs3 => {
                 self.overlay.move_home(self.suggestions.len());
                 self.render(parser, stdout);
                 return Vec::new();
             }
-            KeyEvent::End | KeyEvent::EndCsiTilde | KeyEvent::EndSs3 => {
+            KeyEvent::End | KeyEvent::EndCsiTilde | KeyEvent::EndCsi8Tilde | KeyEvent::EndSs3 => {
                 self.overlay.move_end(self.suggestions.len(), visible_rows);
                 self.render(parser, stdout);
                 return Vec::new();
@@ -2109,9 +2112,11 @@ pub fn key_to_bytes(key: &KeyEvent) -> Vec<u8> {
         KeyEvent::PageDown => vec![0x1B, b'[', b'6', b'~'],
         KeyEvent::Home => vec![0x1B, b'[', b'H'],
         KeyEvent::HomeCsiTilde => vec![0x1B, b'[', b'1', b'~'],
+        KeyEvent::HomeCsi7Tilde => vec![0x1B, b'[', b'7', b'~'],
         KeyEvent::HomeSs3 => vec![0x1B, b'O', b'H'],
         KeyEvent::End => vec![0x1B, b'[', b'F'],
         KeyEvent::EndCsiTilde => vec![0x1B, b'[', b'4', b'~'],
+        KeyEvent::EndCsi8Tilde => vec![0x1B, b'[', b'8', b'~'],
         KeyEvent::EndSs3 => vec![0x1B, b'O', b'F'],
         KeyEvent::CtrlSpace => vec![0x00],
         KeyEvent::CtrlSlash => vec![0x1F],
@@ -2188,6 +2193,7 @@ mod tests {
     fn test_key_to_bytes_home_round_trip() {
         assert_eq!(key_to_bytes(&KeyEvent::Home), b"\x1B[H");
         assert_eq!(key_to_bytes(&KeyEvent::HomeCsiTilde), b"\x1B[1~");
+        assert_eq!(key_to_bytes(&KeyEvent::HomeCsi7Tilde), b"\x1B[7~");
         assert_eq!(key_to_bytes(&KeyEvent::HomeSs3), b"\x1BOH");
     }
 
@@ -2195,6 +2201,7 @@ mod tests {
     fn test_key_to_bytes_end_round_trip() {
         assert_eq!(key_to_bytes(&KeyEvent::End), b"\x1B[F");
         assert_eq!(key_to_bytes(&KeyEvent::EndCsiTilde), b"\x1B[4~");
+        assert_eq!(key_to_bytes(&KeyEvent::EndCsi8Tilde), b"\x1B[8~");
         assert_eq!(key_to_bytes(&KeyEvent::EndSs3), b"\x1BOF");
     }
 
@@ -2223,9 +2230,11 @@ mod tests {
             KeyEvent::PageDown,
             KeyEvent::Home,
             KeyEvent::HomeCsiTilde,
+            KeyEvent::HomeCsi7Tilde,
             KeyEvent::HomeSs3,
             KeyEvent::End,
             KeyEvent::EndCsiTilde,
+            KeyEvent::EndCsi8Tilde,
             KeyEvent::EndSs3,
             KeyEvent::CtrlSpace,
             KeyEvent::CtrlSlash,
@@ -2801,6 +2810,58 @@ mod tests {
     }
 
     #[test]
+    fn test_page_up_uses_effective_popup_height_on_short_terminal() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.overlay.selected = Some(8);
+        handler.overlay.scroll_offset = 6;
+        handler.last_layout = Some(PopupLayout {
+            start_row: 1,
+            start_col: 0,
+            width: 20,
+            height: 3,
+            scroll_deficit: 0,
+        });
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(4, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::PageUp, &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert_eq!(handler.overlay.selected, Some(5));
+        assert_eq!(handler.overlay.scroll_offset, 5);
+        let selected = handler.overlay.selected.unwrap();
+        assert!(handler.overlay.scroll_offset <= selected);
+        assert!(selected < handler.overlay.scroll_offset + 3);
+    }
+
+    #[test]
+    fn test_end_uses_effective_popup_height_with_bordered_short_terminal() {
+        let mut handler = make_visible_handler(numbered_suggestions(50));
+        handler.theme = PopupTheme {
+            borders: true,
+            ..PopupTheme::default()
+        };
+        handler.last_layout = Some(PopupLayout {
+            start_row: 1,
+            start_col: 0,
+            width: 20,
+            height: 5,
+            scroll_deficit: 0,
+        });
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(6, 80)));
+        let mut buf = Vec::new();
+
+        let result = handler.process_key(&KeyEvent::End, &parser, &mut buf);
+
+        assert!(result.is_empty());
+        assert_eq!(handler.overlay.selected, Some(49));
+        assert_eq!(handler.overlay.scroll_offset, 47);
+        let selected = handler.overlay.selected.unwrap();
+        assert!(handler.overlay.scroll_offset <= selected);
+        assert!(selected < handler.overlay.scroll_offset + 3);
+    }
+
+    #[test]
     fn test_page_up_when_visible_retreats_selection() {
         let mut handler = make_visible_handler(numbered_suggestions(50));
         handler.overlay.selected = Some(15);
@@ -2899,7 +2960,14 @@ mod tests {
 
     #[test]
     fn test_hidden_home_end_alternate_encodings_forward_verbatim() {
-        for raw in [b"\x1B[1~".as_slice(), b"\x1B[4~", b"\x1BOH", b"\x1BOF"] {
+        for raw in [
+            b"\x1B[1~".as_slice(),
+            b"\x1B[4~",
+            b"\x1B[7~",
+            b"\x1B[8~",
+            b"\x1BOH",
+            b"\x1BOF",
+        ] {
             let events = crate::input::parse_keys(raw);
             assert_eq!(events.len(), 1, "expected one parsed event for {raw:?}");
 
@@ -2914,15 +2982,41 @@ mod tests {
     }
 
     #[test]
+    fn test_visible_home_end_csi_7_8_tilde_navigate() {
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+
+        let mut home_handler = make_visible_handler(numbered_suggestions(50));
+        home_handler.overlay.selected = Some(20);
+        home_handler.overlay.scroll_offset = 11;
+        let home_result = home_handler.process_key(&KeyEvent::HomeCsi7Tilde, &parser, &mut buf);
+
+        assert!(home_result.is_empty());
+        assert!(home_handler.visible);
+        assert_eq!(home_handler.overlay.selected, Some(0));
+        assert_eq!(home_handler.overlay.scroll_offset, 0);
+
+        let mut end_handler = make_visible_handler(numbered_suggestions(50));
+        let end_result = end_handler.process_key(&KeyEvent::EndCsi8Tilde, &parser, &mut buf);
+
+        assert!(end_result.is_empty());
+        assert!(end_handler.visible);
+        assert_eq!(end_handler.overlay.selected, Some(49));
+        assert_eq!(end_handler.overlay.scroll_offset, 40);
+    }
+
+    #[test]
     fn test_page_navigation_does_not_dismiss_popup() {
         for key in [
             KeyEvent::PageUp,
             KeyEvent::PageDown,
             KeyEvent::Home,
             KeyEvent::HomeCsiTilde,
+            KeyEvent::HomeCsi7Tilde,
             KeyEvent::HomeSs3,
             KeyEvent::End,
             KeyEvent::EndCsiTilde,
+            KeyEvent::EndCsi8Tilde,
             KeyEvent::EndSs3,
         ] {
             let mut handler = make_visible_handler(numbered_suggestions(50));

--- a/crates/gc-pty/src/input.rs
+++ b/crates/gc-pty/src/input.rs
@@ -207,6 +207,48 @@ pub fn parse_keys(buf: &[u8]) -> Vec<KeyEvent> {
     events
 }
 
+#[derive(Debug, Default)]
+pub struct KeyParser {
+    pending: Vec<u8>,
+}
+
+impl KeyParser {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn parse(&mut self, buf: &[u8]) -> Vec<KeyEvent> {
+        let mut combined = Vec::with_capacity(self.pending.len() + buf.len());
+        combined.extend_from_slice(&self.pending);
+        combined.extend_from_slice(buf);
+        self.pending.clear();
+
+        if let Some(start) = incomplete_escape_suffix_start(&combined) {
+            self.pending.extend_from_slice(&combined[start..]);
+            parse_keys(&combined[..start])
+        } else {
+            parse_keys(&combined)
+        }
+    }
+}
+
+fn incomplete_escape_suffix_start(buf: &[u8]) -> Option<usize> {
+    let esc = buf.iter().rposition(|&b| b == 0x1B)?;
+    let suffix = &buf[esc..];
+
+    match suffix {
+        [0x1B, b'['] | [0x1B, b'O'] => Some(esc),
+        [0x1B, b'[', rest @ ..] => {
+            if rest.iter().all(|b| *b < 0x40) {
+                Some(esc)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
 /// Parse a CPR parameter slice like b"15;1" into (row, col).
 /// Returns None if the format doesn't match.
 fn parse_cpr(params: &[u8]) -> Option<(u16, u16)> {
@@ -337,6 +379,33 @@ mod tests {
         assert_eq!(
             parse_keys(b"\x1B[5~a"),
             vec![KeyEvent::PageUp, KeyEvent::Printable('a')]
+        );
+    }
+
+    #[test]
+    fn test_stateful_parser_buffers_split_page_up() {
+        let mut parser = KeyParser::new();
+
+        assert!(parser.parse(b"\x1B[5").is_empty());
+        assert_eq!(parser.parse(b"~"), vec![KeyEvent::PageUp]);
+    }
+
+    #[test]
+    fn test_stateful_parser_buffers_split_ss3_home() {
+        let mut parser = KeyParser::new();
+
+        assert!(parser.parse(b"\x1BO").is_empty());
+        assert_eq!(parser.parse(b"H"), vec![KeyEvent::HomeSs3]);
+    }
+
+    #[test]
+    fn test_stateful_parser_keeps_complete_prefix_before_split_sequence() {
+        let mut parser = KeyParser::new();
+
+        assert_eq!(parser.parse(b"a\x1B[6"), vec![KeyEvent::Printable('a')]);
+        assert_eq!(
+            parser.parse(b"~b"),
+            vec![KeyEvent::PageDown, KeyEvent::Printable('b')]
         );
     }
 

--- a/crates/gc-pty/src/input.rs
+++ b/crates/gc-pty/src/input.rs
@@ -1,7 +1,8 @@
 /// Minimal key event parser for raw terminal stdin bytes.
 ///
-/// Parses known sequences (arrows, Tab, Enter, Escape, Ctrl+Space, Ctrl+/,
-/// Ctrl+A through Ctrl+Z) and passes through everything else as Raw bytes.
+/// Parses known sequences (arrows, PageUp/PageDown, Home/End, Tab, Enter, Escape,
+/// Ctrl+Space, Ctrl+/, Ctrl+A through Ctrl+Z) and passes through everything else
+/// as Raw bytes.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyEvent {
@@ -15,7 +16,11 @@ pub enum KeyEvent {
     PageUp,
     PageDown,
     Home,
+    HomeCsiTilde,
+    HomeSs3,
     End,
+    EndCsiTilde,
+    EndSs3,
     CtrlSpace,
     CtrlSlash,
     Ctrl(char),
@@ -86,11 +91,11 @@ pub fn parse_keys(buf: &[u8]) -> Vec<KeyEvent> {
                             i += 3;
                         }
                         b'1' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
-                            events.push(KeyEvent::Home);
+                            events.push(KeyEvent::HomeCsiTilde);
                             i += 4;
                         }
                         b'4' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
-                            events.push(KeyEvent::End);
+                            events.push(KeyEvent::EndCsiTilde);
                             i += 4;
                         }
                         b'5' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
@@ -144,11 +149,11 @@ pub fn parse_keys(buf: &[u8]) -> Vec<KeyEvent> {
                             i += 3;
                         }
                         b'H' => {
-                            events.push(KeyEvent::Home);
+                            events.push(KeyEvent::HomeSs3);
                             i += 3;
                         }
                         b'F' => {
-                            events.push(KeyEvent::End);
+                            events.push(KeyEvent::EndSs3);
                             i += 3;
                         }
                         _ => {
@@ -273,12 +278,12 @@ mod tests {
 
     #[test]
     fn test_home_csi_tilde_synonym() {
-        assert_eq!(parse_keys(b"\x1B[1~"), vec![KeyEvent::Home]);
+        assert_eq!(parse_keys(b"\x1B[1~"), vec![KeyEvent::HomeCsiTilde]);
     }
 
     #[test]
     fn test_end_csi_tilde_synonym() {
-        assert_eq!(parse_keys(b"\x1B[4~"), vec![KeyEvent::End]);
+        assert_eq!(parse_keys(b"\x1B[4~"), vec![KeyEvent::EndCsiTilde]);
     }
 
     #[test]
@@ -289,12 +294,12 @@ mod tests {
 
     #[test]
     fn test_home_ss3() {
-        assert_eq!(parse_keys(b"\x1BOH"), vec![KeyEvent::Home]);
+        assert_eq!(parse_keys(b"\x1BOH"), vec![KeyEvent::HomeSs3]);
     }
 
     #[test]
     fn test_end_ss3() {
-        assert_eq!(parse_keys(b"\x1BOF"), vec![KeyEvent::End]);
+        assert_eq!(parse_keys(b"\x1BOF"), vec![KeyEvent::EndSs3]);
     }
 
     #[test]

--- a/crates/gc-pty/src/input.rs
+++ b/crates/gc-pty/src/input.rs
@@ -17,9 +17,11 @@ pub enum KeyEvent {
     PageDown,
     Home,
     HomeCsiTilde,
+    HomeCsi7Tilde,
     HomeSs3,
     End,
     EndCsiTilde,
+    EndCsi8Tilde,
     EndSs3,
     CtrlSpace,
     CtrlSlash,
@@ -104,6 +106,14 @@ pub fn parse_keys(buf: &[u8]) -> Vec<KeyEvent> {
                         }
                         b'6' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
                             events.push(KeyEvent::PageDown);
+                            i += 4;
+                        }
+                        b'7' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
+                            events.push(KeyEvent::HomeCsi7Tilde);
+                            i += 4;
+                        }
+                        b'8' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
+                            events.push(KeyEvent::EndCsi8Tilde);
                             i += 4;
                         }
                         _ => {
@@ -279,11 +289,13 @@ mod tests {
     #[test]
     fn test_home_csi_tilde_synonym() {
         assert_eq!(parse_keys(b"\x1B[1~"), vec![KeyEvent::HomeCsiTilde]);
+        assert_eq!(parse_keys(b"\x1B[7~"), vec![KeyEvent::HomeCsi7Tilde]);
     }
 
     #[test]
     fn test_end_csi_tilde_synonym() {
         assert_eq!(parse_keys(b"\x1B[4~"), vec![KeyEvent::EndCsiTilde]);
+        assert_eq!(parse_keys(b"\x1B[8~"), vec![KeyEvent::EndCsi8Tilde]);
     }
 
     #[test]

--- a/crates/gc-pty/src/input.rs
+++ b/crates/gc-pty/src/input.rs
@@ -12,6 +12,10 @@ pub enum KeyEvent {
     ArrowDown,
     ArrowLeft,
     ArrowRight,
+    PageUp,
+    PageDown,
+    Home,
+    End,
     CtrlSpace,
     CtrlSlash,
     Ctrl(char),
@@ -73,6 +77,30 @@ pub fn parse_keys(buf: &[u8]) -> Vec<KeyEvent> {
                             events.push(KeyEvent::ArrowLeft);
                             i += 3;
                         }
+                        b'H' => {
+                            events.push(KeyEvent::Home);
+                            i += 3;
+                        }
+                        b'F' => {
+                            events.push(KeyEvent::End);
+                            i += 3;
+                        }
+                        b'1' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
+                            events.push(KeyEvent::Home);
+                            i += 4;
+                        }
+                        b'4' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
+                            events.push(KeyEvent::End);
+                            i += 4;
+                        }
+                        b'5' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
+                            events.push(KeyEvent::PageUp);
+                            i += 4;
+                        }
+                        b'6' if i + 3 < buf.len() && buf[i + 3] == b'~' => {
+                            events.push(KeyEvent::PageDown);
+                            i += 4;
+                        }
                         _ => {
                             // Unknown CSI — find end and pass through as Raw
                             let start = i;
@@ -113,6 +141,14 @@ pub fn parse_keys(buf: &[u8]) -> Vec<KeyEvent> {
                         }
                         b'D' => {
                             events.push(KeyEvent::ArrowLeft);
+                            i += 3;
+                        }
+                        b'H' => {
+                            events.push(KeyEvent::Home);
+                            i += 3;
+                        }
+                        b'F' => {
+                            events.push(KeyEvent::End);
                             i += 3;
                         }
                         _ => {
@@ -216,9 +252,49 @@ mod tests {
     }
 
     #[test]
+    fn test_page_up_csi_tilde() {
+        assert_eq!(parse_keys(b"\x1B[5~"), vec![KeyEvent::PageUp]);
+    }
+
+    #[test]
+    fn test_page_down_csi_tilde() {
+        assert_eq!(parse_keys(b"\x1B[6~"), vec![KeyEvent::PageDown]);
+    }
+
+    #[test]
+    fn test_home_csi_letter() {
+        assert_eq!(parse_keys(b"\x1B[H"), vec![KeyEvent::Home]);
+    }
+
+    #[test]
+    fn test_end_csi_letter() {
+        assert_eq!(parse_keys(b"\x1B[F"), vec![KeyEvent::End]);
+    }
+
+    #[test]
+    fn test_home_csi_tilde_synonym() {
+        assert_eq!(parse_keys(b"\x1B[1~"), vec![KeyEvent::Home]);
+    }
+
+    #[test]
+    fn test_end_csi_tilde_synonym() {
+        assert_eq!(parse_keys(b"\x1B[4~"), vec![KeyEvent::End]);
+    }
+
+    #[test]
     fn test_arrow_keys_ss3() {
         assert_eq!(parse_keys(b"\x1BOA"), vec![KeyEvent::ArrowUp]);
         assert_eq!(parse_keys(b"\x1BOB"), vec![KeyEvent::ArrowDown]);
+    }
+
+    #[test]
+    fn test_home_ss3() {
+        assert_eq!(parse_keys(b"\x1BOH"), vec![KeyEvent::Home]);
+    }
+
+    #[test]
+    fn test_end_ss3() {
+        assert_eq!(parse_keys(b"\x1BOF"), vec![KeyEvent::End]);
     }
 
     #[test]
@@ -237,6 +313,14 @@ mod tests {
             KeyEvent::Raw(bytes) => assert_eq!(bytes, raw),
             other => panic!("expected Raw, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_paged_then_typed() {
+        assert_eq!(
+            parse_keys(b"\x1B[5~a"),
+            vec![KeyEvent::PageUp, KeyEvent::Printable('a')]
+        );
     }
 
     #[test]

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -14,7 +14,7 @@ use gc_suggest::spec_dirs::resolve_spec_dirs;
 
 use crate::config_watch::spawn_config_watcher;
 use crate::handler::{InputHandler, Keybindings, TriggerPrepared};
-use crate::input::parse_keys;
+use crate::input::KeyParser;
 use crate::resize::{get_terminal_size, resize_pty};
 use crate::spawn::{spawn_shell, SpawnedShell};
 
@@ -278,6 +278,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let stdin_handle = tokio::task::spawn_blocking(move || {
         let mut stdin = std::io::stdin().lock();
         let mut buf = [0u8; 4096];
+        let mut key_parser = KeyParser::new();
         'stdin: loop {
             let n = match stdin.read(&mut buf) {
                 Ok(0) => break, // EOF
@@ -286,7 +287,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 Err(_) => break,
             };
 
-            let keys = parse_keys(&buf[..n]);
+            let keys = key_parser.parse(&buf[..n]);
             for key in &keys {
                 // CPR (Cursor Position Report) responses arrive here
                 // from the real terminal. If we sent the request, consume

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -321,6 +321,7 @@ match_highlight = "underline"
 - **Config hot-reload:** Some fields are applied live without restarting your shell. Others require a shell restart. See the table below.
 - **Nerd Font icons:** The popup gutter uses Nerd Font icons. If your terminal font doesn't include Nerd Font patches, you'll see placeholder characters. Use a [Nerd Font](https://www.nerdfonts.com/) for the best experience.
 - **History control:** Use `max_history_results` (not `providers.history`) to control history. Set to `0` to disable history entirely.
+- **Popup navigation:** PageUp, PageDown, Home, and End navigate the popup when it is visible and are forwarded to the shell when it is hidden. These structural keys are not user-configurable.
 
 ### Hot-Reload Behavior
 


### PR DESCRIPTION
## Summary
- Decode PageUp, PageDown, Home, and End terminal sequences into structural key events while preserving canonical byte forwarding when hidden.
- Add popup page/home/end movement methods that keep selection and scroll offset in sync.
- Intercept those keys while the popup is visible, with tests for visible navigation, hidden forwarding, and accept-after-page navigation.

## Test Plan
- [x] cargo fmt --check
- [x] cargo test -p gc-overlay
- [x] cargo test -p gc-pty
- [x] cargo test
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo build --release
- [ ] cargo run -- validate-specs (blocked by existing invalid specs: default user specs reported 1412/1418 valid; repo specs reported 706/709 valid with failures including index.json, next.json, pnpx.json)
- [ ] Manual terminal smoke in Ghostty/iTerm2/Alacritty not run in this environment
