### PR TITLE
Fix terminal overlap by deferring popup trigger until redraw

### DIFF
--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -543,13 +543,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             };
 
             // Feed bytes through the VT parser to track terminal state
-            let (
-                needs_cpr,
-                display_dirty,
-                viewport_scrolls,
-                latest_buffer_epoch,
-                latest_buffer_generation,
-            ) = {
+            let (needs_cpr, display_dirty, viewport_scrolls, latest_buffer_report) = {
                 let _snapshot_guard = match trigger_snapshot_gate_b.lock() {
                     Ok(guard) => guard,
                     Err(e) => {
@@ -578,8 +572,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     events.needs_cpr,
                     events.display_dirty,
                     events.viewport_scrolls,
-                    events.latest_buffer_epoch,
-                    events.latest_buffer_generation,
+                    events.latest_buffer_report,
                 )
             };
 
@@ -681,14 +674,8 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            // Handle shell buffer updates in Task B instead of Task A so trigger/debounce
-            // decisions see the parser's updated buffer. OSC-only reports may be deferred
-            // until a later display epoch to avoid rendering before the terminal redraws.
-            if let Some(latest_buffer_epoch) = latest_buffer_epoch {
-                let Some(buffer_generation) = latest_buffer_generation else {
-                    tracing::warn!("buffer report missing generation in stdout task");
-                    break;
-                };
+            // Run in Task B so we observe the parser's post-OSC buffer state.
+            if let Some((latest_buffer_epoch, buffer_generation)) = latest_buffer_report {
                 let display_after_latest_buffer = display_epoch > latest_buffer_epoch;
                 let action = {
                     let mut h = match handler_for_stdout.lock() {
@@ -755,7 +742,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         }
                     }
                     ResolvedBufferDirtyAction::NotifyDebounce => debounce_notify_b.notify_one(),
-                    ResolvedBufferDirtyAction::None => {}
+                    ResolvedBufferDirtyAction::NoOp => {}
                 }
             }
 
@@ -813,7 +800,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         }
                     }
                     ResolvedBufferDirtyAction::NotifyDebounce => debounce_notify_b.notify_one(),
-                    ResolvedBufferDirtyAction::None => {}
+                    ResolvedBufferDirtyAction::NoOp => {}
                 }
             }
 
