### PR TITLE
[codex] fix automatic popup triggering

### DIFF
--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -630,16 +630,22 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                             break;
                         }
                     };
-                    if h.has_pending_trigger() {
+                    let had_pending_trigger = h.has_pending_trigger();
+                    let action = buffer_dirty_action(
+                        had_pending_trigger,
+                        delay_ms,
+                        h.auto_trigger_enabled(),
+                        h.is_debounce_suppressed(),
+                    );
+                    if had_pending_trigger {
                         h.clear_trigger_request();
-                        if h.auto_trigger_enabled() {
-                            h.trigger(&parser_for_stdout, &mut render_buf);
+                    }
+                    match action {
+                        BufferDirtyAction::Trigger => {
+                            h.trigger(&parser_for_stdout, &mut render_buf)
                         }
-                    } else if delay_ms > 0
-                        && h.auto_trigger_enabled()
-                        && !h.is_debounce_suppressed()
-                    {
-                        debounce_notify_b.notify_one();
+                        BufferDirtyAction::Debounce => debounce_notify_b.notify_one(),
+                        BufferDirtyAction::Ignore => {}
                     }
                     h.overlay_write_ticket()
                 };
@@ -904,6 +910,35 @@ fn poll_until(
                 return None;
             }
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BufferDirtyAction {
+    Trigger,
+    Debounce,
+    Ignore,
+}
+
+fn buffer_dirty_action(
+    has_pending_trigger: bool,
+    delay_ms: u64,
+    auto_trigger_enabled: bool,
+    debounce_suppressed: bool,
+) -> BufferDirtyAction {
+    if !auto_trigger_enabled {
+        return BufferDirtyAction::Ignore;
+    }
+    if has_pending_trigger {
+        return BufferDirtyAction::Trigger;
+    }
+    if debounce_suppressed {
+        return BufferDirtyAction::Ignore;
+    }
+    if delay_ms == 0 {
+        BufferDirtyAction::Trigger
+    } else {
+        BufferDirtyAction::Debounce
     }
 }
 
@@ -1262,6 +1297,30 @@ mod tests {
             &Terminal::Unknown("foot".into()),
             true
         ));
+    }
+
+    #[test]
+    fn buffer_dirty_action_triggers_immediately_when_delay_zero() {
+        assert_eq!(
+            buffer_dirty_action(false, 0, true, false),
+            BufferDirtyAction::Trigger
+        );
+    }
+
+    #[test]
+    fn buffer_dirty_action_debounces_when_delay_positive() {
+        assert_eq!(
+            buffer_dirty_action(false, 150, true, false),
+            BufferDirtyAction::Debounce
+        );
+    }
+
+    #[test]
+    fn buffer_dirty_action_prefers_pending_trigger() {
+        assert_eq!(
+            buffer_dirty_action(true, 150, true, true),
+            BufferDirtyAction::Trigger
+        );
     }
 
     use gc_parser::TerminalParser;

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -1308,6 +1308,22 @@ mod tests {
     }
 
     #[test]