@@ -850,8 +837,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     defer_cwd_trigger_until_buffer_display(
                         &mut deferred_buffer_dirty,
                         &mut state,
-                        latest_buffer_epoch,
-                        latest_buffer_generation,
+                        latest_buffer_report,
                         display_epoch,
                     )
                 } else {
@@ -1120,8 +1106,10 @@ struct PtyReadEvents {
     needs_cpr: bool,
     display_dirty: bool,
     viewport_scrolls: u16,
-    latest_buffer_epoch: Option<u64>,
-    latest_buffer_generation: Option<u64>,
+    /// (display_epoch, buffer_generation) of the latest buffer report seen in
+    /// this read. Tied as a pair so the type system rules out the impossible
+    /// "epoch without generation" state.
+    latest_buffer_report: Option<(u64, u64)>,
 }
 
 fn process_pty_read(
@@ -1131,6 +1119,12 @@ fn process_pty_read(
     mut next_buffer_generation: impl FnMut() -> u64,
 ) -> PtyReadEvents {
     let mut events = PtyReadEvents::default();
+    // Feed one byte at a time so each take_*_dirty flag is attributed to a
+    // distinct display_epoch. `parser.process_bytes(bytes)` would coalesce a
+    // mid-slice OSC 7770 buffer report with the display bytes that follow it
+    // into the same epoch, which re-introduces the OSC-only render race the
+    // defer-until-redraw logic exists to prevent. This deliberately defeats
+    // vte::Parser::advance's advance_ground fast path; do not "simplify" it.
     for byte in bytes {
         parser.process_bytes(std::slice::from_ref(byte));
         let state = parser.state_mut();
@@ -1146,8 +1140,7 @@ fn process_pty_read(
         }
 
         if state.take_buffer_dirty() {
-            events.latest_buffer_epoch = Some(*display_epoch);
-            events.latest_buffer_generation = Some(next_buffer_generation());
+            events.latest_buffer_report = Some((*display_epoch, next_buffer_generation()));
         }
     }
     events
@@ -1173,6 +1166,10 @@ impl DebounceState {
     }
 
     fn invalidate_for_forwarded_input(&mut self) {
+        // Skip the bump while a deferred report is pending —
+        // resolve_deferred_buffer_dirty requires current_generation ==
+        // pending.generation, and bumping here would silently drop the
+        // deferred trigger when display_epoch advances.
         if self.deferred_generation.is_some() {
             return;
         }
@@ -1200,8 +1197,12 @@ impl DebounceState {
         self.notified_generation
     }
 
-    fn can_fire_generation(&self, generation: u64) -> bool {
+    fn is_current_generation(&self, generation: u64) -> bool {
         self.current_generation == generation
+    }
+
+    fn can_fire_generation(&self, generation: u64) -> bool {
+        self.is_current_generation(generation)
             && self.notified_generation == Some(generation)
             && self.deferred_generation.is_none()
     }
@@ -1230,44 +1231,13 @@ enum BufferDirtyAction {
 enum ResolvedBufferDirtyAction {
     Trigger,
     NotifyDebounce,
-    None,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DebounceFireDecision {
-    Fire,
-    Skip,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DebounceContinuationDecision {
-    Apply,
-    Drop,
+    NoOp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AsyncOverlayGateDecision {
     Render,
     Blocked,
-}
-
-fn debounce_fire_decision(state: &DebounceState, generation: u64) -> DebounceFireDecision {
-    if state.can_fire_generation(generation) {
-        DebounceFireDecision::Fire
-    } else {
-        DebounceFireDecision::Skip
-    }
-}
-
-fn debounce_continuation_decision(
-    state: &DebounceState,
-    generation: u64,
-) -> DebounceContinuationDecision {
-    if state.can_fire_generation(generation) {
-        DebounceContinuationDecision::Apply
-    } else {
-        DebounceContinuationDecision::Drop
-    }
 }
 
 fn async_overlay_gate_decision(state: &DebounceState) -> AsyncOverlayGateDecision {
@@ -1348,11 +1318,11 @@ fn apply_buffer_dirty_action(
                 generation: buffer_generation,
             });
             debounce_state.defer_generation(buffer_generation);
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         }
         BufferDirtyAction::Ignore => {
             clear_deferred_buffer_dirty(deferred, debounce_state);
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         }
     }
 }
@@ -1369,8 +1339,7 @@ fn clear_deferred_buffer_dirty(
 fn defer_cwd_trigger_until_buffer_display(
     deferred: &mut Option<DeferredBufferDirty>,
     debounce_state: &mut DebounceState,
-    latest_buffer_epoch: Option<u64>,
-    latest_buffer_generation: Option<u64>,
+    latest_buffer_report: Option<(u64, u64)>,
     display_epoch: u64,
 ) -> bool {
     if let Some(pending) = deferred.as_mut() {
@@ -1378,9 +1347,7 @@ fn defer_cwd_trigger_until_buffer_display(
         return true;
     }
 
-    let (Some(buffer_epoch), Some(buffer_generation)) =
-        (latest_buffer_epoch, latest_buffer_generation)
-    else {
+    let Some((buffer_epoch, buffer_generation)) = latest_buffer_report else {
         return false;
     };
     if display_epoch > buffer_epoch {
@@ -1404,24 +1371,28 @@ fn resolve_deferred_buffer_dirty(
     debounce_suppressed: bool,
 ) -> ResolvedBufferDirtyAction {
     let Some(pending) = *deferred else {
-        return ResolvedBufferDirtyAction::None;
+        return ResolvedBufferDirtyAction::NoOp;
     };
     if display_epoch <= pending.display_epoch {
-        return ResolvedBufferDirtyAction::None;
+        return ResolvedBufferDirtyAction::NoOp;
     }
 
     *deferred = None;
-    let generation_is_current = debounce_state.current_generation == pending.generation;
+    let generation_is_current = debounce_state.is_current_generation(pending.generation);
     debounce_state.clear_deferred_generation(pending.generation);
     if !generation_is_current {
-        return ResolvedBufferDirtyAction::None;
+        return ResolvedBufferDirtyAction::NoOp;
     }
     match pending.action {
         DeferredBufferDirtyAction::TriggerNow => {
             if auto_trigger_enabled {
                 ResolvedBufferDirtyAction::Trigger
             } else {
-                ResolvedBufferDirtyAction::None
+                tracing::debug!(
+                    generation = pending.generation,
+                    "deferred trigger discarded after redraw: auto_trigger_enabled=false"
+                );
+                ResolvedBufferDirtyAction::NoOp
             }
         }
         DeferredBufferDirtyAction::NotifyDebounce => {
@@ -1429,7 +1400,13 @@ fn resolve_deferred_buffer_dirty(
                 debounce_state.notify_generation(pending.generation);
                 ResolvedBufferDirtyAction::NotifyDebounce
             } else {
-                ResolvedBufferDirtyAction::None
+                tracing::debug!(
+                    generation = pending.generation,
+                    auto_trigger_enabled,
+                    debounce_suppressed,
+                    "deferred debounce notify discarded after redraw"
+                );
+                ResolvedBufferDirtyAction::NoOp
             }
         }
     }
@@ -1563,7 +1540,7 @@ async fn debounce_loop(
                     continue;
                 }
             };
-            let fire_decision = {
+            let can_fire = {
                 let state = match debounce_state.lock() {
                     Ok(state) => state,
                     Err(e) => {
@@ -1571,9 +1548,9 @@ async fn debounce_loop(
                         continue;
                     }
                 };
-                debounce_fire_decision(&state, generation)
+                state.can_fire_generation(generation)
             };
-            if fire_decision == DebounceFireDecision::Skip {
+            if !can_fire {
                 continue;
             }
             let mut h = match handler.lock() {
@@ -1656,7 +1633,7 @@ async fn debounce_loop(
                         continue;
                     }
                 };
-                let continuation_decision = {
+                let can_continue = {
                     let state = match debounce_state.lock() {
                         Ok(state) => state,
                         Err(e) => {
@@ -1666,9 +1643,9 @@ async fn debounce_loop(
                             continue;
                         }
                     };
-                    debounce_continuation_decision(&state, generation)
+                    state.can_fire_generation(generation)
                 };
-                if continuation_decision == DebounceContinuationDecision::Drop {
+                if !can_continue {
                     match handler.lock() {
                         Ok(mut h) => h.abort_dynamic_task_and_clear_ctx(),
                         Err(e) => tracing::warn!(
@@ -1971,12 +1948,12 @@ mod tests {
         let action = buffer_dirty_action(false, 150, true, true, false);
         assert_eq!(
             apply_buffer_dirty_action(&mut deferred, &mut debounce_state, 3, 1, action),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
         assert_eq!(deferred, None);
         assert_eq!(
             resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 4, true, true),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
     }
 
@@ -1989,7 +1966,7 @@ mod tests {
 
         assert_eq!(
             apply_buffer_dirty_action(&mut deferred, &mut debounce_state, 8, generation, action),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
         assert_eq!(
             deferred,
@@ -2001,7 +1978,7 @@ mod tests {
         );
         assert_eq!(
             resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 8, true, false),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
         assert_eq!(
             resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 9, true, false),
@@ -2038,14 +2015,14 @@ mod tests {
                 second_generation,
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
             ),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
         assert!(!debounce_state.can_fire_generation(first_generation));
         assert!(!debounce_state.can_fire_generation(second_generation));
 
         assert_eq!(
             resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 4, true, false),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
         assert!(!debounce_state.can_fire_generation(first_generation));
 
@@ -2058,25 +2035,19 @@ mod tests {
     }
 
     #[test]
-    fn debounce_fire_decision_rejects_generation_invalidated_by_forwarded_input() {
+    fn can_fire_generation_rejects_generation_invalidated_by_forwarded_input() {
         let mut debounce_state = DebounceState::default();
         let generation = debounce_state.next_buffer_generation();
         debounce_state.notify_generation(generation);
-        assert_eq!(
-            debounce_fire_decision(&debounce_state, generation),
-            DebounceFireDecision::Fire
-        );
+        assert!(debounce_state.can_fire_generation(generation));
 
         debounce_state.invalidate_for_forwarded_input();
 
-        assert_eq!(
-            debounce_fire_decision(&debounce_state, generation),
-            DebounceFireDecision::Skip
-        );
+        assert!(!debounce_state.can_fire_generation(generation));
     }
 
     #[test]
-    fn debounce_fire_decision_rejects_prior_generation_when_newer_report_is_deferred() {
+    fn can_fire_generation_rejects_prior_generation_when_newer_report_is_deferred() {
         let mut deferred = None;
         let mut debounce_state = DebounceState::default();
         let first_generation = debounce_state.next_buffer_generation();
@@ -2091,17 +2062,10 @@ mod tests {
                 second_generation,
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
             ),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
 
-        assert_eq!(
-            debounce_fire_decision(&debounce_state, first_generation),
-            DebounceFireDecision::Skip
-        );
-        assert_eq!(
-            debounce_continuation_decision(&debounce_state, first_generation),
-            DebounceContinuationDecision::Drop
-        );
+        assert!(!debounce_state.can_fire_generation(first_generation));
     }
 
     #[test]
@@ -2136,7 +2100,7 @@ mod tests {
                 generation,
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow),
             ),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
 
         debounce_state.invalidate_for_forwarded_input();
@@ -2161,7 +2125,7 @@ mod tests {
                 generation,
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
             ),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
 
         debounce_state.invalidate_for_forwarded_input();
@@ -2172,6 +2136,74 @@ mod tests {
         );
         assert_eq!(deferred, None);
         assert!(debounce_state.can_fire_generation(generation));
+    }
+
+    #[test]
+    fn forwarded_input_invalidates_debounce_excludes_only_cpr() {
+        // CPR responses are emitted by the terminal in reply to our own
+        // queries — they must not bump current_generation, otherwise the
+        // matching deferred trigger would be silently dropped.
+        assert!(!forwarded_input_invalidates_debounce(
+            &KeyEvent::CursorPositionReport(1, 1)
+        ));
+        assert!(forwarded_input_invalidates_debounce(&KeyEvent::Printable(
+            'a'
+        )));
+        assert!(forwarded_input_invalidates_debounce(&KeyEvent::Tab));
+        assert!(forwarded_input_invalidates_debounce(&KeyEvent::Enter));
+        assert!(forwarded_input_invalidates_debounce(&KeyEvent::Backspace));
+        assert!(forwarded_input_invalidates_debounce(&KeyEvent::ArrowUp));
+        assert!(forwarded_input_invalidates_debounce(&KeyEvent::Raw(vec![
+            0x1b, b'A'
+        ])));
+    }
+
+    #[test]
+    fn apply_buffer_dirty_replaces_prior_deferred_with_newer_generation() {
+        // Two OSC 7770 reports arriving back-to-back without a redraw between
+        // them must not leak the older generation in deferred state. The
+        // newer entry wins, and resolving on a later display epoch must fire
+        // the newer action (NotifyDebounce here, not the older TriggerNow).
+        let mut deferred = None;
+        let mut debounce_state = DebounceState::default();
+
+        let first_generation = debounce_state.next_buffer_generation();
+        assert_eq!(
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                3,
+                first_generation,
+                BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow),
+            ),
+            ResolvedBufferDirtyAction::NoOp
+        );
+
+        let second_generation = debounce_state.next_buffer_generation();
+        assert_eq!(
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                3,
+                second_generation,
+                BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
+            ),
+            ResolvedBufferDirtyAction::NoOp
+        );
+        assert_eq!(
+            deferred,
+            Some(DeferredBufferDirty {
+                action: DeferredBufferDirtyAction::NotifyDebounce,
+                display_epoch: 3,
+                generation: second_generation,
+            })
+        );
+        assert_eq!(debounce_state.deferred_generation, Some(second_generation));
+
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 4, true, false),
+            ResolvedBufferDirtyAction::NotifyDebounce
+        );
     }
 
     #[test]
@@ -2189,8 +2221,10 @@ mod tests {
             },
         );
 
-        assert_eq!(events.latest_buffer_epoch, Some(display_epoch));
-        assert_eq!(events.latest_buffer_generation, Some(1));
+        assert_eq!(display_epoch, 0, "pure OSC must not advance display epoch");
+        assert_eq!(events.latest_buffer_report, Some((0, 1)));
+        assert!(!events.display_dirty);
+        assert_eq!(events.viewport_scrolls, 0);
         assert_eq!(next_generation, 1);
         assert!(!parser.state_mut().take_buffer_dirty());
     }
@@ -2212,15 +2246,14 @@ mod tests {
                 current_generation,
                 BufferDirtyAction::Ignore,
             ),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
         assert_eq!(deferred, None);
 
         assert!(defer_cwd_trigger_until_buffer_display(
             &mut deferred,
             &mut debounce_state,
-            Some(4),
-            Some(current_generation),
+            Some((4, current_generation)),
             4,
         ));
         assert_eq!(
@@ -2235,7 +2268,7 @@ mod tests {
 
         assert_eq!(
             resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 4, true, false),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
         assert_eq!(
             resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 5, true, false),
@@ -2260,7 +2293,6 @@ mod tests {
         assert!(defer_cwd_trigger_until_buffer_display(
             &mut deferred,
             &mut debounce_state,
-            None,
             None,
             4,
         ));
@@ -2292,7 +2324,7 @@ mod tests {
 
         assert_eq!(
             resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 5, true, true),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
         assert_eq!(deferred, None);
     }
@@ -2318,7 +2350,7 @@ mod tests {
         assert_eq!(deferred, None);
         assert_eq!(
             resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 2, true, false),
-            ResolvedBufferDirtyAction::None
+            ResolvedBufferDirtyAction::NoOp
         );
     }
 
@@ -2334,9 +2366,10 @@ mod tests {
         );
 
         assert!(events.display_dirty);
-        assert_eq!(events.latest_buffer_epoch, Some(display_epoch));
+        let (latest_epoch, _) = events.latest_buffer_report.expect("buffer report");
+        assert_eq!(latest_epoch, display_epoch);
         assert!(
-            display_epoch <= events.latest_buffer_epoch.unwrap(),
+            display_epoch <= latest_epoch,
             "display bytes before the latest OSC report must not satisfy that report"
         );
     }
@@ -2353,7 +2386,8 @@ mod tests {
         );
 
         assert!(events.display_dirty);
-        assert!(display_epoch > events.latest_buffer_epoch.unwrap());
+        let (latest_epoch, _) = events.latest_buffer_report.expect("buffer report");
+        assert!(display_epoch > latest_epoch);
     }
 
     #[test]
@@ -2373,10 +2407,10 @@ mod tests {
 
         assert!(events.display_dirty);
         assert_eq!(display_epoch, 1);
-        assert_eq!(events.latest_buffer_epoch, Some(1));
-        assert_eq!(events.latest_buffer_generation, Some(2));
+        assert_eq!(events.latest_buffer_report, Some((1, 2)));
         assert_eq!(next_generation, 2);
-        assert!(display_epoch <= events.latest_buffer_epoch.unwrap());
+        let (latest_epoch, _) = events.latest_buffer_report.unwrap();
+        assert!(display_epoch <= latest_epoch);
     }
 
     #[test]
@@ -2396,10 +2430,10 @@ mod tests {
 
         assert!(events.display_dirty);
         assert_eq!(display_epoch, 2);
-        assert_eq!(events.latest_buffer_epoch, Some(1));
-        assert_eq!(events.latest_buffer_generation, Some(2));
+        assert_eq!(events.latest_buffer_report, Some((1, 2)));
         assert_eq!(next_generation, 2);
-        assert!(display_epoch > events.latest_buffer_epoch.unwrap());
+        let (latest_epoch, _) = events.latest_buffer_report.unwrap();
+        assert!(display_epoch > latest_epoch);
     }
 
     use gc_parser::TerminalParser;

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -483,7 +483,8 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let debounce_notify_b = Arc::clone(&debounce_notify);
     let stdout_handle = tokio::task::spawn_blocking(move || {
         let mut buf = [0u8; 8192];
-        let mut deferred_trigger_after_redraw = false;
+        let mut display_epoch = 0_u64;
+        let mut deferred_buffer_dirty: Option<DeferredBufferDirty> = None;
         loop {
             let n = match reader.read(&mut buf) {
                 Ok(0) => break, // PTY closed
@@ -493,7 +494,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             };
 
             // Feed bytes through the VT parser to track terminal state
-            let (needs_cpr, display_dirty, viewport_scrolls) = {
+            let (needs_cpr, display_dirty, viewport_scrolls, latest_buffer_epoch) = {
                 let mut p = match parser_for_stdout.lock() {
                     Ok(p) => p,
                     Err(e) => {
@@ -501,12 +502,12 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         break;
                     }
                 };
-                p.process_bytes(&buf[..n]);
-                let state = p.state_mut();
+                let events = process_pty_read(&mut p, &buf[..n], &mut display_epoch);
                 (
-                    state.take_cursor_sync_requested(),
-                    state.take_display_dirty(),
-                    state.take_viewport_scroll_count(),
+                    events.needs_cpr,
+                    events.display_dirty,
+                    events.viewport_scrolls,
+                    events.latest_buffer_epoch,
                 )
             };
 
@@ -608,22 +609,11 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            let display_changed = display_dirty || viewport_scrolls > 0;
-
             // Check if shell reported a buffer update via OSC 7770.
             // Trigger suggestions here (Task B) instead of Task A to ensure
             // we have the shell's updated buffer, fixing the stale-buffer bug.
-            let buffer_dirty = {
-                match parser_for_stdout.lock() {
-                    Ok(mut p) => p.state_mut().take_buffer_dirty(),
-                    Err(e) => {
-                        tracing::warn!("parser mutex poisoned in stdout task: {e}");
-                        break;
-                    }
-                }
-            };
-
-            if buffer_dirty {
+            if let Some(latest_buffer_epoch) = latest_buffer_epoch {
+                let display_after_latest_buffer = display_epoch > latest_buffer_epoch;
                 let mut render_buf = Vec::new();
                 let render_ticket = {
                     let mut h = match handler_for_stdout.lock() {
@@ -634,30 +624,26 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         }
                     };
                     let had_pending_trigger = h.has_pending_trigger();
-                    let action = if deferred_trigger_after_redraw && display_changed {
-                        BufferDirtyAction::Ignore
-                    } else {
-                        buffer_dirty_action(
-                            had_pending_trigger,
-                            delay_ms,
-                            h.auto_trigger_enabled(),
-                            h.is_debounce_suppressed(),
-                            display_changed,
-                        )
-                    };
+                    let action = buffer_dirty_action(
+                        had_pending_trigger,
+                        delay_ms,
+                        h.auto_trigger_enabled(),
+                        h.is_debounce_suppressed(),
+                        display_after_latest_buffer,
+                    );
                     if had_pending_trigger {
                         h.clear_trigger_request();
                     }
-                    match action {
-                        BufferDirtyAction::Trigger => {
-                            deferred_trigger_after_redraw = false;
+                    match apply_buffer_dirty_action(
+                        &mut deferred_buffer_dirty,
+                        latest_buffer_epoch,
+                        action,
+                    ) {
+                        ResolvedBufferDirtyAction::Trigger => {
                             h.trigger(&parser_for_stdout, &mut render_buf)
                         }
-                        BufferDirtyAction::Debounce => debounce_notify_b.notify_one(),
-                        BufferDirtyAction::DeferUntilDisplay => {
-                            deferred_trigger_after_redraw = true;
-                        }
-                        BufferDirtyAction::Ignore => {}
+                        ResolvedBufferDirtyAction::NotifyDebounce => debounce_notify_b.notify_one(),
+                        ResolvedBufferDirtyAction::None => {}
                     }
                     h.overlay_write_ticket()
                 };
@@ -671,7 +657,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            if deferred_trigger_after_redraw && display_changed {
+            if deferred_buffer_dirty.is_some_and(|pending| display_epoch > pending.display_epoch) {
                 let mut render_buf = Vec::new();
                 let render_ticket = {
                     let mut h = match handler_for_stdout.lock() {
@@ -681,9 +667,17 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                             break;
                         }
                     };
-                    deferred_trigger_after_redraw = false;
-                    if h.auto_trigger_enabled() {
-                        h.trigger(&parser_for_stdout, &mut render_buf);
+                    match resolve_deferred_buffer_dirty(
+                        &mut deferred_buffer_dirty,
+                        display_epoch,
+                        h.auto_trigger_enabled(),
+                        h.is_debounce_suppressed(),
+                    ) {
+                        ResolvedBufferDirtyAction::Trigger => {
+                            h.trigger(&parser_for_stdout, &mut render_buf);
+                        }
+                        ResolvedBufferDirtyAction::NotifyDebounce => debounce_notify_b.notify_one(),
+                        ResolvedBufferDirtyAction::None => {}
                     }
                     h.overlay_write_ticket()
                 };
@@ -951,12 +945,66 @@ fn poll_until(
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct PtyReadEvents {
+    needs_cpr: bool,
+    display_dirty: bool,
+    viewport_scrolls: u16,
+    latest_buffer_epoch: Option<u64>,
+}
+
+fn process_pty_read(
+    parser: &mut TerminalParser,
+    bytes: &[u8],
+    display_epoch: &mut u64,
+) -> PtyReadEvents {
+    let mut events = PtyReadEvents::default();
+    for byte in bytes {
+        parser.process_bytes(std::slice::from_ref(byte));
+        let state = parser.state_mut();
+
+        events.needs_cpr |= state.take_cursor_sync_requested();
+
+        let display_dirty = state.take_display_dirty();
+        let viewport_scrolls = state.take_viewport_scroll_count();
+        events.display_dirty |= display_dirty;
+        events.viewport_scrolls = events.viewport_scrolls.saturating_add(viewport_scrolls);
+        if display_dirty || viewport_scrolls > 0 {
+            *display_epoch = display_epoch.saturating_add(1);
+        }
+
+        if state.take_buffer_dirty() {
+            events.latest_buffer_epoch = Some(*display_epoch);
+        }
+    }
+    events
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeferredBufferDirtyAction {
+    TriggerNow,
+    NotifyDebounce,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DeferredBufferDirty {
+    action: DeferredBufferDirtyAction,
+    display_epoch: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BufferDirtyAction {
     Trigger,
     Debounce,
-    DeferUntilDisplay,
+    DeferUntilDisplay(DeferredBufferDirtyAction),
     Ignore,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResolvedBufferDirtyAction {
+    Trigger,
+    NotifyDebounce,
+    None,
 }
 
 fn buffer_dirty_action(
@@ -970,7 +1018,7 @@ fn buffer_dirty_action(
         return BufferDirtyAction::Ignore;
     }
     if has_pending_trigger && !display_changed {
-        return BufferDirtyAction::DeferUntilDisplay;
+        return BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow);
     }
     if has_pending_trigger {
         return BufferDirtyAction::Trigger;
@@ -979,11 +1027,73 @@ fn buffer_dirty_action(
         return BufferDirtyAction::Ignore;
     }
     if delay_ms == 0 && !display_changed {
-        BufferDirtyAction::DeferUntilDisplay
+        BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow)
     } else if delay_ms == 0 {
         BufferDirtyAction::Trigger
+    } else if !display_changed {
+        BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce)
     } else {
         BufferDirtyAction::Debounce
+    }
+}
+
+fn apply_buffer_dirty_action(
+    deferred: &mut Option<DeferredBufferDirty>,
+    buffer_epoch: u64,
+    action: BufferDirtyAction,
+) -> ResolvedBufferDirtyAction {
+    match action {
+        BufferDirtyAction::Trigger => {
+            *deferred = None;
+            ResolvedBufferDirtyAction::Trigger
+        }
+        BufferDirtyAction::Debounce => {
+            *deferred = None;
+            ResolvedBufferDirtyAction::NotifyDebounce
+        }
+        BufferDirtyAction::DeferUntilDisplay(action) => {
+            *deferred = Some(DeferredBufferDirty {
+                action,
+                display_epoch: buffer_epoch,
+            });
+            ResolvedBufferDirtyAction::None
+        }
+        BufferDirtyAction::Ignore => {
+            *deferred = None;
+            ResolvedBufferDirtyAction::None
+        }
+    }
+}
+
+fn resolve_deferred_buffer_dirty(
+    deferred: &mut Option<DeferredBufferDirty>,
+    display_epoch: u64,
+    auto_trigger_enabled: bool,
+    debounce_suppressed: bool,
+) -> ResolvedBufferDirtyAction {
+    let Some(pending) = *deferred else {
+        return ResolvedBufferDirtyAction::None;
+    };
+    if display_epoch <= pending.display_epoch {
+        return ResolvedBufferDirtyAction::None;
+    }
+
+    *deferred = None;
+    match pending.action {
+        DeferredBufferDirtyAction::TriggerNow => {
+            if auto_trigger_enabled {
+                ResolvedBufferDirtyAction::Trigger
+            } else {
+                ResolvedBufferDirtyAction::None
+            }
+        }
+        DeferredBufferDirtyAction::NotifyDebounce => {
+            if auto_trigger_enabled && !debounce_suppressed {
+                ResolvedBufferDirtyAction::NotifyDebounce
+            } else {
+                ResolvedBufferDirtyAction::None
+            }
+        }
     }
 }
 
@@ -1356,7 +1466,7 @@ mod tests {
     fn buffer_dirty_action_defers_delay_zero_until_redraw() {
         assert_eq!(
             buffer_dirty_action(false, 0, true, false, false),
-            BufferDirtyAction::DeferUntilDisplay
+            BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow)
         );
     }
 
@@ -1377,9 +1487,17 @@ mod tests {
     }
 
     #[test]
-    fn buffer_dirty_action_debounces_when_delay_positive() {
+    fn buffer_dirty_action_defers_debounce_until_redraw_when_delay_positive() {
         assert_eq!(
             buffer_dirty_action(false, 150, true, false, false),
+            BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce)
+        );
+    }
+
+    #[test]
+    fn buffer_dirty_action_debounces_after_redraw_when_delay_positive() {
+        assert_eq!(
+            buffer_dirty_action(false, 150, true, false, true),
             BufferDirtyAction::Debounce
         );
     }
@@ -1388,7 +1506,7 @@ mod tests {
     fn buffer_dirty_action_defers_pending_trigger_until_redraw() {
         assert_eq!(
             buffer_dirty_action(true, 150, true, true, false),
-            BufferDirtyAction::DeferUntilDisplay,
+            BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow),
             "OSC-only buffer reports must not render before the matching ZLE redraw moves the cursor"
         );
     }
@@ -1399,6 +1517,109 @@ mod tests {
             buffer_dirty_action(true, 150, true, true, true),
             BufferDirtyAction::Trigger
         );
+    }
+
+    #[test]
+    fn deferred_trigger_clears_when_suppressed_buffer_dirty_arrives() {
+        let mut deferred = Some(DeferredBufferDirty {
+            action: DeferredBufferDirtyAction::TriggerNow,
+            display_epoch: 3,
+        });
+
+        let action = buffer_dirty_action(false, 150, true, true, false);
+        assert_eq!(
+            apply_buffer_dirty_action(&mut deferred, 3, action),
+            ResolvedBufferDirtyAction::None
+        );
+        assert_eq!(deferred, None);
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, 4, true, true),
+            ResolvedBufferDirtyAction::None
+        );
+    }
+
+    #[test]
+    fn deferred_debounce_notifies_only_after_later_display() {
+        let mut deferred = None;
+        let action = buffer_dirty_action(false, 150, true, false, false);
+
+        assert_eq!(
+            apply_buffer_dirty_action(&mut deferred, 8, action),
+            ResolvedBufferDirtyAction::None
+        );
+        assert_eq!(
+            deferred,
+            Some(DeferredBufferDirty {
+                action: DeferredBufferDirtyAction::NotifyDebounce,
+                display_epoch: 8,
+            })
+        );
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, 8, true, false),
+            ResolvedBufferDirtyAction::None
+        );
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, 9, true, false),
+            ResolvedBufferDirtyAction::NotifyDebounce
+        );
+        assert_eq!(deferred, None);
+    }
+
+    #[test]
+    fn deferred_debounce_is_dropped_if_suppression_changes_before_redraw() {
+        let mut deferred = Some(DeferredBufferDirty {
+            action: DeferredBufferDirtyAction::NotifyDebounce,
+            display_epoch: 4,
+        });
+
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, 5, true, true),
+            ResolvedBufferDirtyAction::None
+        );
+        assert_eq!(deferred, None);
+    }
+
+    #[test]
+    fn current_buffer_dirty_trigger_replaces_deferred_without_double_fire() {
+        let mut deferred = Some(DeferredBufferDirty {
+            action: DeferredBufferDirtyAction::TriggerNow,
+            display_epoch: 1,
+        });
+        let action = buffer_dirty_action(true, 150, true, false, true);
+
+        assert_eq!(
+            apply_buffer_dirty_action(&mut deferred, 2, action),
+            ResolvedBufferDirtyAction::Trigger
+        );
+        assert_eq!(deferred, None);
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, 2, true, false),
+            ResolvedBufferDirtyAction::None
+        );
+    }
+
+    #[test]
+    fn pty_read_tracks_display_epoch_before_latest_buffer_report() {
+        let mut parser = TerminalParser::new(24, 80);
+        let mut display_epoch = 0;
+        let events = process_pty_read(&mut parser, b"x\x1b]7770;4;git \x07", &mut display_epoch);
+
+        assert!(events.display_dirty);
+        assert_eq!(events.latest_buffer_epoch, Some(display_epoch));
+        assert!(
+            display_epoch <= events.latest_buffer_epoch.unwrap(),
+            "display bytes before the latest OSC report must not satisfy that report"
+        );
+    }
+
+    #[test]
+    fn pty_read_tracks_display_epoch_after_latest_buffer_report() {
+        let mut parser = TerminalParser::new(24, 80);
+        let mut display_epoch = 0;
+        let events = process_pty_read(&mut parser, b"\x1b]7770;4;git \x07x", &mut display_epoch);
+
+        assert!(events.display_dirty);
+        assert!(display_epoch > events.latest_buffer_epoch.unwrap());
     }
 
     use gc_parser::TerminalParser;

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -14,7 +14,7 @@ use gc_suggest::spec_dirs::resolve_spec_dirs;
 
 use crate::config_watch::spawn_config_watcher;
 use crate::handler::{InputHandler, Keybindings, OverlayWriteTicket, TriggerPrepared};
-use crate::input::KeyParser;
+use crate::input::{KeyEvent, KeyParser};
 use crate::resize::{get_terminal_size, resize_pty};
 use crate::spawn::{spawn_shell, SpawnedShell};
 
@@ -24,6 +24,7 @@ use crate::spawn::{spawn_shell, SpawnedShell};
 /// `CprAction::DropEmpty` and is forwarded defensively, which is why the
 /// threshold is generous.
 const CPR_STALE_THRESHOLD: Duration = Duration::from_secs(30);
+const ASYNC_OVERLAY_GATE_RETRY: Duration = Duration::from_millis(10);
 
 /// Drop guard that ensures raw mode is always restored, even on panic.
 struct RawModeGuard;
@@ -262,8 +263,15 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     };
     let handler_for_merge = Arc::clone(&handler);
     let parser_for_merge = Arc::clone(&parser);
+    let debounce_state_for_merge = Arc::clone(&debounce_state);
     let merge_handle = tokio::spawn(async move {
-        dynamic_merge_loop(dynamic_notify, handler_for_merge, parser_for_merge).await;
+        dynamic_merge_loop(
+            dynamic_notify,
+            handler_for_merge,
+            parser_for_merge,
+            debounce_state_for_merge,
+        )
+        .await;
     });
 
     let feedback_notify = {
@@ -277,8 +285,14 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
         h.feedback_tick_notify()
     };
     let handler_for_feedback = Arc::clone(&handler);
+    let debounce_state_for_feedback = Arc::clone(&debounce_state);
     let feedback_handle = tokio::spawn(async move {
-        feedback_tick_loop(feedback_notify, handler_for_feedback).await;
+        feedback_tick_loop(
+            feedback_notify,
+            handler_for_feedback,
+            debounce_state_for_feedback,
+        )
+        .await;
     });
 
     // Channel to signal that one of the I/O tasks has finished
@@ -289,6 +303,8 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let mut pty_writer = writer;
     let parser_for_stdin = Arc::clone(&parser);
     let handler_for_stdin = Arc::clone(&handler);
+    let debounce_state_for_stdin = Arc::clone(&debounce_state);
+    let trigger_snapshot_gate_a = Arc::clone(&trigger_snapshot_gate);
     let stdin_handle = tokio::task::spawn_blocking(move || {
         let mut stdin = std::io::stdin().lock();
         let mut buf = [0u8; 4096];
@@ -456,6 +472,13 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 // with Task B's stdout writes).
                 let mut render_buf = Vec::new();
                 let (forward, render_ticket) = {
+                    let _snapshot_guard = match trigger_snapshot_gate_a.lock() {
+                        Ok(guard) => guard,
+                        Err(e) => {
+                            tracing::warn!("trigger snapshot gate poisoned in stdin task: {e}");
+                            break 'stdin;
+                        }
+                    };
                     let mut h = match handler_for_stdin.lock() {
                         Ok(h) => h,
                         Err(e) => {
@@ -464,6 +487,17 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         }
                     };
                     let forward = h.process_key(key, &parser_for_stdin, &mut render_buf);
+                    let invalidates_debounce =
+                        !forward.is_empty() && forwarded_input_invalidates_debounce(key);
+                    if invalidates_debounce {
+                        match debounce_state_for_stdin.lock() {
+                            Ok(mut state) => state.invalidate_for_forwarded_input(),
+                            Err(e) => {
+                                tracing::warn!("debounce state mutex poisoned in stdin task: {e}");
+                                break 'stdin;
+                            }
+                        }
+                    }
                     (forward, h.overlay_write_ticket())
                 };
                 if !render_buf.is_empty() {
@@ -851,23 +885,33 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
 
             // Poll for dynamic (script generator) results — non-blocking.
             {
-                let mut render_buf = Vec::new();
-                let render_ticket = {
-                    let mut h = match handler_for_stdout.lock() {
-                        Ok(h) => h,
-                        Err(e) => {
-                            tracing::warn!("handler mutex poisoned in stdout task: {e}");
-                            break;
+                match locked_async_overlay_gate_decision(&debounce_state_b, "stdout task") {
+                    Some(AsyncOverlayGateDecision::Render) => {
+                        let mut render_buf = Vec::new();
+                        let render_ticket = {
+                            let mut h = match handler_for_stdout.lock() {
+                                Ok(h) => h,
+                                Err(e) => {
+                                    tracing::warn!("handler mutex poisoned in stdout task: {e}");
+                                    break;
+                                }
+                            };
+                            h.try_merge_dynamic(&parser_for_stdout, &mut render_buf);
+                            h.overlay_write_ticket()
+                        };
+                        if !render_buf.is_empty() {
+                            if let Err(e) = write_overlay_if_current(
+                                &handler_for_stdout,
+                                render_ticket,
+                                &render_buf,
+                            ) {
+                                tracing::debug!("Task B overlay write/flush failed: {e}");
+                                break;
+                            }
                         }
-                    };
-                    h.try_merge_dynamic(&parser_for_stdout, &mut render_buf);
-                    h.overlay_write_ticket()
-                };
-                if !render_buf.is_empty() {
-                    if let Err(e) =
-                        write_overlay_if_current(&handler_for_stdout, render_ticket, &render_buf)
-                    {
-                        tracing::debug!("Task B overlay write/flush failed: {e}");
+                    }
+                    Some(AsyncOverlayGateDecision::Blocked) => {}
+                    None => {
                         break;
                     }
                 }
@@ -1067,6 +1111,10 @@ fn poll_until(
     }
 }
 
+fn forwarded_input_invalidates_debounce(key: &KeyEvent) -> bool {
+    !matches!(key, KeyEvent::CursorPositionReport(_, _))
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct PtyReadEvents {
     needs_cpr: bool,
@@ -1124,6 +1172,13 @@ impl DebounceState {
         self.current_generation
     }
 
+    fn invalidate_for_forwarded_input(&mut self) {
+        if self.deferred_generation.is_some() {
+            return;
+        }
+        self.current_generation += 1;
+    }
+
     fn notify_generation(&mut self, generation: u64) {
         self.notified_generation = Some(generation);
         if self.deferred_generation == Some(generation) {
@@ -1150,6 +1205,10 @@ impl DebounceState {
             && self.notified_generation == Some(generation)
             && self.deferred_generation.is_none()
     }
+
+    fn has_deferred_generation(&self) -> bool {
+        self.deferred_generation.is_some()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1172,6 +1231,67 @@ enum ResolvedBufferDirtyAction {
     Trigger,
     NotifyDebounce,
     None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DebounceFireDecision {
+    Fire,
+    Skip,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DebounceContinuationDecision {
+    Apply,
+    Drop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AsyncOverlayGateDecision {
+    Render,
+    Blocked,
+}
+
+fn debounce_fire_decision(state: &DebounceState, generation: u64) -> DebounceFireDecision {
+    if state.can_fire_generation(generation) {
+        DebounceFireDecision::Fire
+    } else {
+        DebounceFireDecision::Skip
+    }
+}
+
+fn debounce_continuation_decision(
+    state: &DebounceState,
+    generation: u64,
+) -> DebounceContinuationDecision {
+    if state.can_fire_generation(generation) {
+        DebounceContinuationDecision::Apply
+    } else {
+        DebounceContinuationDecision::Drop
+    }
+}
+
+fn async_overlay_gate_decision(state: &DebounceState) -> AsyncOverlayGateDecision {
+    if state.has_deferred_generation() {
+        AsyncOverlayGateDecision::Blocked
+    } else {
+        AsyncOverlayGateDecision::Render
+    }
+}
+
+fn locked_async_overlay_gate_decision(
+    debounce_state: &Arc<Mutex<DebounceState>>,
+    source: &'static str,
+) -> Option<AsyncOverlayGateDecision> {
+    match debounce_state.lock() {
+        Ok(state) => Some(async_overlay_gate_decision(&state)),
+        Err(e) => {
+            tracing::warn!(
+                source = source,
+                "async overlay gate skipped (debounce state lock poisoned): {e}"
+            );
+            None
+        }
+    }
 }
 
 fn buffer_dirty_action(
@@ -1291,7 +1411,11 @@ fn resolve_deferred_buffer_dirty(
     }
 
     *deferred = None;
+    let generation_is_current = debounce_state.current_generation == pending.generation;
     debounce_state.clear_deferred_generation(pending.generation);
+    if !generation_is_current {
+        return ResolvedBufferDirtyAction::None;
+    }
     match pending.action {
         DeferredBufferDirtyAction::TriggerNow => {
             if auto_trigger_enabled {
@@ -1439,7 +1563,7 @@ async fn debounce_loop(
                     continue;
                 }
             };
-            let should_fire = {
+            let fire_decision = {
                 let state = match debounce_state.lock() {
                     Ok(state) => state,
                     Err(e) => {
@@ -1447,9 +1571,9 @@ async fn debounce_loop(
                         continue;
                     }
                 };
-                state.can_fire_generation(generation)
+                debounce_fire_decision(&state, generation)
             };
-            if !should_fire {
+            if fire_decision == DebounceFireDecision::Skip {
                 continue;
             }
             let mut h = match handler.lock() {
@@ -1523,6 +1647,36 @@ async fn debounce_loop(
 
             let mut render_buf2 = Vec::new();
             let render_ticket2 = {
+                let _snapshot_guard = match trigger_snapshot_gate.lock() {
+                    Ok(guard) => guard,
+                    Err(e) => {
+                        tracing::warn!(
+                            "debounce apply_block_result skipped (trigger snapshot gate poisoned): {e}"
+                        );
+                        continue;
+                    }
+                };
+                let continuation_decision = {
+                    let state = match debounce_state.lock() {
+                        Ok(state) => state,
+                        Err(e) => {
+                            tracing::warn!(
+                                "debounce apply_block_result skipped (state lock poisoned): {e}"
+                            );
+                            continue;
+                        }
+                    };
+                    debounce_continuation_decision(&state, generation)
+                };
+                if continuation_decision == DebounceContinuationDecision::Drop {
+                    match handler.lock() {
+                        Ok(mut h) => h.abort_dynamic_task_and_clear_ctx(),
+                        Err(e) => tracing::warn!(
+                            "handler mutex poisoned during stale block-result cleanup: {e}"
+                        ),
+                    }
+                    continue;
+                }
                 let mut h = match handler.lock() {
                     Ok(h) => h,
                     Err(e) => {
@@ -1565,9 +1719,19 @@ async fn dynamic_merge_loop(
     notify: Arc<Notify>,
     handler: Arc<Mutex<InputHandler>>,
     parser: Arc<Mutex<TerminalParser>>,
+    debounce_state: Arc<Mutex<DebounceState>>,
 ) {
     loop {
         notify.notified().await;
+        loop {
+            match locked_async_overlay_gate_decision(&debounce_state, "dynamic merge loop") {
+                Some(AsyncOverlayGateDecision::Render) => break,
+                Some(AsyncOverlayGateDecision::Blocked) => {
+                    tokio::time::sleep(ASYNC_OVERLAY_GATE_RETRY).await;
+                }
+                None => return,
+            }
+        }
         let mut render_buf = Vec::new();
         let render_ticket = {
             let mut h = match handler.lock() {
@@ -1589,13 +1753,25 @@ async fn dynamic_merge_loop(
     }
 }
 
-async fn feedback_tick_loop(notify: Arc<Notify>, handler: Arc<Mutex<InputHandler>>) {
+async fn feedback_tick_loop(
+    notify: Arc<Notify>,
+    handler: Arc<Mutex<InputHandler>>,
+    debounce_state: Arc<Mutex<DebounceState>>,
+) {
     loop {
         notify.notified().await;
         let mut next_ms: u64 = 0;
         loop {
             if next_ms > 0 {
                 tokio::time::sleep(Duration::from_millis(next_ms)).await;
+            }
+            match locked_async_overlay_gate_decision(&debounce_state, "feedback tick loop") {
+                Some(AsyncOverlayGateDecision::Render) => {}
+                Some(AsyncOverlayGateDecision::Blocked) => {
+                    tokio::time::sleep(ASYNC_OVERLAY_GATE_RETRY).await;
+                    continue;
+                }
+                None => return,
             }
             let mut render_buf: Vec<u8> = Vec::new();
             let (keep_running, render_ticket) = {
@@ -1882,6 +2058,123 @@ mod tests {
     }
 
     #[test]
+    fn debounce_fire_decision_rejects_generation_invalidated_by_forwarded_input() {
+        let mut debounce_state = DebounceState::default();
+        let generation = debounce_state.next_buffer_generation();
+        debounce_state.notify_generation(generation);
+        assert_eq!(
+            debounce_fire_decision(&debounce_state, generation),
+            DebounceFireDecision::Fire
+        );
+
+        debounce_state.invalidate_for_forwarded_input();
+
+        assert_eq!(
+            debounce_fire_decision(&debounce_state, generation),
+            DebounceFireDecision::Skip
+        );
+    }
+
+    #[test]
+    fn debounce_fire_decision_rejects_prior_generation_when_newer_report_is_deferred() {
+        let mut deferred = None;
+        let mut debounce_state = DebounceState::default();
+        let first_generation = debounce_state.next_buffer_generation();
+        debounce_state.notify_generation(first_generation);
+
+        let second_generation = debounce_state.next_buffer_generation();
+        assert_eq!(
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                4,
+                second_generation,
+                BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
+            ),
+            ResolvedBufferDirtyAction::None
+        );
+
+        assert_eq!(
+            debounce_fire_decision(&debounce_state, first_generation),
+            DebounceFireDecision::Skip
+        );
+        assert_eq!(
+            debounce_continuation_decision(&debounce_state, first_generation),
+            DebounceContinuationDecision::Drop
+        );
+    }
+
+    #[test]
+    fn async_overlay_gate_blocks_while_redraw_deferred() {
+        let mut debounce_state = DebounceState::default();
+        let generation = debounce_state.next_buffer_generation();
+        debounce_state.defer_generation(generation);
+
+        assert_eq!(
+            async_overlay_gate_decision(&debounce_state),
+            AsyncOverlayGateDecision::Blocked
+        );
+
+        debounce_state.clear_deferred_generation(generation);
+
+        assert_eq!(
+            async_overlay_gate_decision(&debounce_state),
+            AsyncOverlayGateDecision::Render
+        );
+    }
+
+    #[test]
+    fn deferred_trigger_survives_forwarded_input_that_advances_display() {
+        let mut deferred = None;
+        let mut debounce_state = DebounceState::default();
+        let generation = debounce_state.next_buffer_generation();
+        assert_eq!(
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                4,
+                generation,
+                BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow),
+            ),
+            ResolvedBufferDirtyAction::None
+        );
+
+        debounce_state.invalidate_for_forwarded_input();
+
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 5, true, false),
+            ResolvedBufferDirtyAction::Trigger
+        );
+        assert_eq!(deferred, None);
+    }
+
+    #[test]
+    fn deferred_debounce_survives_forwarded_input_that_advances_display() {
+        let mut deferred = None;
+        let mut debounce_state = DebounceState::default();
+        let generation = debounce_state.next_buffer_generation();
+        assert_eq!(
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                4,
+                generation,
+                BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
+            ),
+            ResolvedBufferDirtyAction::None
+        );
+
+        debounce_state.invalidate_for_forwarded_input();
+
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 5, true, false),
+            ResolvedBufferDirtyAction::NotifyDebounce
+        );
+        assert_eq!(deferred, None);
+        assert!(debounce_state.can_fire_generation(generation));
+    }
+
+    #[test]
     fn pty_read_records_buffer_generation_when_report_updates_parser() {
         let mut parser = TerminalParser::new(24, 80);
         let mut display_epoch = 0;
@@ -2067,16 +2360,22 @@ mod tests {
     fn pty_read_uses_latest_buffer_epoch_when_reports_coalesce() {
         let mut parser = TerminalParser::new(24, 80);
         let mut display_epoch = 0;
+        let mut next_generation = 0;
         let events = process_pty_read(
             &mut parser,
             b"\x1b]7770;4;git \x07x\x1b]7770;5;git s\x07",
             &mut display_epoch,
-            || 1,
+            || {
+                next_generation += 1;
+                next_generation
+            },
         );
 
         assert!(events.display_dirty);
         assert_eq!(display_epoch, 1);
         assert_eq!(events.latest_buffer_epoch, Some(1));
+        assert_eq!(events.latest_buffer_generation, Some(2));
+        assert_eq!(next_generation, 2);
         assert!(display_epoch <= events.latest_buffer_epoch.unwrap());
     }
 
@@ -2084,16 +2383,22 @@ mod tests {
     fn pty_read_allows_display_after_latest_coalesced_buffer_report() {
         let mut parser = TerminalParser::new(24, 80);
         let mut display_epoch = 0;
+        let mut next_generation = 0;
         let events = process_pty_read(
             &mut parser,
             b"\x1b]7770;4;git \x07x\x1b]7770;5;git s\x07y",
             &mut display_epoch,
-            || 1,
+            || {
+                next_generation += 1;
+                next_generation
+            },
         );
 
         assert!(events.display_dirty);
         assert_eq!(display_epoch, 2);
         assert_eq!(events.latest_buffer_epoch, Some(1));
+        assert_eq!(events.latest_buffer_generation, Some(2));
+        assert_eq!(next_generation, 2);
         assert!(display_epoch > events.latest_buffer_epoch.unwrap());
     }
 

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -674,9 +674,10 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            // Run in Task B so we observe the parser's post-OSC buffer state.
-            if let Some((latest_buffer_epoch, buffer_generation)) = latest_buffer_report {
-                let display_after_latest_buffer = display_epoch > latest_buffer_epoch;
+            // Observe the parser's post-OSC buffer state after the stdout
+            // pipeline drains it.
+            if let Some(report) = latest_buffer_report {
+                let display_after_latest_buffer = display_epoch > report.display_epoch;
                 let action = {
                     let mut h = match handler_for_stdout.lock() {
                         Ok(h) => h,
@@ -710,8 +711,8 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     apply_buffer_dirty_action(
                         &mut deferred_buffer_dirty,
                         &mut state,
-                        latest_buffer_epoch,
-                        buffer_generation,
+                        report.display_epoch,
+                        report.generation,
                         action,
                     )
                 };
@@ -1101,15 +1102,22 @@ fn forwarded_input_invalidates_debounce(key: &KeyEvent) -> bool {
     !matches!(key, KeyEvent::CursorPositionReport(_, _))
 }
 
+/// Latest OSC 7770 buffer report observed in a single PTY read. Named so the
+/// two same-typed `u64` fields can't be silently transposed at a call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BufferReport {
+    display_epoch: u64,
+    generation: u64,
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct PtyReadEvents {
     needs_cpr: bool,
     display_dirty: bool,
     viewport_scrolls: u16,
-    /// (display_epoch, buffer_generation) of the latest buffer report seen in
-    /// this read. Tied as a pair so the type system rules out the impossible
-    /// "epoch without generation" state.
-    latest_buffer_report: Option<(u64, u64)>,
+    /// Latest buffer report seen in this read. Tied as a pair so the type
+    /// system rules out the impossible "epoch without generation" state.
+    latest_buffer_report: Option<BufferReport>,
 }
 
 fn process_pty_read(
@@ -1140,7 +1148,10 @@ fn process_pty_read(
         }
 
         if state.take_buffer_dirty() {
-            events.latest_buffer_report = Some((*display_epoch, next_buffer_generation()));
+            events.latest_buffer_report = Some(BufferReport {
+                display_epoch: *display_epoch,
+                generation: next_buffer_generation(),
+            });
         }
     }
     events
@@ -1152,6 +1163,11 @@ enum DeferredBufferDirtyAction {
     NotifyDebounce,
 }
 
+/// Tracks buffer-generation state across the stdout/debounce/dynamic-merge
+/// tasks. `notified_generation` is intentionally not cleared when superseded
+/// by `next_buffer_generation()`: gating in `can_fire_generation` is anchored
+/// on `current_generation == generation`, so a stale notified value can never
+/// satisfy a live check. The next `notify_generation` overwrites it in place.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct DebounceState {
     current_generation: u64,
@@ -1339,7 +1355,7 @@ fn clear_deferred_buffer_dirty(
 fn defer_cwd_trigger_until_buffer_display(
     deferred: &mut Option<DeferredBufferDirty>,
     debounce_state: &mut DebounceState,
-    latest_buffer_report: Option<(u64, u64)>,
+    latest_buffer_report: Option<BufferReport>,
     display_epoch: u64,
 ) -> bool {
     if let Some(pending) = deferred.as_mut() {
@@ -1347,19 +1363,19 @@ fn defer_cwd_trigger_until_buffer_display(
         return true;
     }
 
-    let Some((buffer_epoch, buffer_generation)) = latest_buffer_report else {
+    let Some(report) = latest_buffer_report else {
         return false;
     };
-    if display_epoch > buffer_epoch {
+    if display_epoch > report.display_epoch {
         return false;
     }
 
     *deferred = Some(DeferredBufferDirty {
         action: DeferredBufferDirtyAction::TriggerNow,
-        display_epoch: buffer_epoch,
-        generation: buffer_generation,
+        display_epoch: report.display_epoch,
+        generation: report.generation,
     });
-    debounce_state.defer_generation(buffer_generation);
+    debounce_state.defer_generation(report.generation);
     true
 }
 
@@ -2222,7 +2238,13 @@ mod tests {
         );
 
         assert_eq!(display_epoch, 0, "pure OSC must not advance display epoch");
-        assert_eq!(events.latest_buffer_report, Some((0, 1)));
+        assert_eq!(
+            events.latest_buffer_report,
+            Some(BufferReport {
+                display_epoch: 0,
+                generation: 1,
+            })
+        );
         assert!(!events.display_dirty);
         assert_eq!(events.viewport_scrolls, 0);
         assert_eq!(next_generation, 1);
@@ -2253,7 +2275,10 @@ mod tests {
         assert!(defer_cwd_trigger_until_buffer_display(
             &mut deferred,
             &mut debounce_state,
-            Some((4, current_generation)),
+            Some(BufferReport {
+                display_epoch: 4,
+                generation: current_generation,
+            }),
             4,
         ));
         assert_eq!(
@@ -2307,6 +2332,46 @@ mod tests {
         );
         assert_eq!(deferred, None);
         assert!(!debounce_state.can_fire_generation(1));
+    }
+
+    #[test]
+    fn cwd_dirty_fires_immediately_when_no_buffer_report_pending() {
+        // No prior deferred and no buffer report this read — the CWD-only
+        // trigger must fire immediately (caller observes false return).
+        let mut deferred = None;
+        let mut debounce_state = DebounceState::default();
+
+        assert!(!defer_cwd_trigger_until_buffer_display(
+            &mut deferred,
+            &mut debounce_state,
+            None,
+            5,
+        ));
+        assert_eq!(deferred, None);
+        assert!(!debounce_state.has_deferred_generation());
+    }
+
+    #[test]
+    fn cwd_dirty_fires_immediately_when_buffer_report_already_displayed() {
+        // The buffer report rode in on bytes that already updated the screen
+        // (display_epoch advanced past the report's epoch), so there is
+        // nothing left to wait for — fire immediately (false return).
+        let mut deferred = None;
+        let mut debounce_state = DebounceState::default();
+        let prior_generation = debounce_state.next_buffer_generation();
+        debounce_state.notify_generation(prior_generation);
+
+        assert!(!defer_cwd_trigger_until_buffer_display(
+            &mut deferred,
+            &mut debounce_state,
+            Some(BufferReport {
+                display_epoch: 4,
+                generation: 2,
+            }),
+            5,
+        ));
+        assert_eq!(deferred, None);
+        assert!(!debounce_state.has_deferred_generation());
     }
 
     #[test]
@@ -2366,10 +2431,10 @@ mod tests {
         );
 
         assert!(events.display_dirty);
-        let (latest_epoch, _) = events.latest_buffer_report.expect("buffer report");
-        assert_eq!(latest_epoch, display_epoch);
+        let report = events.latest_buffer_report.expect("buffer report");
+        assert_eq!(report.display_epoch, display_epoch);
         assert!(
-            display_epoch <= latest_epoch,
+            display_epoch <= report.display_epoch,
             "display bytes before the latest OSC report must not satisfy that report"
         );
     }
@@ -2386,8 +2451,8 @@ mod tests {
         );
 
         assert!(events.display_dirty);
-        let (latest_epoch, _) = events.latest_buffer_report.expect("buffer report");
-        assert!(display_epoch > latest_epoch);
+        let report = events.latest_buffer_report.expect("buffer report");
+        assert!(display_epoch > report.display_epoch);
     }
 
     #[test]
@@ -2407,10 +2472,16 @@ mod tests {
 
         assert!(events.display_dirty);
         assert_eq!(display_epoch, 1);
-        assert_eq!(events.latest_buffer_report, Some((1, 2)));
+        assert_eq!(
+            events.latest_buffer_report,
+            Some(BufferReport {
+                display_epoch: 1,
+                generation: 2,
+            })
+        );
         assert_eq!(next_generation, 2);
-        let (latest_epoch, _) = events.latest_buffer_report.unwrap();
-        assert!(display_epoch <= latest_epoch);
+        let report = events.latest_buffer_report.unwrap();
+        assert!(display_epoch <= report.display_epoch);
     }
 
     #[test]
@@ -2430,10 +2501,16 @@ mod tests {
 
         assert!(events.display_dirty);
         assert_eq!(display_epoch, 2);
-        assert_eq!(events.latest_buffer_report, Some((1, 2)));
+        assert_eq!(
+            events.latest_buffer_report,
+            Some(BufferReport {
+                display_epoch: 1,
+                generation: 2,
+            })
+        );
         assert_eq!(next_generation, 2);
-        let (latest_epoch, _) = events.latest_buffer_report.unwrap();
-        assert!(display_epoch > latest_epoch);
+        let report = events.latest_buffer_report.unwrap();
+        assert!(display_epoch > report.display_epoch);
     }
 
     use gc_parser::TerminalParser;

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -220,15 +220,26 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     // Debounce task: fires suggestions after a typing pause
     let debounce_notify = Arc::new(Notify::new());
     let debounce_state = Arc::new(Mutex::new(DebounceState::default()));
+    // Keeps debounce generation checks atomic with the parser snapshot they render from.
+    let trigger_snapshot_gate = Arc::new(Mutex::new(()));
     let delay_ms = config.trigger.delay_ms;
 
     let debounce_handle = if delay_ms > 0 {
         let notify = Arc::clone(&debounce_notify);
         let debounce_state_d = Arc::clone(&debounce_state);
+        let trigger_snapshot_gate_d = Arc::clone(&trigger_snapshot_gate);
         let handler_d = Arc::clone(&handler);
         let parser_d = Arc::clone(&parser);
         Some(tokio::spawn(async move {
-            debounce_loop(notify, debounce_state_d, handler_d, parser_d, delay_ms).await;
+            debounce_loop(
+                notify,
+                debounce_state_d,
+                trigger_snapshot_gate_d,
+                handler_d,
+                parser_d,
+                delay_ms,
+            )
+            .await;
         }))
     } else {
         None
@@ -484,6 +495,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let handler_for_stdout = Arc::clone(&handler);
     let debounce_notify_b = Arc::clone(&debounce_notify);
     let debounce_state_b = Arc::clone(&debounce_state);
+    let trigger_snapshot_gate_b = Arc::clone(&trigger_snapshot_gate);
     let stdout_handle = tokio::task::spawn_blocking(move || {
         let mut buf = [0u8; 8192];
         let mut display_epoch = 0_u64;
@@ -497,7 +509,20 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             };
 
             // Feed bytes through the VT parser to track terminal state
-            let (needs_cpr, display_dirty, viewport_scrolls, latest_buffer_epoch) = {
+            let (
+                needs_cpr,
+                display_dirty,
+                viewport_scrolls,
+                latest_buffer_epoch,
+                latest_buffer_generation,
+            ) = {
+                let _snapshot_guard = match trigger_snapshot_gate_b.lock() {
+                    Ok(guard) => guard,
+                    Err(e) => {
+                        tracing::warn!("trigger snapshot gate poisoned in stdout task: {e}");
+                        break;
+                    }
+                };
                 let mut p = match parser_for_stdout.lock() {
                     Ok(p) => p,
                     Err(e) => {
@@ -505,12 +530,22 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         break;
                     }
                 };
-                let events = process_pty_read(&mut p, &buf[..n], &mut display_epoch);
+                let mut debounce_state = match debounce_state_b.lock() {
+                    Ok(state) => state,
+                    Err(e) => {
+                        tracing::warn!("debounce state mutex poisoned in stdout task: {e}");
+                        break;
+                    }
+                };
+                let events = process_pty_read(&mut p, &buf[..n], &mut display_epoch, || {
+                    debounce_state.next_buffer_generation()
+                });
                 (
                     events.needs_cpr,
                     events.display_dirty,
                     events.viewport_scrolls,
                     events.latest_buffer_epoch,
+                    events.latest_buffer_generation,
                 )
             };
 
@@ -616,15 +651,9 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             // decisions see the parser's updated buffer. OSC-only reports may be deferred
             // until a later display epoch to avoid rendering before the terminal redraws.
             if let Some(latest_buffer_epoch) = latest_buffer_epoch {
-                let buffer_generation = {
-                    let mut state = match debounce_state_b.lock() {
-                        Ok(state) => state,
-                        Err(e) => {
-                            tracing::warn!("debounce state mutex poisoned in stdout task: {e}");
-                            break;
-                        }
-                    };
-                    state.next_buffer_generation()
+                let Some(buffer_generation) = latest_buffer_generation else {
+                    tracing::warn!("buffer report missing generation in stdout task");
+                    break;
                 };
                 let display_after_latest_buffer = display_epoch > latest_buffer_epoch;
                 let action = {
@@ -776,8 +805,24 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     };
                     h.auto_trigger_enabled()
                 };
-                let cwd_deferred = auto_trigger_enabled
-                    && defer_cwd_trigger_until_buffer_display(&mut deferred_buffer_dirty);
+                let cwd_deferred = if auto_trigger_enabled {
+                    let mut state = match debounce_state_b.lock() {
+                        Ok(state) => state,
+                        Err(e) => {
+                            tracing::warn!("debounce state mutex poisoned in stdout task: {e}");
+                            break;
+                        }
+                    };
+                    defer_cwd_trigger_until_buffer_display(
+                        &mut deferred_buffer_dirty,
+                        &mut state,
+                        latest_buffer_epoch,
+                        latest_buffer_generation,
+                        display_epoch,
+                    )
+                } else {
+                    false
+                };
                 if auto_trigger_enabled && !cwd_deferred {
                     let mut render_buf = Vec::new();
                     let render_ticket = {
@@ -1028,12 +1073,14 @@ struct PtyReadEvents {
     display_dirty: bool,
     viewport_scrolls: u16,
     latest_buffer_epoch: Option<u64>,
+    latest_buffer_generation: Option<u64>,
 }
 
 fn process_pty_read(
     parser: &mut TerminalParser,
     bytes: &[u8],
     display_epoch: &mut u64,
+    mut next_buffer_generation: impl FnMut() -> u64,
 ) -> PtyReadEvents {
     let mut events = PtyReadEvents::default();
     for byte in bytes {
@@ -1052,6 +1099,7 @@ fn process_pty_read(
 
         if state.take_buffer_dirty() {
             events.latest_buffer_epoch = Some(*display_epoch);
+            events.latest_buffer_generation = Some(next_buffer_generation());
         }
     }
     events
@@ -1198,11 +1246,33 @@ fn clear_deferred_buffer_dirty(
     }
 }
 
-fn defer_cwd_trigger_until_buffer_display(deferred: &mut Option<DeferredBufferDirty>) -> bool {
-    let Some(pending) = deferred.as_mut() else {
+fn defer_cwd_trigger_until_buffer_display(
+    deferred: &mut Option<DeferredBufferDirty>,
+    debounce_state: &mut DebounceState,
+    latest_buffer_epoch: Option<u64>,
+    latest_buffer_generation: Option<u64>,
+    display_epoch: u64,
+) -> bool {
+    if let Some(pending) = deferred.as_mut() {
+        pending.action = DeferredBufferDirtyAction::TriggerNow;
+        return true;
+    }
+
+    let (Some(buffer_epoch), Some(buffer_generation)) =
+        (latest_buffer_epoch, latest_buffer_generation)
+    else {
         return false;
     };
-    pending.action = DeferredBufferDirtyAction::TriggerNow;
+    if display_epoch > buffer_epoch {
+        return false;
+    }
+
+    *deferred = Some(DeferredBufferDirty {
+        action: DeferredBufferDirtyAction::TriggerNow,
+        display_epoch: buffer_epoch,
+        generation: buffer_generation,
+    });
+    debounce_state.defer_generation(buffer_generation);
     true
 }
 
@@ -1312,6 +1382,7 @@ fn write_overlay_if_current(
 async fn debounce_loop(
     notify: Arc<Notify>,
     debounce_state: Arc<Mutex<DebounceState>>,
+    trigger_snapshot_gate: Arc<Mutex<()>>,
     handler: Arc<Mutex<InputHandler>>,
     parser: Arc<Mutex<TerminalParser>>,
     delay_ms: u64,
@@ -1353,20 +1424,6 @@ async fn debounce_loop(
                 _ = tokio::time::sleep(delay) => { break; }
             }
         }
-        let should_fire = {
-            let state = match debounce_state.lock() {
-                Ok(state) => state,
-                Err(e) => {
-                    tracing::warn!("debounce skipped (state lock poisoned): {e}");
-                    continue;
-                }
-            };
-            state.can_fire_generation(generation)
-        };
-        if !should_fire {
-            continue;
-        }
-
         // Timer expired — fire trigger with bounded-block support.
         //
         // Phase 1: run suggest_sync under the handler lock and paint sync-only
@@ -1375,6 +1432,26 @@ async fn debounce_loop(
         // the channel receiver and sync geometry.
         let mut render_buf = Vec::new();
         let (prepared, render_ticket) = {
+            let _snapshot_guard = match trigger_snapshot_gate.lock() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    tracing::warn!("debounce skipped (trigger snapshot gate poisoned): {e}");
+                    continue;
+                }
+            };
+            let should_fire = {
+                let state = match debounce_state.lock() {
+                    Ok(state) => state,
+                    Err(e) => {
+                        tracing::warn!("debounce skipped (state lock poisoned): {e}");
+                        continue;
+                    }
+                };
+                state.can_fire_generation(generation)
+            };
+            if !should_fire {
+                continue;
+            }
             let mut h = match handler.lock() {
                 Ok(h) => h,
                 Err(e) => {
@@ -1805,6 +1882,75 @@ mod tests {
     }
 
     #[test]
+    fn pty_read_records_buffer_generation_when_report_updates_parser() {
+        let mut parser = TerminalParser::new(24, 80);
+        let mut display_epoch = 0;
+        let mut next_generation = 0;
+        let events = process_pty_read(
+            &mut parser,
+            b"\x1b]7770;4;git \x07",
+            &mut display_epoch,
+            || {
+                next_generation += 1;
+                next_generation
+            },
+        );
+
+        assert_eq!(events.latest_buffer_epoch, Some(display_epoch));
+        assert_eq!(events.latest_buffer_generation, Some(1));
+        assert_eq!(next_generation, 1);
+        assert!(!parser.state_mut().take_buffer_dirty());
+    }
+
+    #[test]
+    fn cwd_dirty_defers_after_ignored_undisplayed_buffer_report() {
+        let mut deferred = None;
+        let mut debounce_state = DebounceState::default();
+        let prior_generation = debounce_state.next_buffer_generation();
+        debounce_state.notify_generation(prior_generation);
+        assert!(debounce_state.can_fire_generation(prior_generation));
+
+        let current_generation = debounce_state.next_buffer_generation();
+        assert_eq!(
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                4,
+                current_generation,
+                BufferDirtyAction::Ignore,
+            ),
+            ResolvedBufferDirtyAction::None
+        );
+        assert_eq!(deferred, None);
+
+        assert!(defer_cwd_trigger_until_buffer_display(
+            &mut deferred,
+            &mut debounce_state,
+            Some(4),
+            Some(current_generation),
+            4,
+        ));
+        assert_eq!(
+            deferred,
+            Some(DeferredBufferDirty {
+                action: DeferredBufferDirtyAction::TriggerNow,
+                display_epoch: 4,
+                generation: current_generation,
+            })
+        );
+        assert!(!debounce_state.can_fire_generation(prior_generation));
+
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 4, true, false),
+            ResolvedBufferDirtyAction::None
+        );
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 5, true, false),
+            ResolvedBufferDirtyAction::Trigger
+        );
+    }
+
+    #[test]
     fn cwd_dirty_upgrades_pending_deferred_buffer_to_trigger_after_redraw() {
         let generation = 2;
         let mut deferred = Some(DeferredBufferDirty {
@@ -1818,7 +1964,13 @@ mod tests {
             deferred_generation: Some(generation),
         };
 
-        assert!(defer_cwd_trigger_until_buffer_display(&mut deferred));
+        assert!(defer_cwd_trigger_until_buffer_display(
+            &mut deferred,
+            &mut debounce_state,
+            None,
+            None,
+            4,
+        ));
         assert_eq!(
             deferred.map(|pending| pending.action),
             Some(DeferredBufferDirtyAction::TriggerNow)
@@ -1881,7 +2033,12 @@ mod tests {
     fn pty_read_tracks_display_epoch_before_latest_buffer_report() {
         let mut parser = TerminalParser::new(24, 80);
         let mut display_epoch = 0;
-        let events = process_pty_read(&mut parser, b"x\x1b]7770;4;git \x07", &mut display_epoch);
+        let events = process_pty_read(
+            &mut parser,
+            b"x\x1b]7770;4;git \x07",
+            &mut display_epoch,
+            || 1,
+        );
 
         assert!(events.display_dirty);
         assert_eq!(events.latest_buffer_epoch, Some(display_epoch));
@@ -1895,7 +2052,12 @@ mod tests {
     fn pty_read_tracks_display_epoch_after_latest_buffer_report() {
         let mut parser = TerminalParser::new(24, 80);
         let mut display_epoch = 0;
-        let events = process_pty_read(&mut parser, b"\x1b]7770;4;git \x07x", &mut display_epoch);
+        let events = process_pty_read(
+            &mut parser,
+            b"\x1b]7770;4;git \x07x",
+            &mut display_epoch,
+            || 1,
+        );
 
         assert!(events.display_dirty);
         assert!(display_epoch > events.latest_buffer_epoch.unwrap());
@@ -1909,6 +2071,7 @@ mod tests {
             &mut parser,
             b"\x1b]7770;4;git \x07x\x1b]7770;5;git s\x07",
             &mut display_epoch,
+            || 1,
         );
 
         assert!(events.display_dirty);
@@ -1925,6 +2088,7 @@ mod tests {
             &mut parser,
             b"\x1b]7770;4;git \x07x\x1b]7770;5;git s\x07y",
             &mut display_epoch,
+            || 1,
         );
 
         assert!(events.display_dirty);

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -483,6 +483,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let debounce_notify_b = Arc::clone(&debounce_notify);
     let stdout_handle = tokio::task::spawn_blocking(move || {
         let mut buf = [0u8; 8192];
+        let mut deferred_trigger_after_redraw = false;
         loop {
             let n = match reader.read(&mut buf) {
                 Ok(0) => break, // PTY closed
@@ -607,6 +608,8 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
+            let display_changed = display_dirty || viewport_scrolls > 0;
+
             // Check if shell reported a buffer update via OSC 7770.
             // Trigger suggestions here (Task B) instead of Task A to ensure
             // we have the shell's updated buffer, fixing the stale-buffer bug.
@@ -631,20 +634,29 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         }
                     };
                     let had_pending_trigger = h.has_pending_trigger();
-                    let action = buffer_dirty_action(
-                        had_pending_trigger,
-                        delay_ms,
-                        h.auto_trigger_enabled(),
-                        h.is_debounce_suppressed(),
-                    );
+                    let action = if deferred_trigger_after_redraw && display_changed {
+                        BufferDirtyAction::Ignore
+                    } else {
+                        buffer_dirty_action(
+                            had_pending_trigger,
+                            delay_ms,
+                            h.auto_trigger_enabled(),
+                            h.is_debounce_suppressed(),
+                            display_changed,
+                        )
+                    };
                     if had_pending_trigger {
                         h.clear_trigger_request();
                     }
                     match action {
                         BufferDirtyAction::Trigger => {
+                            deferred_trigger_after_redraw = false;
                             h.trigger(&parser_for_stdout, &mut render_buf)
                         }
                         BufferDirtyAction::Debounce => debounce_notify_b.notify_one(),
+                        BufferDirtyAction::DeferUntilDisplay => {
+                            deferred_trigger_after_redraw = true;
+                        }
                         BufferDirtyAction::Ignore => {}
                     }
                     h.overlay_write_ticket()
@@ -654,6 +666,32 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         write_overlay_if_current(&handler_for_stdout, render_ticket, &render_buf)
                     {
                         tracing::debug!("Task B overlay write/flush failed: {e}");
+                        break;
+                    }
+                }
+            }
+
+            if deferred_trigger_after_redraw && display_changed {
+                let mut render_buf = Vec::new();
+                let render_ticket = {
+                    let mut h = match handler_for_stdout.lock() {
+                        Ok(h) => h,
+                        Err(e) => {
+                            tracing::warn!("handler mutex poisoned in stdout task: {e}");
+                            break;
+                        }
+                    };
+                    deferred_trigger_after_redraw = false;
+                    if h.auto_trigger_enabled() {
+                        h.trigger(&parser_for_stdout, &mut render_buf);
+                    }
+                    h.overlay_write_ticket()
+                };
+                if !render_buf.is_empty() {
+                    if let Err(e) =
+                        write_overlay_if_current(&handler_for_stdout, render_ticket, &render_buf)
+                    {
+                        tracing::debug!("Task B deferred overlay write/flush failed: {e}");
                         break;
                     }
                 }
@@ -917,6 +955,7 @@ fn poll_until(
 enum BufferDirtyAction {
     Trigger,
     Debounce,
+    DeferUntilDisplay,
     Ignore,
 }
 
@@ -925,9 +964,13 @@ fn buffer_dirty_action(
     delay_ms: u64,
     auto_trigger_enabled: bool,
     debounce_suppressed: bool,
+    display_changed: bool,
 ) -> BufferDirtyAction {
     if !auto_trigger_enabled {
         return BufferDirtyAction::Ignore;
+    }
+    if has_pending_trigger && !display_changed {
+        return BufferDirtyAction::DeferUntilDisplay;
     }
     if has_pending_trigger {
         return BufferDirtyAction::Trigger;
@@ -935,7 +978,9 @@ fn buffer_dirty_action(
     if debounce_suppressed {
         return BufferDirtyAction::Ignore;
     }
-    if delay_ms == 0 {
+    if delay_ms == 0 && !display_changed {
+        BufferDirtyAction::DeferUntilDisplay
+    } else if delay_ms == 0 {
         BufferDirtyAction::Trigger
     } else {
         BufferDirtyAction::Debounce
@@ -1302,15 +1347,23 @@ mod tests {
     #[test]
     fn buffer_dirty_action_triggers_immediately_when_delay_zero() {
         assert_eq!(
-            buffer_dirty_action(false, 0, true, false),
+            buffer_dirty_action(false, 0, true, false, true),
             BufferDirtyAction::Trigger
+        );
+    }
+
+    #[test]
+    fn buffer_dirty_action_defers_delay_zero_until_redraw() {
+        assert_eq!(
+            buffer_dirty_action(false, 0, true, false, false),
+            BufferDirtyAction::DeferUntilDisplay
         );
     }
 
     #[test]
     fn buffer_dirty_action_ignores_when_auto_trigger_disabled() {
         assert_eq!(
-            buffer_dirty_action(false, 0, false, false),
+            buffer_dirty_action(false, 0, false, false, true),
             BufferDirtyAction::Ignore
         );
     }
@@ -1318,7 +1371,7 @@ mod tests {
     #[test]
     fn buffer_dirty_action_ignores_when_debounce_suppressed() {
         assert_eq!(
-            buffer_dirty_action(false, 0, true, true),
+            buffer_dirty_action(false, 0, true, true, true),
             BufferDirtyAction::Ignore
         );
     }
@@ -1326,15 +1379,24 @@ mod tests {
     #[test]
     fn buffer_dirty_action_debounces_when_delay_positive() {
         assert_eq!(
-            buffer_dirty_action(false, 150, true, false),
+            buffer_dirty_action(false, 150, true, false, false),
             BufferDirtyAction::Debounce
         );
     }
 
     #[test]
-    fn buffer_dirty_action_prefers_pending_trigger() {
+    fn buffer_dirty_action_defers_pending_trigger_until_redraw() {
         assert_eq!(
-            buffer_dirty_action(true, 150, true, true),
+            buffer_dirty_action(true, 150, true, true, false),
+            BufferDirtyAction::DeferUntilDisplay,
+            "OSC-only buffer reports must not render before the matching ZLE redraw moves the cursor"
+        );
+    }
+
+    #[test]
+    fn buffer_dirty_action_triggers_pending_after_redraw() {
+        assert_eq!(
+            buffer_dirty_action(true, 150, true, true, true),
             BufferDirtyAction::Trigger
         );
     }

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -711,8 +711,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     apply_buffer_dirty_action(
                         &mut deferred_buffer_dirty,
                         &mut state,
-                        report.display_epoch,
-                        report.generation,
+                        report,
                         action,
                     )
                 };
@@ -1226,6 +1225,11 @@ impl DebounceState {
     fn has_deferred_generation(&self) -> bool {
         self.deferred_generation.is_some()
     }
+
+    #[cfg(test)]
+    fn deferred_generation(&self) -> Option<u64> {
+        self.deferred_generation
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1313,8 +1317,7 @@ fn buffer_dirty_action(
 fn apply_buffer_dirty_action(
     deferred: &mut Option<DeferredBufferDirty>,
     debounce_state: &mut DebounceState,
-    buffer_epoch: u64,
-    buffer_generation: u64,
+    report: BufferReport,
     action: BufferDirtyAction,
 ) -> ResolvedBufferDirtyAction {
     match action {
@@ -1324,16 +1327,16 @@ fn apply_buffer_dirty_action(
         }
         BufferDirtyAction::Debounce => {
             clear_deferred_buffer_dirty(deferred, debounce_state);
-            debounce_state.notify_generation(buffer_generation);
+            debounce_state.notify_generation(report.generation);
             ResolvedBufferDirtyAction::NotifyDebounce
         }
         BufferDirtyAction::DeferUntilDisplay(action) => {
             *deferred = Some(DeferredBufferDirty {
                 action,
-                display_epoch: buffer_epoch,
-                generation: buffer_generation,
+                display_epoch: report.display_epoch,
+                generation: report.generation,
             });
-            debounce_state.defer_generation(buffer_generation);
+            debounce_state.defer_generation(report.generation);
             ResolvedBufferDirtyAction::NoOp
         }
         BufferDirtyAction::Ignore => {
@@ -1963,7 +1966,15 @@ mod tests {
 
         let action = buffer_dirty_action(false, 150, true, true, false);
         assert_eq!(
-            apply_buffer_dirty_action(&mut deferred, &mut debounce_state, 3, 1, action),
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                BufferReport {
+                    display_epoch: 3,
+                    generation: 1,
+                },
+                action,
+            ),
             ResolvedBufferDirtyAction::NoOp
         );
         assert_eq!(deferred, None);
@@ -1981,7 +1992,15 @@ mod tests {
         let action = buffer_dirty_action(false, 150, true, false, false);
 
         assert_eq!(
-            apply_buffer_dirty_action(&mut deferred, &mut debounce_state, 8, generation, action),
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                BufferReport {
+                    display_epoch: 8,
+                    generation,
+                },
+                action,
+            ),
             ResolvedBufferDirtyAction::NoOp
         );
         assert_eq!(
@@ -2014,8 +2033,10 @@ mod tests {
             apply_buffer_dirty_action(
                 &mut deferred,
                 &mut debounce_state,
-                3,
-                first_generation,
+                BufferReport {
+                    display_epoch: 3,
+                    generation: first_generation,
+                },
                 BufferDirtyAction::Debounce,
             ),
             ResolvedBufferDirtyAction::NotifyDebounce
@@ -2027,8 +2048,10 @@ mod tests {
             apply_buffer_dirty_action(
                 &mut deferred,
                 &mut debounce_state,
-                4,
-                second_generation,
+                BufferReport {
+                    display_epoch: 4,
+                    generation: second_generation,
+                },
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
             ),
             ResolvedBufferDirtyAction::NoOp
@@ -2074,8 +2097,10 @@ mod tests {
             apply_buffer_dirty_action(
                 &mut deferred,
                 &mut debounce_state,
-                4,
-                second_generation,
+                BufferReport {
+                    display_epoch: 4,
+                    generation: second_generation,
+                },
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
             ),
             ResolvedBufferDirtyAction::NoOp
@@ -2112,8 +2137,10 @@ mod tests {
             apply_buffer_dirty_action(
                 &mut deferred,
                 &mut debounce_state,
-                4,
-                generation,
+                BufferReport {
+                    display_epoch: 4,
+                    generation,
+                },
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow),
             ),
             ResolvedBufferDirtyAction::NoOp
@@ -2137,8 +2164,10 @@ mod tests {
             apply_buffer_dirty_action(
                 &mut deferred,
                 &mut debounce_state,
-                4,
-                generation,
+                BufferReport {
+                    display_epoch: 4,
+                    generation,
+                },
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
             ),
             ResolvedBufferDirtyAction::NoOp
@@ -2188,8 +2217,10 @@ mod tests {
             apply_buffer_dirty_action(
                 &mut deferred,
                 &mut debounce_state,
-                3,
-                first_generation,
+                BufferReport {
+                    display_epoch: 3,
+                    generation: first_generation,
+                },
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow),
             ),
             ResolvedBufferDirtyAction::NoOp
@@ -2200,8 +2231,10 @@ mod tests {
             apply_buffer_dirty_action(
                 &mut deferred,
                 &mut debounce_state,
-                3,
-                second_generation,
+                BufferReport {
+                    display_epoch: 3,
+                    generation: second_generation,
+                },
                 BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
             ),
             ResolvedBufferDirtyAction::NoOp
@@ -2214,7 +2247,10 @@ mod tests {
                 generation: second_generation,
             })
         );
-        assert_eq!(debounce_state.deferred_generation, Some(second_generation));
+        assert_eq!(
+            debounce_state.deferred_generation(),
+            Some(second_generation)
+        );
 
         assert_eq!(
             resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 4, true, false),
@@ -2264,8 +2300,10 @@ mod tests {
             apply_buffer_dirty_action(
                 &mut deferred,
                 &mut debounce_state,
-                4,
-                current_generation,
+                BufferReport {
+                    display_epoch: 4,
+                    generation: current_generation,
+                },
                 BufferDirtyAction::Ignore,
             ),
             ResolvedBufferDirtyAction::NoOp
@@ -2409,7 +2447,15 @@ mod tests {
         let action = buffer_dirty_action(true, 150, true, false, true);
 
         assert_eq!(
-            apply_buffer_dirty_action(&mut deferred, &mut debounce_state, 2, 2, action),
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                BufferReport {
+                    display_epoch: 2,
+                    generation: 2,
+                },
+                action,
+            ),
             ResolvedBufferDirtyAction::Trigger
         );
         assert_eq!(deferred, None);

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -219,14 +219,16 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
 
     // Debounce task: fires suggestions after a typing pause
     let debounce_notify = Arc::new(Notify::new());
+    let debounce_state = Arc::new(Mutex::new(DebounceState::default()));
     let delay_ms = config.trigger.delay_ms;
 
     let debounce_handle = if delay_ms > 0 {
         let notify = Arc::clone(&debounce_notify);
+        let debounce_state_d = Arc::clone(&debounce_state);
         let handler_d = Arc::clone(&handler);
         let parser_d = Arc::clone(&parser);
         Some(tokio::spawn(async move {
-            debounce_loop(notify, handler_d, parser_d, delay_ms).await;
+            debounce_loop(notify, debounce_state_d, handler_d, parser_d, delay_ms).await;
         }))
     } else {
         None
@@ -481,6 +483,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let parser_for_stdout = Arc::clone(&parser);
     let handler_for_stdout = Arc::clone(&handler);
     let debounce_notify_b = Arc::clone(&debounce_notify);
+    let debounce_state_b = Arc::clone(&debounce_state);
     let stdout_handle = tokio::task::spawn_blocking(move || {
         let mut buf = [0u8; 8192];
         let mut display_epoch = 0_u64;
@@ -609,13 +612,22 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            // Check if shell reported a buffer update via OSC 7770.
-            // Trigger suggestions here (Task B) instead of Task A to ensure
-            // we have the shell's updated buffer, fixing the stale-buffer bug.
+            // Handle shell buffer updates in Task B instead of Task A so trigger/debounce
+            // decisions see the parser's updated buffer. OSC-only reports may be deferred
+            // until a later display epoch to avoid rendering before the terminal redraws.
             if let Some(latest_buffer_epoch) = latest_buffer_epoch {
+                let buffer_generation = {
+                    let mut state = match debounce_state_b.lock() {
+                        Ok(state) => state,
+                        Err(e) => {
+                            tracing::warn!("debounce state mutex poisoned in stdout task: {e}");
+                            break;
+                        }
+                    };
+                    state.next_buffer_generation()
+                };
                 let display_after_latest_buffer = display_epoch > latest_buffer_epoch;
-                let mut render_buf = Vec::new();
-                let render_ticket = {
+                let action = {
                     let mut h = match handler_for_stdout.lock() {
                         Ok(h) => h,
                         Err(e) => {
@@ -634,60 +646,111 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     if had_pending_trigger {
                         h.clear_trigger_request();
                     }
-                    match apply_buffer_dirty_action(
-                        &mut deferred_buffer_dirty,
-                        latest_buffer_epoch,
-                        action,
-                    ) {
-                        ResolvedBufferDirtyAction::Trigger => {
-                            h.trigger(&parser_for_stdout, &mut render_buf)
-                        }
-                        ResolvedBufferDirtyAction::NotifyDebounce => debounce_notify_b.notify_one(),
-                        ResolvedBufferDirtyAction::None => {}
-                    }
-                    h.overlay_write_ticket()
+                    action
                 };
-                if !render_buf.is_empty() {
-                    if let Err(e) =
-                        write_overlay_if_current(&handler_for_stdout, render_ticket, &render_buf)
-                    {
-                        tracing::debug!("Task B overlay write/flush failed: {e}");
-                        break;
+
+                let resolved_action = {
+                    let mut state = match debounce_state_b.lock() {
+                        Ok(state) => state,
+                        Err(e) => {
+                            tracing::warn!("debounce state mutex poisoned in stdout task: {e}");
+                            break;
+                        }
+                    };
+                    apply_buffer_dirty_action(
+                        &mut deferred_buffer_dirty,
+                        &mut state,
+                        latest_buffer_epoch,
+                        buffer_generation,
+                        action,
+                    )
+                };
+
+                match resolved_action {
+                    ResolvedBufferDirtyAction::Trigger => {
+                        let mut render_buf = Vec::new();
+                        let render_ticket = {
+                            let mut h = match handler_for_stdout.lock() {
+                                Ok(h) => h,
+                                Err(e) => {
+                                    tracing::warn!("handler mutex poisoned in stdout task: {e}");
+                                    break;
+                                }
+                            };
+                            h.trigger(&parser_for_stdout, &mut render_buf);
+                            h.overlay_write_ticket()
+                        };
+                        if !render_buf.is_empty() {
+                            if let Err(e) = write_overlay_if_current(
+                                &handler_for_stdout,
+                                render_ticket,
+                                &render_buf,
+                            ) {
+                                tracing::debug!("Task B overlay write/flush failed: {e}");
+                                break;
+                            }
+                        }
                     }
+                    ResolvedBufferDirtyAction::NotifyDebounce => debounce_notify_b.notify_one(),
+                    ResolvedBufferDirtyAction::None => {}
                 }
             }
 
             if deferred_buffer_dirty.is_some_and(|pending| display_epoch > pending.display_epoch) {
-                let mut render_buf = Vec::new();
-                let render_ticket = {
-                    let mut h = match handler_for_stdout.lock() {
+                let (auto_trigger_enabled, debounce_suppressed) = {
+                    let h = match handler_for_stdout.lock() {
                         Ok(h) => h,
                         Err(e) => {
                             tracing::warn!("handler mutex poisoned in stdout task: {e}");
                             break;
                         }
                     };
-                    match resolve_deferred_buffer_dirty(
-                        &mut deferred_buffer_dirty,
-                        display_epoch,
-                        h.auto_trigger_enabled(),
-                        h.is_debounce_suppressed(),
-                    ) {
-                        ResolvedBufferDirtyAction::Trigger => {
-                            h.trigger(&parser_for_stdout, &mut render_buf);
-                        }
-                        ResolvedBufferDirtyAction::NotifyDebounce => debounce_notify_b.notify_one(),
-                        ResolvedBufferDirtyAction::None => {}
-                    }
-                    h.overlay_write_ticket()
+                    (h.auto_trigger_enabled(), h.is_debounce_suppressed())
                 };
-                if !render_buf.is_empty() {
-                    if let Err(e) =
-                        write_overlay_if_current(&handler_for_stdout, render_ticket, &render_buf)
-                    {
-                        tracing::debug!("Task B deferred overlay write/flush failed: {e}");
-                        break;
+                let resolved_action = {
+                    let mut state = match debounce_state_b.lock() {
+                        Ok(state) => state,
+                        Err(e) => {
+                            tracing::warn!("debounce state mutex poisoned in stdout task: {e}");
+                            break;
+                        }
+                    };
+                    resolve_deferred_buffer_dirty(
+                        &mut deferred_buffer_dirty,
+                        &mut state,
+                        display_epoch,
+                        auto_trigger_enabled,
+                        debounce_suppressed,
+                    )
+                };
+
+                match resolved_action {
+                    ResolvedBufferDirtyAction::Trigger => {
+                        let mut render_buf = Vec::new();
+                        let render_ticket = {
+                            let mut h = match handler_for_stdout.lock() {
+                                Ok(h) => h,
+                                Err(e) => {
+                                    tracing::warn!("handler mutex poisoned in stdout task: {e}");
+                                    break;
+                                }
+                            };
+                            h.trigger(&parser_for_stdout, &mut render_buf);
+                            h.overlay_write_ticket()
+                        };
+                        if !render_buf.is_empty() {
+                            if let Err(e) = write_overlay_if_current(
+                                &handler_for_stdout,
+                                render_ticket,
+                                &render_buf,
+                            ) {
+                                tracing::debug!("Task B deferred overlay write/flush failed: {e}");
+                                break;
+                            }
+                        }
                     }
+                    ResolvedBufferDirtyAction::NotifyDebounce => debounce_notify_b.notify_one(),
+                    ResolvedBufferDirtyAction::None => {}
                 }
             }
 
@@ -703,26 +766,40 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
             };
 
             if cwd_dirty {
-                let mut render_buf = Vec::new();
-                let render_ticket = {
-                    let mut h = match handler_for_stdout.lock() {
+                let auto_trigger_enabled = {
+                    let h = match handler_for_stdout.lock() {
                         Ok(h) => h,
                         Err(e) => {
                             tracing::warn!("handler mutex poisoned in stdout task: {e}");
                             break;
                         }
                     };
-                    if h.auto_trigger_enabled() {
-                        h.trigger(&parser_for_stdout, &mut render_buf);
-                    }
-                    h.overlay_write_ticket()
+                    h.auto_trigger_enabled()
                 };
-                if !render_buf.is_empty() {
-                    if let Err(e) =
-                        write_overlay_if_current(&handler_for_stdout, render_ticket, &render_buf)
-                    {
-                        tracing::debug!("Task B overlay write/flush failed: {e}");
-                        break;
+                let cwd_deferred = auto_trigger_enabled
+                    && defer_cwd_trigger_until_buffer_display(&mut deferred_buffer_dirty);
+                if auto_trigger_enabled && !cwd_deferred {
+                    let mut render_buf = Vec::new();
+                    let render_ticket = {
+                        let mut h = match handler_for_stdout.lock() {
+                            Ok(h) => h,
+                            Err(e) => {
+                                tracing::warn!("handler mutex poisoned in stdout task: {e}");
+                                break;
+                            }
+                        };
+                        h.trigger(&parser_for_stdout, &mut render_buf);
+                        h.overlay_write_ticket()
+                    };
+                    if !render_buf.is_empty() {
+                        if let Err(e) = write_overlay_if_current(
+                            &handler_for_stdout,
+                            render_ticket,
+                            &render_buf,
+                        ) {
+                            tracing::debug!("Task B overlay write/flush failed: {e}");
+                            break;
+                        }
                     }
                 }
             }
@@ -986,10 +1063,52 @@ enum DeferredBufferDirtyAction {
     NotifyDebounce,
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct DebounceState {
+    current_generation: u64,
+    notified_generation: Option<u64>,
+    deferred_generation: Option<u64>,
+}
+
+impl DebounceState {
+    fn next_buffer_generation(&mut self) -> u64 {
+        self.current_generation += 1;
+        self.current_generation
+    }
+
+    fn notify_generation(&mut self, generation: u64) {
+        self.notified_generation = Some(generation);
+        if self.deferred_generation == Some(generation) {
+            self.deferred_generation = None;
+        }
+    }
+
+    fn defer_generation(&mut self, generation: u64) {
+        self.deferred_generation = Some(generation);
+    }
+
+    fn clear_deferred_generation(&mut self, generation: u64) {
+        if self.deferred_generation == Some(generation) {
+            self.deferred_generation = None;
+        }
+    }
+
+    fn latest_notified_generation(&self) -> Option<u64> {
+        self.notified_generation
+    }
+
+    fn can_fire_generation(&self, generation: u64) -> bool {
+        self.current_generation == generation
+            && self.notified_generation == Some(generation)
+            && self.deferred_generation.is_none()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DeferredBufferDirty {
     action: DeferredBufferDirtyAction,
     display_epoch: u64,
+    generation: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1039,34 +1158,57 @@ fn buffer_dirty_action(
 
 fn apply_buffer_dirty_action(
     deferred: &mut Option<DeferredBufferDirty>,
+    debounce_state: &mut DebounceState,
     buffer_epoch: u64,
+    buffer_generation: u64,
     action: BufferDirtyAction,
 ) -> ResolvedBufferDirtyAction {
     match action {
         BufferDirtyAction::Trigger => {
-            *deferred = None;
+            clear_deferred_buffer_dirty(deferred, debounce_state);
             ResolvedBufferDirtyAction::Trigger
         }
         BufferDirtyAction::Debounce => {
-            *deferred = None;
+            clear_deferred_buffer_dirty(deferred, debounce_state);
+            debounce_state.notify_generation(buffer_generation);
             ResolvedBufferDirtyAction::NotifyDebounce
         }
         BufferDirtyAction::DeferUntilDisplay(action) => {
             *deferred = Some(DeferredBufferDirty {
                 action,
                 display_epoch: buffer_epoch,
+                generation: buffer_generation,
             });
+            debounce_state.defer_generation(buffer_generation);
             ResolvedBufferDirtyAction::None
         }
         BufferDirtyAction::Ignore => {
-            *deferred = None;
+            clear_deferred_buffer_dirty(deferred, debounce_state);
             ResolvedBufferDirtyAction::None
         }
     }
 }
 
+fn clear_deferred_buffer_dirty(
+    deferred: &mut Option<DeferredBufferDirty>,
+    debounce_state: &mut DebounceState,
+) {
+    if let Some(pending) = deferred.take() {
+        debounce_state.clear_deferred_generation(pending.generation);
+    }
+}
+
+fn defer_cwd_trigger_until_buffer_display(deferred: &mut Option<DeferredBufferDirty>) -> bool {
+    let Some(pending) = deferred.as_mut() else {
+        return false;
+    };
+    pending.action = DeferredBufferDirtyAction::TriggerNow;
+    true
+}
+
 fn resolve_deferred_buffer_dirty(
     deferred: &mut Option<DeferredBufferDirty>,
+    debounce_state: &mut DebounceState,
     display_epoch: u64,
     auto_trigger_enabled: bool,
     debounce_suppressed: bool,
@@ -1079,6 +1221,7 @@ fn resolve_deferred_buffer_dirty(
     }
 
     *deferred = None;
+    debounce_state.clear_deferred_generation(pending.generation);
     match pending.action {
         DeferredBufferDirtyAction::TriggerNow => {
             if auto_trigger_enabled {
@@ -1089,6 +1232,7 @@ fn resolve_deferred_buffer_dirty(
         }
         DeferredBufferDirtyAction::NotifyDebounce => {
             if auto_trigger_enabled && !debounce_suppressed {
+                debounce_state.notify_generation(pending.generation);
                 ResolvedBufferDirtyAction::NotifyDebounce
             } else {
                 ResolvedBufferDirtyAction::None
@@ -1167,6 +1311,7 @@ fn write_overlay_if_current(
 /// new notification, and fires suggestions once the timer expires (typing pause).
 async fn debounce_loop(
     notify: Arc<Notify>,
+    debounce_state: Arc<Mutex<DebounceState>>,
     handler: Arc<Mutex<InputHandler>>,
     parser: Arc<Mutex<TerminalParser>>,
     delay_ms: u64,
@@ -1175,13 +1320,51 @@ async fn debounce_loop(
     loop {
         // Wait for first buffer change notification
         notify.notified().await;
+        let mut generation = {
+            let state = match debounce_state.lock() {
+                Ok(state) => state,
+                Err(e) => {
+                    tracing::warn!("debounce skipped (state lock poisoned): {e}");
+                    continue;
+                }
+            };
+            match state.latest_notified_generation() {
+                Some(generation) => generation,
+                None => continue,
+            }
+        };
 
         // Debounce: reset timer on every new notification
         loop {
             tokio::select! {
-                _ = notify.notified() => { continue; }
+                _ = notify.notified() => {
+                    let state = match debounce_state.lock() {
+                        Ok(state) => state,
+                        Err(e) => {
+                            tracing::warn!("debounce skipped (state lock poisoned): {e}");
+                            break;
+                        }
+                    };
+                    if let Some(next_generation) = state.latest_notified_generation() {
+                        generation = next_generation;
+                    }
+                    continue;
+                }
                 _ = tokio::time::sleep(delay) => { break; }
             }
+        }
+        let should_fire = {
+            let state = match debounce_state.lock() {
+                Ok(state) => state,
+                Err(e) => {
+                    tracing::warn!("debounce skipped (state lock poisoned): {e}");
+                    continue;
+                }
+            };
+            state.can_fire_generation(generation)
+        };
+        if !should_fire {
+            continue;
         }
 
         // Timer expired — fire trigger with bounded-block support.
@@ -1507,7 +1690,7 @@ mod tests {
         assert_eq!(
             buffer_dirty_action(true, 150, true, true, false),
             BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::TriggerNow),
-            "OSC-only buffer reports must not render before the matching ZLE redraw moves the cursor"
+            "OSC-only buffer reports must not render before a later display epoch advances after the report"
         );
     }
 
@@ -1524,16 +1707,22 @@ mod tests {
         let mut deferred = Some(DeferredBufferDirty {
             action: DeferredBufferDirtyAction::TriggerNow,
             display_epoch: 3,
+            generation: 1,
         });
+        let mut debounce_state = DebounceState {
+            current_generation: 1,
+            notified_generation: None,
+            deferred_generation: Some(1),
+        };
 
         let action = buffer_dirty_action(false, 150, true, true, false);
         assert_eq!(
-            apply_buffer_dirty_action(&mut deferred, 3, action),
+            apply_buffer_dirty_action(&mut deferred, &mut debounce_state, 3, 1, action),
             ResolvedBufferDirtyAction::None
         );
         assert_eq!(deferred, None);
         assert_eq!(
-            resolve_deferred_buffer_dirty(&mut deferred, 4, true, true),
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 4, true, true),
             ResolvedBufferDirtyAction::None
         );
     }
@@ -1541,10 +1730,12 @@ mod tests {
     #[test]
     fn deferred_debounce_notifies_only_after_later_display() {
         let mut deferred = None;
+        let mut debounce_state = DebounceState::default();
+        let generation = debounce_state.next_buffer_generation();
         let action = buffer_dirty_action(false, 150, true, false, false);
 
         assert_eq!(
-            apply_buffer_dirty_action(&mut deferred, 8, action),
+            apply_buffer_dirty_action(&mut deferred, &mut debounce_state, 8, generation, action),
             ResolvedBufferDirtyAction::None
         );
         assert_eq!(
@@ -1552,17 +1743,93 @@ mod tests {
             Some(DeferredBufferDirty {
                 action: DeferredBufferDirtyAction::NotifyDebounce,
                 display_epoch: 8,
+                generation,
             })
         );
         assert_eq!(
-            resolve_deferred_buffer_dirty(&mut deferred, 8, true, false),
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 8, true, false),
             ResolvedBufferDirtyAction::None
         );
         assert_eq!(
-            resolve_deferred_buffer_dirty(&mut deferred, 9, true, false),
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 9, true, false),
             ResolvedBufferDirtyAction::NotifyDebounce
         );
         assert_eq!(deferred, None);
+        assert!(debounce_state.can_fire_generation(generation));
+    }
+
+    #[test]
+    fn deferred_debounce_generation_blocks_prior_timer_until_redraw() {
+        let mut deferred = None;
+        let mut debounce_state = DebounceState::default();
+
+        let first_generation = debounce_state.next_buffer_generation();
+        assert_eq!(
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                3,
+                first_generation,
+                BufferDirtyAction::Debounce,
+            ),
+            ResolvedBufferDirtyAction::NotifyDebounce
+        );
+        assert!(debounce_state.can_fire_generation(first_generation));
+
+        let second_generation = debounce_state.next_buffer_generation();
+        assert_eq!(
+            apply_buffer_dirty_action(
+                &mut deferred,
+                &mut debounce_state,
+                4,
+                second_generation,
+                BufferDirtyAction::DeferUntilDisplay(DeferredBufferDirtyAction::NotifyDebounce),
+            ),
+            ResolvedBufferDirtyAction::None
+        );
+        assert!(!debounce_state.can_fire_generation(first_generation));
+        assert!(!debounce_state.can_fire_generation(second_generation));
+
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 4, true, false),
+            ResolvedBufferDirtyAction::None
+        );
+        assert!(!debounce_state.can_fire_generation(first_generation));
+
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 5, true, false),
+            ResolvedBufferDirtyAction::NotifyDebounce
+        );
+        assert!(!debounce_state.can_fire_generation(first_generation));
+        assert!(debounce_state.can_fire_generation(second_generation));
+    }
+
+    #[test]
+    fn cwd_dirty_upgrades_pending_deferred_buffer_to_trigger_after_redraw() {
+        let generation = 2;
+        let mut deferred = Some(DeferredBufferDirty {
+            action: DeferredBufferDirtyAction::NotifyDebounce,
+            display_epoch: 4,
+            generation,
+        });
+        let mut debounce_state = DebounceState {
+            current_generation: generation,
+            notified_generation: Some(1),
+            deferred_generation: Some(generation),
+        };
+
+        assert!(defer_cwd_trigger_until_buffer_display(&mut deferred));
+        assert_eq!(
+            deferred.map(|pending| pending.action),
+            Some(DeferredBufferDirtyAction::TriggerNow)
+        );
+        assert!(!debounce_state.can_fire_generation(1));
+        assert_eq!(
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 5, true, false),
+            ResolvedBufferDirtyAction::Trigger
+        );
+        assert_eq!(deferred, None);
+        assert!(!debounce_state.can_fire_generation(1));
     }
 
     #[test]
@@ -1570,10 +1837,16 @@ mod tests {
         let mut deferred = Some(DeferredBufferDirty {
             action: DeferredBufferDirtyAction::NotifyDebounce,
             display_epoch: 4,
+            generation: 1,
         });
+        let mut debounce_state = DebounceState {
+            current_generation: 1,
+            notified_generation: None,
+            deferred_generation: Some(1),
+        };
 
         assert_eq!(
-            resolve_deferred_buffer_dirty(&mut deferred, 5, true, true),
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 5, true, true),
             ResolvedBufferDirtyAction::None
         );
         assert_eq!(deferred, None);
@@ -1584,16 +1857,22 @@ mod tests {
         let mut deferred = Some(DeferredBufferDirty {
             action: DeferredBufferDirtyAction::TriggerNow,
             display_epoch: 1,
+            generation: 1,
         });
+        let mut debounce_state = DebounceState {
+            current_generation: 2,
+            notified_generation: None,
+            deferred_generation: Some(1),
+        };
         let action = buffer_dirty_action(true, 150, true, false, true);
 
         assert_eq!(
-            apply_buffer_dirty_action(&mut deferred, 2, action),
+            apply_buffer_dirty_action(&mut deferred, &mut debounce_state, 2, 2, action),
             ResolvedBufferDirtyAction::Trigger
         );
         assert_eq!(deferred, None);
         assert_eq!(
-            resolve_deferred_buffer_dirty(&mut deferred, 2, true, false),
+            resolve_deferred_buffer_dirty(&mut deferred, &mut debounce_state, 2, true, false),
             ResolvedBufferDirtyAction::None
         );
     }
@@ -1619,6 +1898,38 @@ mod tests {
         let events = process_pty_read(&mut parser, b"\x1b]7770;4;git \x07x", &mut display_epoch);
 
         assert!(events.display_dirty);
+        assert!(display_epoch > events.latest_buffer_epoch.unwrap());
+    }
+
+    #[test]
+    fn pty_read_uses_latest_buffer_epoch_when_reports_coalesce() {
+        let mut parser = TerminalParser::new(24, 80);
+        let mut display_epoch = 0;
+        let events = process_pty_read(
+            &mut parser,
+            b"\x1b]7770;4;git \x07x\x1b]7770;5;git s\x07",
+            &mut display_epoch,
+        );
+
+        assert!(events.display_dirty);
+        assert_eq!(display_epoch, 1);
+        assert_eq!(events.latest_buffer_epoch, Some(1));
+        assert!(display_epoch <= events.latest_buffer_epoch.unwrap());
+    }
+
+    #[test]
+    fn pty_read_allows_display_after_latest_coalesced_buffer_report() {
+        let mut parser = TerminalParser::new(24, 80);
+        let mut display_epoch = 0;
+        let events = process_pty_read(
+            &mut parser,
+            b"\x1b]7770;4;git \x07x\x1b]7770;5;git s\x07y",
+            &mut display_epoch,
+        );
+
+        assert!(events.display_dirty);
+        assert_eq!(display_epoch, 2);
+        assert_eq!(events.latest_buffer_epoch, Some(1));
         assert!(display_epoch > events.latest_buffer_epoch.unwrap());
     }
 

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -12,8 +12,9 @@ const POPUP_RENDER_MARKER: &[u8] = b"\x1b7";
 const POPUP_RESTORE_MARKER: &[u8] = b"\x1b8";
 const REDRAW_MARKER: &[u8] = b"@";
 const NO_POPUP_BEFORE_REDRAW_TIMEOUT: Duration = Duration::from_millis(500);
-const NO_POPUP_DURING_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(300);
 const OSC_ONLY_DEBOUNCE_DELAY_MS: u64 = 1000;
+const NO_POPUP_DURING_DEBOUNCE_TIMEOUT: Duration =
+    Duration::from_millis(OSC_ONLY_DEBOUNCE_DELAY_MS - 100);
 
 trait PopupSmokeProcess {
     fn wait_for_bytes_after(&self, needle: &[u8], start_offset: usize, timeout: Duration) -> bool;
@@ -497,18 +498,20 @@ fn test_multiple_commands() {
 ///   `buffer_dirty = true`, which Task B (stdout -> terminal loop) notices.
 ///   OSC-only reports are intentionally deferred until later display output
 ///   proves the terminal has advanced/redrawn after the report.
-/// - No manual Ctrl+/ is needed in this test; emitting an OSC buffer report
-///   directly exercises Task B's auto-trigger/debounce path. zsh production
-///   integration uses OSC 7772 from zle-line-pre-redraw, while OSC 7770
-///   remains accepted for legacy compatibility and is convenient for this
-///   smoke harness.
+/// - No manual Ctrl+/ is needed in this test. The typed shell command around
+///   the OSC report contains literal default trigger characters, so it can
+///   leave a pending trigger before the shell emits the OSC bytes. The trailing
+///   space in the reported `git ` buffer is shell output consumed by gc-parser;
+///   it is not typed through `InputHandler::process_key_hidden`. The
+///   no-pending debounce test below avoids typed trigger characters and covers
+///   the pure OSC-only dirty-buffer path.
 ///
 /// Assumptions:
 ///   - Embedded `git` spec declares well-known subcommands such as status,
 ///     commit, branch, checkout, clone, and add, and is always embedded via
 ///     include_str!.
-///   - Trigger char ' ' is in the default `auto_chars` list, so the space
-///     at the end of "git " activates the auto-trigger path.
+///   - The OSC payload's trailing space updates parser state only; it is not a
+///     typed auto-trigger character.
 ///   - `clear_popup` emits DECSC (`\x1b7`) followed by blanking writes and
 ///     DECRC (`\x1b8`). DECRC appearing after our ESC mark = dismissed.
 ///   - Default dismiss keybind is ESC (see Keybindings::default()).
@@ -655,6 +658,7 @@ fn test_osc_only_report_without_pending_trigger_waits_for_debounce_after_redraw(
             String::from_utf8_lossy(since_redraw),
         );
     }
+    let redraw_observed_at = Instant::now();
 
     let snapshot_after_redraw = proc.output_snapshot();
     let since_redraw = &snapshot_after_redraw[mark_before_redraw..];
@@ -678,8 +682,12 @@ fn test_osc_only_report_without_pending_trigger_waits_for_debounce_after_redraw(
         let snapshot = proc.output_snapshot();
         let during_debounce = &snapshot[mark_after_redraw..];
         panic!(
-            "OSC-only buffer report rendered before the configured debounce elapsed.\n\
+            "OSC-only buffer report rendered {:?} after redraw observation, before the {:?} \
+             debounce guard elapsed (configured delay: {} ms).\n\
              Bytes during debounce guard ({} bytes, lossy UTF-8):\n{:?}",
+            redraw_observed_at.elapsed(),
+            NO_POPUP_DURING_DEBOUNCE_TIMEOUT,
+            OSC_ONLY_DEBOUNCE_DELAY_MS,
             during_debounce.len(),
             String::from_utf8_lossy(during_debounce),
         );

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -4,6 +4,11 @@ use harness::GhostProcess;
 use std::thread;
 use std::time::Duration;
 
+const OSC_GIT_REPORT: &[u8] = b"\x1b]7770;4;git \x07";
+const POPUP_RENDER_MARKER: &[u8] = b"\x1b7";
+const POPUP_RESTORE_MARKER: &[u8] = b"\x1b8";
+const NO_POPUP_BEFORE_REDRAW_TIMEOUT: Duration = Duration::from_millis(500);
+
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     if needle.is_empty() {
         return Some(0);
@@ -11,6 +16,44 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack
         .windows(needle.len())
         .position(|window| window == needle)
+}
+
+fn assert_osc_only_report_defers_popup(proc: &GhostProcess, start_offset: usize, context: &str) {
+    let osc_seen = proc.wait_for_bytes_after(OSC_GIT_REPORT, start_offset, Duration::from_secs(5));
+    if !osc_seen {
+        let snapshot = proc.output_snapshot();
+        let since_start = &snapshot[start_offset..];
+        panic!(
+            "OSC 7770 report did not arrive before {context}.\n\
+             Bytes since mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_start.len(),
+            String::from_utf8_lossy(since_start),
+        );
+    }
+
+    let rendered_before_redraw = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        start_offset,
+        NO_POPUP_BEFORE_REDRAW_TIMEOUT,
+    );
+    if rendered_before_redraw {
+        let snapshot = proc.output_snapshot();
+        let since_start = &snapshot[start_offset..];
+        panic!(
+            "OSC-only buffer report rendered popup before later display change during {context}.\n\
+             Bytes since mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_start.len(),
+            String::from_utf8_lossy(since_start),
+        );
+    }
+}
+
+fn advance_display_after_osc_only_report(proc: &mut GhostProcess) -> usize {
+    let mark_before_redraw = proc.output_len();
+    // The shell is blocked in `read`; one printable byte is echoed by the PTY
+    // without completing the read, giving the proxy a real later display epoch.
+    proc.write_raw(b"x");
+    mark_before_redraw
 }
 
 #[test]
@@ -148,8 +191,8 @@ fn test_multiple_commands() {
 /// End-to-end popup smoke test.
 ///
 /// Verifies the entire UX pipeline: OSC 7770 buffer-report (from simulated
-/// shell integration) -> auto-trigger -> popup renders with git-spec
-/// subcommand text -> ESC dismisses the popup.
+/// shell integration) -> defer until the terminal display advances -> popup
+/// renders with git-spec subcommand text -> ESC dismisses the popup.
 ///
 /// Architecture notes:
 /// - The harness wraps `/bin/sh` (no shell integration). Without shell
@@ -162,8 +205,9 @@ fn test_multiple_commands() {
 ///   The shell executes printf, emits the raw ANSI bytes to its stdout,
 ///   which flow through gc-parser's VT state machine and set
 ///   `command_buffer = "git "` with cursor = 4. This also sets
-///   `buffer_dirty = true`, which Task B (stdout -> terminal loop) notices
-///   and uses to fire `trigger()` automatically.
+///   `buffer_dirty = true`, which Task B (stdout -> terminal loop) notices.
+///   OSC-only reports are intentionally deferred until later display output
+///   proves the terminal has advanced/redrawn after the report.
 /// - No manual Ctrl+/ is needed — the auto-trigger path from OSC 7770 is
 ///   exactly what real shell integration does on every keystroke.
 ///
@@ -184,7 +228,7 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
     let mut proc = GhostProcess::spawn();
 
     // Settle the shell so our printf doesn't race with any banner output.
-    proc.send_line("echo smoke_popup_ready_marker");
+    proc.send_line("printf '%s%s\\n' smoke_popup_ready_ marker");
     proc.expect_output("smoke_popup_ready_marker");
 
     // Mark the pre-trigger offset — popup render bytes must appear after.
@@ -195,27 +239,35 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
     //     \x1b]7770;4;git \x07
     // The shell executes printf, emits the raw bytes to stdout, gc-parser
     // consumes them and sets command_buffer = "git " with cursor = 4.
-    // The buffer_dirty flag causes Task B to auto-fire trigger().
+    // The buffer_dirty flag causes Task B to defer the trigger until a later
+    // display epoch.
     //
     // Keep the shell command blocked after the OSC write. If the command
     // exits immediately, the shell prints a new prompt, and the proxy now
     // correctly tears down the popup before forwarding that prompt output.
     proc.send_line(r"printf '\033]7770;4;git \007'; read _ghost_popup_hold");
 
+    assert_osc_only_report_defers_popup(&proc, mark_before_trigger, "git popup trigger");
+
+    let mark_before_redraw = advance_display_after_osc_only_report(&mut proc);
+
     // Wait for the popup render. The overlay's first emitted byte sequence
-    // is DECSC (`\x1b7` = save cursor). Seeing it after mark_before_trigger
-    // proves that the OSC 7770 -> auto-trigger -> render_popup pipeline ran.
-    let popup_rendered =
-        proc.wait_for_bytes_after(b"\x1b7", mark_before_trigger, Duration::from_secs(5));
+    // is DECSC (`\x1b7` = save cursor). Seeing it after mark_before_redraw
+    // proves that the OSC 7770 -> later display epoch -> render_popup pipeline ran.
+    let popup_rendered = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        mark_before_redraw,
+        Duration::from_secs(5),
+    );
 
     if !popup_rendered {
         let snapshot = proc.output_snapshot();
-        let since_trigger = &snapshot[mark_before_trigger..];
+        let since_redraw = &snapshot[mark_before_redraw..];
         panic!(
-            "Popup did not render within 5s after OSC 7770 injection.\n\
-             Bytes since trigger mark ({} bytes, lossy UTF-8):\n{:?}",
-            since_trigger.len(),
-            String::from_utf8_lossy(since_trigger),
+            "Popup did not render within 5s after display advanced following OSC 7770 injection.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
         );
     }
 
@@ -252,7 +304,11 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
 
     // clear_popup emits DECSC + movement + blanks + DECRC. The DECRC
     // (`\x1b8`) appearing after the ESC mark is the dismiss signal.
-    let dismissed = proc.wait_for_bytes_after(b"\x1b8", mark_before_esc, Duration::from_secs(5));
+    let dismissed = proc.wait_for_bytes_after(
+        POPUP_RESTORE_MARKER,
+        mark_before_esc,
+        Duration::from_secs(5),
+    );
 
     if !dismissed {
         let snapshot = proc.output_snapshot();
@@ -276,27 +332,34 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
 fn test_popup_is_cleared_before_later_shell_output() {
     let mut proc = GhostProcess::spawn();
 
-    proc.send_line("PS1='smoke_prompt_repaint_marker '");
-    proc.expect_output("smoke_prompt_repaint_marker");
+    proc.send_line("PS1=\"smoke_prompt_repaint_$((1+1))_marker \"");
+    proc.expect_output("smoke_prompt_repaint_2_marker");
 
     let mark_before_trigger = proc.output_len();
     proc.send_line(r"printf '\033]7770;4;git \007'; read _gc_smoke_gate");
 
-    let popup_rendered =
-        proc.wait_for_bytes_after(b"\x1b7", mark_before_trigger, Duration::from_secs(5));
+    assert_osc_only_report_defers_popup(&proc, mark_before_trigger, "prompt repaint cleanup");
+
+    let mark_before_redraw = advance_display_after_osc_only_report(&mut proc);
+
+    let popup_rendered = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        mark_before_redraw,
+        Duration::from_secs(5),
+    );
     if !popup_rendered {
         let snapshot = proc.output_snapshot();
-        let since_trigger = &snapshot[mark_before_trigger..];
+        let since_redraw = &snapshot[mark_before_redraw..];
         panic!(
-            "Popup did not render before prompt repaint.\n\
-             Bytes since trigger mark ({} bytes, lossy UTF-8):\n{:?}",
-            since_trigger.len(),
-            String::from_utf8_lossy(since_trigger),
+            "Popup did not render after display advanced before prompt repaint.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
         );
     }
 
     let mark_after_popup = proc.output_len();
-    let marker = b"smoke_prompt_repaint_marker";
+    let marker = b"smoke_prompt_repaint_2_marker";
     proc.send_line("");
     let marker_seen = proc.wait_for_bytes_after(marker, mark_after_popup, Duration::from_secs(5));
     if !marker_seen {
@@ -315,7 +378,7 @@ fn test_popup_is_cleared_before_later_shell_output() {
     let marker_pos = find_subslice(since_popup, marker).expect("marker position");
     let before_marker = &since_popup[..marker_pos];
     assert!(
-        find_subslice(before_marker, b"\x1b8").is_some(),
+        find_subslice(before_marker, POPUP_RESTORE_MARKER).is_some(),
         "popup cleanup must finish before later shell output is forwarded. \
          Bytes before marker ({} bytes, lossy UTF-8):\n{:?}",
         before_marker.len(),
@@ -324,7 +387,7 @@ fn test_popup_is_cleared_before_later_shell_output() {
 
     let after_marker = &since_popup[marker_pos + marker.len()..];
     assert!(
-        find_subslice(after_marker, b"\x1b7").is_none(),
+        find_subslice(after_marker, POPUP_RENDER_MARKER).is_none(),
         "no stale popup render should follow shell repaint output. \
          Bytes after marker ({} bytes, lossy UTF-8):\n{:?}",
         after_marker.len(),

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -504,17 +504,19 @@ fn test_multiple_commands() {
 ///   smoke harness.
 ///
 /// Assumptions:
-///   - Embedded `git` spec contains well-known subcommands (status, commit,
-///     branch, etc.). Verified: specs/git.json has ~30 `"name": "status"`
-///     occurrences and is always embedded via include_str!.
+///   - Embedded `git` spec declares well-known subcommands such as status,
+///     commit, branch, checkout, clone, and add, and is always embedded via
+///     include_str!.
 ///   - Trigger char ' ' is in the default `auto_chars` list, so the space
 ///     at the end of "git " activates the auto-trigger path.
 ///   - `clear_popup` emits DECSC (`\x1b7`) followed by blanking writes and
 ///     DECRC (`\x1b8`). DECRC appearing after our ESC mark = dismissed.
 ///   - Default dismiss keybind is ESC (see Keybindings::default()).
 ///
-/// Determinism: byte-level polling with condvar-based wakeup, 5s timeouts,
-/// no blind sleeps.
+/// Determinism: positive readiness waits use byte-level polling with
+/// condvar-based wakeups and bounded timeouts. Startup settling and negative
+/// guards still use bounded sleeps/timeouts where the test needs to prove
+/// absence before redraw.
 #[test]
 fn test_popup_renders_and_dismisses_on_git_trigger() {
     let mut proc = GhostProcess::spawn();

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -102,7 +102,10 @@ impl ConfiguredGhostProcess {
                         data.extend_from_slice(&buf[..n]);
                         cvar.notify_all();
                     }
-                    Err(_) => break,
+                    Err(e) => {
+                        eprintln!("ConfiguredGhostProcess reader IO error: {e}");
+                        break;
+                    }
                 }
             }
         });
@@ -478,79 +481,24 @@ fn test_multiple_commands() {
     proc.exit_with_code(0);
 }
 
-/// End-to-end popup smoke test.
-///
-/// Verifies the entire UX pipeline: OSC 7770 buffer-report (from simulated
-/// shell integration) -> defer until the terminal display advances -> popup
-/// renders with git-spec subcommand text -> ESC dismisses the popup.
-///
-/// Architecture notes:
-/// - The harness wraps `/bin/sh` (no shell integration). Without shell
-///   integration, the shell will NOT emit OSC 7770 buffer-report sequences,
-///   so the parser's `command_buffer` stays empty, and `handler.trigger()`
-///   would dismiss immediately (see gc-pty/src/handler.rs: `if
-///   buffer.is_empty() { return; }`).
-/// - To simulate shell integration without installing it, we have the
-///   inner shell print OSC 7770 itself: `printf '\033]7770;4;git \007'`.
-///   The shell executes printf, emits the raw ANSI bytes to its stdout,
-///   which flow through gc-parser's VT state machine and set
-///   `command_buffer = "git "` with cursor = 4. This also sets
-///   `buffer_dirty = true`, which Task B (stdout -> terminal loop) notices.
-///   OSC-only reports are intentionally deferred until later display output
-///   proves the terminal has advanced/redrawn after the report.
-/// - No manual Ctrl+/ is needed in this test. The typed shell command around
-///   the OSC report contains literal default trigger characters, so it can
-///   leave a pending trigger before the shell emits the OSC bytes. The trailing
-///   space in the reported `git ` buffer is shell output consumed by gc-parser;
-///   it is not typed through `InputHandler::process_key_hidden`. The
-///   no-pending debounce test below avoids typed trigger characters and covers
-///   the pure OSC-only dirty-buffer path.
-///
-/// Assumptions:
-///   - Embedded `git` spec declares well-known subcommands such as status,
-///     commit, branch, checkout, clone, and add, and is always embedded via
-///     include_str!.
-///   - The OSC payload's trailing space updates parser state only; it is not a
-///     typed auto-trigger character.
-///   - `clear_popup` emits DECSC (`\x1b7`) followed by blanking writes and
-///     DECRC (`\x1b8`). DECRC appearing after our ESC mark = dismissed.
-///   - Default dismiss keybind is ESC (see Keybindings::default()).
-///
-/// Determinism: positive readiness waits use byte-level polling with
-/// condvar-based wakeups and bounded timeouts. Startup settling and negative
-/// guards still use bounded sleeps/timeouts where the test needs to prove
-/// absence before redraw.
+/// OSC 7770 buffer-report defers popup until a later display epoch; ESC dismisses it.
 #[test]
 fn test_popup_renders_and_dismisses_on_git_trigger() {
     let mut proc = GhostProcess::spawn();
 
-    // Settle the shell so our printf doesn't race with any banner output.
     proc.send_line("printf '%s%s\\n' smoke_popup_ready_ marker");
     proc.expect_output("smoke_popup_ready_marker");
 
-    // Mark the pre-trigger offset — popup render bytes must appear after.
     let mark_before_trigger = proc.output_len();
 
-    // Inject OSC 7770 via shell printf. Format:
-    //     OSC ] 7770 ; <cursor-char-offset> ; <buffer> BEL
-    //     \x1b]7770;4;git \x07
-    // The shell executes printf, emits the raw bytes to stdout, gc-parser
-    // consumes them and sets command_buffer = "git " with cursor = 4.
-    // The buffer_dirty flag causes Task B to defer the trigger until a later
-    // display epoch.
-    //
-    // Keep the shell command blocked after the OSC write. If the command
-    // exits immediately, the shell prints a new prompt, and the proxy now
-    // correctly tears down the popup before forwarding that prompt output.
+    // `read _ghost_popup_hold` keeps the shell blocked after the OSC write so
+    // shell output does not race the visible-popup pipeline.
     proc.send_line(r"printf '\033]7770;4;git \007'; read _ghost_popup_hold");
 
     assert_osc_only_report_defers_popup(&proc, mark_before_trigger, "git popup trigger");
 
     let mark_before_redraw = advance_display_after_osc_only_report(&mut proc);
 
-    // A popup render includes DECSC (`\x1b7` = save cursor). Seeing it after
-    // mark_before_redraw proves that the OSC 7770 -> later display epoch ->
-    // render_popup pipeline ran.
     let popup_rendered = proc.wait_for_bytes_after(
         POPUP_RENDER_MARKER,
         mark_before_redraw,
@@ -569,11 +517,6 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
     }
     assert_redraw_marker_precedes_popup(&proc, mark_before_redraw, "git popup trigger");
 
-    // Assert the popup contains git subcommand text. We accept any of a
-    // handful of well-known git subcommands because the exact ordering on
-    // the first page depends on nucleo's empty-query ordering and the
-    // spec's declared order. Tolerating several known-good names keeps the
-    // test deterministic across future spec updates.
     let snapshot_after_popup = proc.output_snapshot();
     let popup_slice = &snapshot_after_popup[mark_before_trigger..];
     let popup_text = String::from_utf8_lossy(popup_slice);
@@ -593,15 +536,10 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
         popup_text,
     );
 
-    // Mark offset before dismiss — dismissal bytes must appear after.
     let mark_before_esc = proc.output_len();
 
-    // Send a lone ESC (0x1B). The input parser treats a lone ESC at end
-    // of buffer as KeyEvent::Escape, which dispatches dismiss().
     proc.write_raw(&[0x1B]);
 
-    // clear_popup emits DECSC + movement + blanks + DECRC. The DECRC
-    // (`\x1b8`) appearing after the ESC mark is the dismiss signal.
     let dismissed = proc.wait_for_bytes_after(
         POPUP_RESTORE_MARKER,
         mark_before_esc,
@@ -619,8 +557,6 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
         );
     }
 
-    // Release the blocking `read` used to keep shell output from racing the
-    // visible-popup dismissal path.
     proc.send_line("");
 
     proc.exit_with_code(0);
@@ -709,6 +645,43 @@ fn test_osc_only_report_without_pending_trigger_waits_for_debounce_after_redraw(
         );
     }
     assert_redraw_marker_precedes_popup(&proc, mark_before_redraw, "no-pending debounce");
+
+    proc.send_line("");
+    proc.exit_with_code(0);
+}
+
+#[test]
+fn test_osc_only_report_with_delay_zero_renders_after_redraw() {
+    let mut proc = ConfiguredGhostProcess::spawn_with_config("[trigger]\ndelay_ms = 0\n");
+
+    proc.send_line("echo${IFS}smoke_delay_zero_ready");
+    proc.expect_output("smoke_delay_zero_ready");
+    wait_for_output_quiet(&proc, Duration::from_millis(150), Duration::from_secs(5));
+
+    let mark_before_trigger = proc.output_len();
+
+    proc.send_line(r"printf${IFS}'\033]7770;4;git\040\007';read${IFS}_gc_smoke_gate");
+
+    assert_osc_only_report_defers_popup(&proc, mark_before_trigger, "delay_zero defer");
+
+    let mark_before_redraw = advance_display_after_osc_only_report(&mut proc);
+
+    let popup_rendered = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        mark_before_redraw,
+        Duration::from_secs(5),
+    );
+    if !popup_rendered {
+        let snapshot = proc.output_snapshot();
+        let since_redraw = &snapshot[mark_before_redraw..];
+        panic!(
+            "Popup did not render after display advanced with delay_ms = 0.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
+        );
+    }
+    assert_redraw_marker_precedes_popup(&proc, mark_before_redraw, "delay_zero defer");
 
     proc.send_line("");
     proc.exit_with_code(0);

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -1,13 +1,227 @@
 mod harness;
 
 use harness::GhostProcess;
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use std::io::{Read, Write};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const OSC_GIT_REPORT: &[u8] = b"\x1b]7770;4;git \x07";
 const POPUP_RENDER_MARKER: &[u8] = b"\x1b7";
 const POPUP_RESTORE_MARKER: &[u8] = b"\x1b8";
+const REDRAW_MARKER: &[u8] = b"@";
 const NO_POPUP_BEFORE_REDRAW_TIMEOUT: Duration = Duration::from_millis(500);
+const NO_POPUP_DURING_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(300);
+const OSC_ONLY_DEBOUNCE_DELAY_MS: u64 = 1000;
+
+trait PopupSmokeProcess {
+    fn wait_for_bytes_after(&self, needle: &[u8], start_offset: usize, timeout: Duration) -> bool;
+    fn output_snapshot(&self) -> Vec<u8>;
+    fn output_len(&self) -> usize;
+    fn write_raw(&mut self, data: &[u8]);
+}
+
+impl PopupSmokeProcess for GhostProcess {
+    fn wait_for_bytes_after(&self, needle: &[u8], start_offset: usize, timeout: Duration) -> bool {
+        GhostProcess::wait_for_bytes_after(self, needle, start_offset, timeout)
+    }
+
+    fn output_snapshot(&self) -> Vec<u8> {
+        GhostProcess::output_snapshot(self)
+    }
+
+    fn output_len(&self) -> usize {
+        GhostProcess::output_len(self)
+    }
+
+    fn write_raw(&mut self, data: &[u8]) {
+        GhostProcess::write_raw(self, data);
+    }
+}
+
+struct ConfiguredGhostProcess {
+    writer: Box<dyn Write + Send>,
+    output: Arc<(Mutex<Vec<u8>>, Condvar)>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    _config: tempfile::NamedTempFile,
+}
+
+impl ConfiguredGhostProcess {
+    fn spawn_with_config(config: &str) -> Self {
+        let mut config_file = tempfile::NamedTempFile::new().expect("failed to create temp config");
+        config_file
+            .write_all(config.as_bytes())
+            .expect("failed to write temp config");
+        config_file.flush().expect("failed to flush temp config");
+        let config_path = config_file
+            .path()
+            .to_str()
+            .expect("temp config path must be valid UTF-8");
+
+        let pty_system = native_pty_system();
+        let pty_pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("failed to open PTY pair");
+
+        let bin = env!("CARGO_BIN_EXE_ghost-complete");
+        let mut cmd = CommandBuilder::new(bin);
+        cmd.args(["--config", config_path, "--log-level", "error", "/bin/sh"]);
+        cmd.env("TERM_PROGRAM", "ghostty");
+
+        let child = pty_pair
+            .slave
+            .spawn_command(cmd)
+            .expect("failed to spawn ghost-complete");
+
+        let writer = pty_pair
+            .master
+            .take_writer()
+            .expect("failed to take PTY writer");
+        let mut reader = pty_pair
+            .master
+            .try_clone_reader()
+            .expect("failed to clone PTY reader");
+
+        let output = Arc::new((Mutex::new(Vec::new()), Condvar::new()));
+        let output_clone = Arc::clone(&output);
+        thread::spawn(move || {
+            let mut buf = [0u8; 8192];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let (lock, cvar) = &*output_clone;
+                        let mut data = lock.lock().unwrap();
+                        data.extend_from_slice(&buf[..n]);
+                        cvar.notify_all();
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        thread::sleep(Duration::from_millis(1500));
+
+        Self {
+            writer,
+            output,
+            child,
+            _config: config_file,
+        }
+    }
+
+    fn send_line(&mut self, line: &str) {
+        let data = format!("{}\r", line);
+        self.writer
+            .write_all(data.as_bytes())
+            .expect("failed to write to PTY");
+        self.writer.flush().expect("failed to flush PTY writer");
+    }
+
+    fn expect_output(&self, substr: &str) {
+        let timeout = Duration::from_secs(10);
+        let start = Instant::now();
+        let (lock, cvar) = &*self.output;
+
+        loop {
+            let data = lock.lock().unwrap();
+            let text = String::from_utf8_lossy(&data);
+            if text.contains(substr) {
+                return;
+            }
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
+                panic!(
+                    "Timed out after {:?} waiting for {:?} in output.\nOutput so far ({} bytes):\n{}",
+                    timeout,
+                    substr,
+                    data.len(),
+                    String::from_utf8_lossy(&data[..data.len().min(2000)])
+                );
+            }
+            let remaining = timeout - elapsed;
+            let (data, _) = cvar.wait_timeout(data, remaining).unwrap();
+            let text = String::from_utf8_lossy(&data);
+            if text.contains(substr) {
+                return;
+            }
+        }
+    }
+
+    fn exit_with_code(&mut self, code: i32) -> i32 {
+        self.send_line(&format!("exit {}", code));
+        self.wait_for_exit()
+    }
+
+    fn wait_for_exit(&mut self) -> i32 {
+        let timeout = Duration::from_secs(15);
+        let start = Instant::now();
+
+        loop {
+            if let Some(status) = self.child.try_wait().expect("try_wait failed") {
+                return status.exit_code().try_into().unwrap_or(1);
+            }
+            if start.elapsed() >= timeout {
+                self.child.kill().ok();
+                panic!("Process did not exit within {:?}", timeout);
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl PopupSmokeProcess for ConfiguredGhostProcess {
+    fn wait_for_bytes_after(&self, needle: &[u8], start_offset: usize, timeout: Duration) -> bool {
+        let start = Instant::now();
+        let (lock, cvar) = &*self.output;
+        loop {
+            let data = lock.lock().unwrap();
+            if data.len() > start_offset && find_subslice(&data[start_offset..], needle).is_some() {
+                return true;
+            }
+            let elapsed = start.elapsed();
+            if elapsed >= timeout {
+                return false;
+            }
+            let remaining = timeout - elapsed;
+            let (data, _) = cvar.wait_timeout(data, remaining).unwrap();
+            if data.len() > start_offset && find_subslice(&data[start_offset..], needle).is_some() {
+                return true;
+            }
+        }
+    }
+
+    fn output_snapshot(&self) -> Vec<u8> {
+        let (lock, _) = &*self.output;
+        lock.lock().unwrap().clone()
+    }
+
+    fn output_len(&self) -> usize {
+        let (lock, _) = &*self.output;
+        lock.lock().unwrap().len()
+    }
+
+    fn write_raw(&mut self, data: &[u8]) {
+        self.writer
+            .write_all(data)
+            .expect("failed to write raw to PTY");
+        self.writer.flush().expect("failed to flush PTY writer");
+    }
+}
+
+impl Drop for ConfiguredGhostProcess {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            self.child.kill().ok();
+        }
+    }
+}
 
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     if needle.is_empty() {
@@ -18,7 +232,11 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-fn assert_osc_only_report_defers_popup(proc: &GhostProcess, start_offset: usize, context: &str) {
+fn assert_osc_only_report_defers_popup<P: PopupSmokeProcess + ?Sized>(
+    proc: &P,
+    start_offset: usize,
+    context: &str,
+) {
     let osc_seen = proc.wait_for_bytes_after(OSC_GIT_REPORT, start_offset, Duration::from_secs(5));
     if !osc_seen {
         let snapshot = proc.output_snapshot();
@@ -48,12 +266,83 @@ fn assert_osc_only_report_defers_popup(proc: &GhostProcess, start_offset: usize,
     }
 }
 
-fn advance_display_after_osc_only_report(proc: &mut GhostProcess) -> usize {
+fn advance_display_after_osc_only_report<P: PopupSmokeProcess + ?Sized>(proc: &mut P) -> usize {
     let mark_before_redraw = proc.output_len();
     // The shell is blocked in `read`; one printable byte is echoed by the PTY
     // without completing the read, giving the proxy a real later display epoch.
-    proc.write_raw(b"x");
+    proc.write_raw(REDRAW_MARKER);
     mark_before_redraw
+}
+
+fn wait_for_output_quiet<P: PopupSmokeProcess + ?Sized>(
+    proc: &P,
+    quiet_for: Duration,
+    timeout: Duration,
+) {
+    let start = Instant::now();
+    let mut quiet_start = Instant::now();
+    let mut previous_len = proc.output_len();
+
+    loop {
+        thread::sleep(Duration::from_millis(25));
+        let current_len = proc.output_len();
+        if current_len == previous_len {
+            if quiet_start.elapsed() >= quiet_for {
+                return;
+            }
+        } else {
+            previous_len = current_len;
+            quiet_start = Instant::now();
+        }
+
+        if start.elapsed() >= timeout {
+            let snapshot = proc.output_snapshot();
+            panic!(
+                "Output did not stay quiet for {:?} within {:?}.\n\
+                 Output so far ({} bytes, lossy UTF-8):\n{:?}",
+                quiet_for,
+                timeout,
+                snapshot.len(),
+                String::from_utf8_lossy(&snapshot),
+            );
+        }
+    }
+}
+
+fn assert_redraw_marker_precedes_popup<P: PopupSmokeProcess + ?Sized>(
+    proc: &P,
+    mark_before_redraw: usize,
+    context: &str,
+) {
+    let snapshot = proc.output_snapshot();
+    let since_redraw = &snapshot[mark_before_redraw..];
+    let redraw_pos = find_subslice(since_redraw, REDRAW_MARKER).unwrap_or_else(|| {
+        panic!(
+            "Redraw marker missing after display advance during {context}.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
+        )
+    });
+    let popup_pos = find_subslice(since_redraw, POPUP_RENDER_MARKER).unwrap_or_else(|| {
+        panic!(
+            "Popup marker missing after display advance during {context}.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
+        )
+    });
+
+    assert!(
+        redraw_pos < popup_pos,
+        "display output must be forwarded before popup render during {context}. \
+         Redraw marker at {}, popup marker at {}.\n\
+         Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+        redraw_pos,
+        popup_pos,
+        since_redraw.len(),
+        String::from_utf8_lossy(since_redraw),
+    );
 }
 
 #[test]
@@ -208,8 +497,11 @@ fn test_multiple_commands() {
 ///   `buffer_dirty = true`, which Task B (stdout -> terminal loop) notices.
 ///   OSC-only reports are intentionally deferred until later display output
 ///   proves the terminal has advanced/redrawn after the report.
-/// - No manual Ctrl+/ is needed — the auto-trigger path from OSC 7770 is
-///   exactly what real shell integration does on every keystroke.
+/// - No manual Ctrl+/ is needed in this test; emitting an OSC buffer report
+///   directly exercises Task B's auto-trigger/debounce path. zsh production
+///   integration uses OSC 7772 from zle-line-pre-redraw, while OSC 7770
+///   remains accepted for legacy compatibility and is convenient for this
+///   smoke harness.
 ///
 /// Assumptions:
 ///   - Embedded `git` spec contains well-known subcommands (status, commit,
@@ -251,9 +543,9 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
 
     let mark_before_redraw = advance_display_after_osc_only_report(&mut proc);
 
-    // Wait for the popup render. The overlay's first emitted byte sequence
-    // is DECSC (`\x1b7` = save cursor). Seeing it after mark_before_redraw
-    // proves that the OSC 7770 -> later display epoch -> render_popup pipeline ran.
+    // A popup render includes DECSC (`\x1b7` = save cursor). Seeing it after
+    // mark_before_redraw proves that the OSC 7770 -> later display epoch ->
+    // render_popup pipeline ran.
     let popup_rendered = proc.wait_for_bytes_after(
         POPUP_RENDER_MARKER,
         mark_before_redraw,
@@ -270,6 +562,7 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
             String::from_utf8_lossy(since_redraw),
         );
     }
+    assert_redraw_marker_precedes_popup(&proc, mark_before_redraw, "git popup trigger");
 
     // Assert the popup contains git subcommand text. We accept any of a
     // handful of well-known git subcommands because the exact ordering on
@@ -329,6 +622,89 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
 }
 
 #[test]
+fn test_osc_only_report_without_pending_trigger_waits_for_debounce_after_redraw() {
+    let config = format!("[trigger]\ndelay_ms = {}\n", OSC_ONLY_DEBOUNCE_DELAY_MS);
+    let mut proc = ConfiguredGhostProcess::spawn_with_config(&config);
+
+    proc.send_line("echo${IFS}smoke_debounce_ready");
+    proc.expect_output("smoke_debounce_ready");
+    wait_for_output_quiet(&proc, Duration::from_millis(150), Duration::from_secs(5));
+
+    let mark_before_trigger = proc.output_len();
+
+    // This shell command contains no literal default auto-trigger chars
+    // (space, '/', '-', '.') before the OSC report. `${IFS}` supplies shell
+    // separators at execution time, and `\040` emits the buffer's trailing
+    // space from printf rather than from typed input.
+    proc.send_line(r"printf${IFS}'\033]7770;4;git\040\007';read${IFS}_gc_smoke_gate");
+
+    assert_osc_only_report_defers_popup(&proc, mark_before_trigger, "no-pending debounce");
+
+    let mark_before_redraw = advance_display_after_osc_only_report(&mut proc);
+    let redraw_seen =
+        proc.wait_for_bytes_after(REDRAW_MARKER, mark_before_redraw, Duration::from_secs(5));
+    if !redraw_seen {
+        let snapshot = proc.output_snapshot();
+        let since_redraw = &snapshot[mark_before_redraw..];
+        panic!(
+            "Redraw marker did not arrive after OSC-only report.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
+        );
+    }
+
+    let snapshot_after_redraw = proc.output_snapshot();
+    let since_redraw = &snapshot_after_redraw[mark_before_redraw..];
+    if find_subslice(since_redraw, POPUP_RENDER_MARKER).is_some() {
+        panic!(
+            "OSC-only buffer report rendered immediately when the later display output arrived; \
+             expected deferred debounce.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
+        );
+    }
+
+    let mark_after_redraw = snapshot_after_redraw.len();
+    let rendered_during_debounce = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        mark_after_redraw,
+        NO_POPUP_DURING_DEBOUNCE_TIMEOUT,
+    );
+    if rendered_during_debounce {
+        let snapshot = proc.output_snapshot();
+        let during_debounce = &snapshot[mark_after_redraw..];
+        panic!(
+            "OSC-only buffer report rendered before the configured debounce elapsed.\n\
+             Bytes during debounce guard ({} bytes, lossy UTF-8):\n{:?}",
+            during_debounce.len(),
+            String::from_utf8_lossy(during_debounce),
+        );
+    }
+
+    let popup_rendered = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        mark_after_redraw,
+        Duration::from_secs(5),
+    );
+    if !popup_rendered {
+        let snapshot = proc.output_snapshot();
+        let since_redraw = &snapshot[mark_before_redraw..];
+        panic!(
+            "Popup did not render after deferred debounce following OSC-only report.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
+        );
+    }
+    assert_redraw_marker_precedes_popup(&proc, mark_before_redraw, "no-pending debounce");
+
+    proc.send_line("");
+    proc.exit_with_code(0);
+}
+
+#[test]
 fn test_popup_is_cleared_before_later_shell_output() {
     let mut proc = GhostProcess::spawn();
 
@@ -357,6 +733,7 @@ fn test_popup_is_cleared_before_later_shell_output() {
             String::from_utf8_lossy(since_redraw),
         );
     }
+    assert_redraw_marker_precedes_popup(&proc, mark_before_redraw, "prompt repaint cleanup");
 
     let mark_after_popup = proc.output_len();
     let marker = b"smoke_prompt_repaint_2_marker";


### PR DESCRIPTION
Fixes #83.

## Summary
- Defer immediate popup triggers when an OSC 7772 buffer report arrives before matching redraw bytes.
- Trigger after the next display-changing PTY chunk refreshes cursor geometry.
- Cover pending-trigger and `delay_ms = 0` paths with proxy tests.

## Root Cause
Zsh emits the OSC 7772 buffer report from `zle-line-pre-redraw`. If that OSC arrives in an OSC-only PTY read, Task B previously triggered immediately and rendered the popup from stale parser cursor geometry before ZLE redraw moved the cursor. That can place completion output over the active prompt line.

## Validation
- `cargo test -p gc-pty buffer_dirty_action`
- `cargo test -p gc-pty`
- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`