+    fn buffer_dirty_action_ignores_when_auto_trigger_disabled() {
+        assert_eq!(
+            buffer_dirty_action(false, 0, false, false),
+            BufferDirtyAction::Ignore
+        );
+    }
+
+    #[test]
+    fn buffer_dirty_action_ignores_when_debounce_suppressed() {
+        assert_eq!(
+            buffer_dirty_action(false, 0, true, true),
+            BufferDirtyAction::Ignore
+        );
+    }
+
+    #[test]
     fn buffer_dirty_action_debounces_when_delay_positive() {
         assert_eq!(
             buffer_dirty_action(false, 150, true, false),

--- a/crates/gc-suggest/src/embedded.rs
+++ b/crates/gc-suggest/src/embedded.rs
@@ -45,12 +45,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 // `build.rs` for details.
 include!(concat!(env!("OUT_DIR"), "/embedded_specs.rs"));
 
-/// Path under the user's home where embedded specs are materialized when no
-/// other spec directory is available. Kept separate from the `~/.config`
-/// install location so a fresh `cargo install` user gets specs without
-/// `ghost-complete install`, while still letting an installed user's
-/// `~/.config/ghost-complete/specs` take precedence (auto-detection in
-/// `spec_dirs::resolve_spec_dirs` checks that path first).
+/// Path under the user's home where embedded specs are materialized for the
+/// auto-detected spec-dir path. Kept separate from the `~/.config` install
+/// location so a fresh `cargo install` user gets specs without
+/// `ghost-complete install`, while still letting discovered filesystem dirs
+/// such as `~/.config/ghost-complete/specs` take precedence because the
+/// resolver appends this path after them.
 pub fn embedded_cache_dir() -> Option<PathBuf> {
     dirs::home_dir().map(|h| {
         h.join(".cache")

--- a/crates/gc-suggest/src/embedded.rs
+++ b/crates/gc-suggest/src/embedded.rs
@@ -16,12 +16,12 @@
 //! specs and got no error — autocomplete silently degraded to filesystem +
 //! history + `$PATH` only.
 //!
-//! This module makes the embedded specs the **runtime fallback** for the
-//! spec loader. When the on-disk auto-detection chain in
-//! [`crate::spec_dirs::resolve_spec_dirs`] finds no usable directory, the
-//! embedded specs are materialized (lazily, once per binary version) into
-//! `~/.cache/ghost-complete/embedded-specs/` and that path is appended to
-//! the resolved list. From the spec loader's perspective it's just another
+//! This module makes the embedded specs the **runtime safety net** for the
+//! spec loader. In the auto-detected spec-dir path,
+//! [`crate::spec_dirs::resolve_spec_dirs`] materializes the embedded specs
+//! (lazily, once per binary version) into
+//! `~/.cache/ghost-complete/embedded-specs/` and appends that path at the
+//! lowest precedence. From the spec loader's perspective it's just another
 //! directory full of JSON; no special-cased "embedded mode" logic is needed
 //! downstream.
 //!

--- a/crates/gc-suggest/src/spec_dirs.rs
+++ b/crates/gc-suggest/src/spec_dirs.rs
@@ -48,11 +48,11 @@ pub fn partition_spec_dirs(configured: &[String]) -> SpecDirPartition {
 /// Resolve spec directories from config, with tilde expansion.
 ///
 /// If `configured` is non-empty, validate each entry and use the valid
-/// subset; emit a `tracing::warn!` for each invalid entry. If every
-/// configured entry is invalid, fall through to auto-detection.
+/// subset exactly; emit a `tracing::warn!` for each invalid entry. If
+/// every configured entry is invalid, fall through to auto-detection.
 ///
-/// Auto-detection chain (first hit that's an existing directory wins;
-/// accumulates into a list in this order):
+/// Auto-detection chain (accumulates existing filesystem directories in
+/// this order):
 ///   1. `~/.config/ghost-complete/specs` (installed by `ghost-complete install`)
 ///   2. `<current_exe_dir>/specs` (development / `cargo run`)
 ///   3. `./specs` (cwd, development)
@@ -60,11 +60,30 @@ pub fn partition_spec_dirs(configured: &[String]) -> SpecDirPartition {
 ///      `gc_suggest::embedded::EMBEDDED_SPECS` via
 ///      [`embedded::materialize_embedded_specs`])
 ///
-/// The embedded fallback is what closes the
-/// `cargo install ghost-complete && ghost-complete` (no `install` step) case
-/// — without it the proxy would start with zero specs and silently degrade
-/// autocomplete.
+/// In the auto-detected path, the embedded directory is appended as the
+/// lowest-precedence source, not only when every filesystem source is
+/// missing. This closes both the `cargo install ghost-complete &&
+/// ghost-complete` case and the Homebrew / installer-upgrade case where
+/// `~/.config/ghost-complete/specs` exists but is stale and lacks specs
+/// added by the newer binary. Explicit `paths.spec_dirs` remains an exact
+/// override.
 pub fn resolve_spec_dirs(configured: &[String]) -> Vec<PathBuf> {
+    resolve_spec_dirs_with_embedded(
+        configured,
+        auto_detect_spec_dirs,
+        embedded::materialize_embedded_specs,
+    )
+}
+
+fn resolve_spec_dirs_with_embedded<A, E>(
+    configured: &[String],
+    auto_detect: A,
+    materialize_embedded: E,
+) -> Vec<PathBuf>
+where
+    A: FnOnce() -> Vec<PathBuf>,
+    E: FnOnce() -> Option<PathBuf>,
+{
     if !configured.is_empty() {
         let partition = partition_spec_dirs(configured);
         for bad in &partition.invalid {
@@ -80,7 +99,24 @@ pub fn resolve_spec_dirs(configured: &[String]) -> Vec<PathBuf> {
         tracing::warn!("all configured spec_dirs are invalid — falling back to auto-detection");
     }
 
-    // Auto-detect: check config dir, next to binary, then cwd
+    let mut dirs = auto_detect();
+
+    if let Some(embedded_dir) = materialize_embedded() {
+        if !dirs.iter().any(|dir| dir == &embedded_dir) {
+            dirs.push(embedded_dir);
+        }
+    } else if dirs.is_empty() {
+        tracing::warn!(
+            "no spec directory available — autocomplete will fall back \
+             to filesystem/history/$PATH only. Run `ghost-complete \
+             install` to deploy the bundled completion specs."
+        );
+    }
+
+    dirs
+}
+
+fn auto_detect_spec_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
     // Config directory (installed by `ghost-complete install`)
@@ -104,23 +140,6 @@ pub fn resolve_spec_dirs(configured: &[String]) -> Vec<PathBuf> {
     let cwd_specs = PathBuf::from("specs");
     if cwd_specs.is_dir() {
         dirs.push(cwd_specs);
-    }
-
-    if dirs.is_empty() {
-        // Last-ditch: materialize the binary-embedded spec set into a cache
-        // dir and use that. This is what makes `cargo install
-        // ghost-complete` followed by `ghost-complete` (without the install
-        // subcommand) actually load the 700+ shipped specs instead of
-        // running with an empty `SpecStore`.
-        if let Some(embedded_dir) = embedded::materialize_embedded_specs() {
-            dirs.push(embedded_dir);
-        } else {
-            tracing::warn!(
-                "no spec directory available — autocomplete will fall back \
-                 to filesystem/history/$PATH only. Run `ghost-complete \
-                 install` to deploy the bundled completion specs."
-            );
-        }
     }
 
     dirs
@@ -221,6 +240,40 @@ mod tests {
             known.iter().any(|cmd| result.store.get(cmd).is_some()),
             "expected at least one of {known:?} to be loaded from the \
              embedded fallback; the fallback may be empty"
+        );
+    }
+
+    #[test]
+    fn embedded_fallback_supplements_stale_installed_specs() {
+        let installed = tempfile::TempDir::new().unwrap();
+        let embedded = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            installed.path().join("z.json"),
+            r#"{"name":"z","description":"stale installed copy"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            embedded.path().join("aws.json"),
+            r#"{"name":"aws","subcommands":[{"name":"sso"}]}"#,
+        )
+        .unwrap();
+
+        let dirs: Vec<String> = Vec::new();
+        let installed_path = installed.path().to_path_buf();
+        let embedded_path = embedded.path().to_path_buf();
+        let resolved =
+            resolve_spec_dirs_with_embedded(&dirs, || vec![installed_path], || Some(embedded_path));
+        let result = crate::specs::SpecStore::load_from_dirs(&resolved).unwrap();
+
+        assert!(
+            result.store.get("z").is_some(),
+            "installed specs should still be loaded"
+        );
+        assert!(
+            result.store.get("aws").is_some(),
+            "embedded specs must supplement stale installed specs so upgraded \
+             binaries expose newly shipped specs without requiring \
+             `ghost-complete install`"
         );
     }
 }

--- a/crates/gc-suggest/src/spec_dirs.rs
+++ b/crates/gc-suggest/src/spec_dirs.rs
@@ -105,12 +105,22 @@ where
         if !dirs.iter().any(|dir| dir == &embedded_dir) {
             dirs.push(embedded_dir);
         }
-    } else if dirs.is_empty() {
-        tracing::warn!(
-            "no spec directory available — autocomplete will fall back \
-             to filesystem/history/$PATH only. Run `ghost-complete \
-             install` to deploy the bundled completion specs."
-        );
+    } else {
+        match dirs.is_empty() {
+            true => {
+                tracing::warn!(
+                    "no spec directory available — autocomplete will fall back \
+                     to filesystem/history/$PATH only. Run `ghost-complete \
+                     install` to deploy the bundled completion specs."
+                );
+            }
+            false => {
+                tracing::warn!(
+                    "embedded completion specs unavailable; using only \
+                     auto-detected filesystem spec dirs"
+                );
+            }
+        }
     }
 
     dirs
@@ -157,6 +167,46 @@ fn expand_tilde(path: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn install_log_capture() -> (Arc<Mutex<Vec<u8>>>, tracing::subscriber::DefaultGuard) {
+        let captured = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let writer = CaptureWriter(Arc::clone(&captured));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer)
+            .with_max_level(tracing::Level::TRACE)
+            .with_ansi(false)
+            .finish();
+        let guard = tracing::subscriber::set_default(subscriber);
+        (captured, guard)
+    }
 
     #[test]
     fn partition_spec_dirs_separates_valid_and_invalid() {
@@ -248,32 +298,59 @@ mod tests {
         let installed = tempfile::TempDir::new().unwrap();
         let embedded = tempfile::TempDir::new().unwrap();
         std::fs::write(
-            installed.path().join("z.json"),
-            r#"{"name":"z","description":"stale installed copy"}"#,
+            installed.path().join("git.json"),
+            r#"{"name":"git","subcommands":[{"name":"installed-copy"}]}"#,
         )
         .unwrap();
         std::fs::write(
-            embedded.path().join("aws.json"),
-            r#"{"name":"aws","subcommands":[{"name":"sso"}]}"#,
+            embedded.path().join("git.json"),
+            r#"{"name":"git","subcommands":[{"name":"embedded-copy"}]}"#,
         )
         .unwrap();
 
         let dirs: Vec<String> = Vec::new();
         let installed_path = installed.path().to_path_buf();
         let embedded_path = embedded.path().to_path_buf();
-        let resolved =
-            resolve_spec_dirs_with_embedded(&dirs, || vec![installed_path], || Some(embedded_path));
-        let result = crate::specs::SpecStore::load_from_dirs(&resolved).unwrap();
-
-        assert!(
-            result.store.get("z").is_some(),
-            "installed specs should still be loaded"
+        let resolved = resolve_spec_dirs_with_embedded(
+            &dirs,
+            || vec![installed_path.clone()],
+            || Some(embedded_path.clone()),
         );
+        assert_eq!(
+            resolved,
+            vec![installed_path.clone(), embedded_path.clone()],
+            "embedded specs must be appended after installed specs as the \
+             lowest-precedence source"
+        );
+
+        let result = crate::specs::SpecStore::load_from_dirs(&resolved).unwrap();
+        let git = result.store.get("git").expect("git spec must load");
+
+        assert_eq!(
+            git.subcommands[0].name, "installed-copy",
+            "installed specs must keep precedence when embedded ships the \
+             same filename"
+        );
+    }
+
+    #[test]
+    fn embedded_materialization_failure_warns_even_with_auto_detected_dirs() {
+        let (captured, _guard) = install_log_capture();
+        let installed = tempfile::TempDir::new().unwrap();
+        let installed_path = installed.path().to_path_buf();
+
+        let dirs: Vec<String> = Vec::new();
+        let resolved =
+            resolve_spec_dirs_with_embedded(&dirs, || vec![installed_path.clone()], || None);
+
+        assert_eq!(resolved, vec![installed_path]);
+        let logs = String::from_utf8_lossy(&captured.lock().expect("capture buffer poisoned"))
+            .into_owned();
         assert!(
-            result.store.get("aws").is_some(),
-            "embedded specs must supplement stale installed specs so upgraded \
-             binaries expose newly shipped specs without requiring \
-             `ghost-complete install`"
+            logs.contains(
+                "embedded completion specs unavailable; using only auto-detected filesystem spec dirs"
+            ),
+            "expected supplemental embedded fallback failure to be logged, got:\n{logs}"
         );
     }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,7 +92,7 @@ Override default file paths.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `spec_dirs` | string[] | `[]` | Directories to load completion specs from. Supports `~` expansion. When empty, the loader auto-detects in this order: `~/.config/ghost-complete/specs/`, then `<exe-dir>/specs`, then `./specs`, with the binary's embedded specs appended as a lowest-precedence safety net. When set, the configured directories are used instead — but if all of them are missing or unreadable, the loader falls back to the same auto-detection chain. |
+| `spec_dirs` | string[] | `[]` | Directories to load completion specs from. Supports `~` expansion. When empty, the loader auto-detects in this order: `~/.config/ghost-complete/specs/`, then `<exe-dir>/specs`, then `./specs`, with the binary's embedded specs appended as a lowest-precedence safety net. When set, the configured directories are used instead — but if all of them are missing or not directories, the loader falls back to the same auto-detection chain. Read errors from existing configured directories are reported by the spec loader and do not trigger auto-detection fallback. |
 
 ```toml
 [paths]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,7 +92,7 @@ Override default file paths.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `spec_dirs` | string[] | `[]` | Directories to load completion specs from. Supports `~` expansion. When empty, the loader auto-detects in this order: `~/.config/ghost-complete/specs/`, then `<exe-dir>/specs`, then `./specs`, then the embedded specs in the binary. When set, the configured directories are used instead — but if all of them are missing or unreadable, the loader falls back to the same auto-detection chain. |
+| `spec_dirs` | string[] | `[]` | Directories to load completion specs from. Supports `~` expansion. When empty, the loader auto-detects in this order: `~/.config/ghost-complete/specs/`, then `<exe-dir>/specs`, then `./specs`, with the binary's embedded specs appended as a lowest-precedence safety net. When set, the configured directories are used instead — but if all of them are missing or unreadable, the loader falls back to the same auto-detection chain. |
 
 ```toml
 [paths]


### PR DESCRIPTION
## Summary

Fixes #104 by addressing two paths that could make automatic popup rendering unreliable:

- `delay_ms = 0` now triggers immediately on normal buffer updates instead of only reacting when a pending auto-character trigger exists.
- Auto-detected installed spec directories are supplemented by the binary's embedded specs as a lowest-precedence fallback, so stale installed/Homebrew specs cannot hide newer bundled specs like `aws`.
- Documentation now reflects the embedded fallback behavior for the default `paths.spec_dirs = []` setup.

## Root Cause

The passive typing path had a gap when debounce was disabled: buffer updates with no pending trigger did not schedule or fire suggestions. Separately, the runtime only materialized embedded specs when no spec directory existed, so an older `~/.config/ghost-complete/specs` directory could continue masking specs added by a newer binary.

## Validation

- `cargo test`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
