### PR TITLE
fix(pty): defer popup trigger until display catches up (#107)

### DIFF
--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -56,12 +56,8 @@ pub struct TerminalState {
     command_buffer: Option<String>,
     buffer_cursor: usize,
     buffer_dirty: bool,
-    /// True when an OSC 7772 buffer report has been observed but the parser
-    /// has not yet applied any subsequent display-changing operation. Used
-    /// by the proxy to decide whether the popup can be triggered now (the
-    /// terminal display already reflects the new buffer) or must wait until
-    /// the redraw arrives in a later PTY read. Set in [`Self::set_command_buffer`]
-    /// and cleared in [`Self::mark_display_dirty`].
+    /// Set when a shell-side buffer report (OSC 7770/7772) updates the buffer
+    /// ahead of the matching display redraw; cleared when display catches up.
     buffer_pending_display: bool,
     cwd_dirty: bool,
     cursor_sync_requested: bool,
@@ -176,16 +172,6 @@ impl TerminalState {
         dirty
     }
 
-    /// Returns true if the most recent buffer-update event has not yet been
-    /// followed by a display-changing op in the parser stream. This signals
-    /// to the proxy that the terminal display has not yet been redrawn to
-    /// reflect the new buffer state, and that triggering the popup now would
-    /// position it from stale cursor geometry.
-    ///
-    /// The flag is `false` if no buffer event has been seen yet, or if any
-    /// display-changing op has been processed since the last buffer event.
-    /// Reading does not clear the flag — the proxy's deferral only resolves
-    /// once the parser observes a real display update.
     pub fn buffer_pending_display(&self) -> bool {
         self.buffer_pending_display
     }
@@ -518,6 +504,8 @@ impl TerminalState {
     pub(crate) fn clear_command_buffer(&mut self) {
         self.command_buffer = None;
         self.buffer_cursor = 0;
+        self.buffer_dirty = false;
+        self.buffer_pending_display = false;
     }
 
     pub(crate) fn set_autowrap(&mut self, enabled: bool) {
@@ -917,6 +905,18 @@ mod tests {
             state.buffer_pending_display(),
             "draining buffer_dirty must not advance the pending-display flag"
         );
+    }
+
+    #[test]
+    fn buffer_pending_display_via_process_bytes_osc_then_print() {
+        // Mirrors the proxy's actual byte-stream path: OSC buffer report
+        // followed by a printable byte in a single batch should set the
+        // flag on the OSC and clear it on the printable.
+        let mut p = crate::TerminalParser::new(24, 80);
+        p.process_bytes(b"\x1b]7770;3;git\x07");
+        assert!(p.state().buffer_pending_display());
+        p.process_bytes(b"x");
+        assert!(!p.state().buffer_pending_display());
     }
 
     #[test]

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -56,6 +56,13 @@ pub struct TerminalState {
     command_buffer: Option<String>,
     buffer_cursor: usize,
     buffer_dirty: bool,
+    /// True when an OSC 7772 buffer report has been observed but the parser
+    /// has not yet applied any subsequent display-changing operation. Used
+    /// by the proxy to decide whether the popup can be triggered now (the
+    /// terminal display already reflects the new buffer) or must wait until
+    /// the redraw arrives in a later PTY read. Set in [`Self::set_command_buffer`]
+    /// and cleared in [`Self::mark_display_dirty`].
+    buffer_pending_display: bool,
     cwd_dirty: bool,
     cursor_sync_requested: bool,
     cpr_synced: bool,
@@ -98,6 +105,7 @@ impl TerminalState {
             command_buffer: None,
             buffer_cursor: 0,
             buffer_dirty: false,
+            buffer_pending_display: false,
             cwd_dirty: false,
             cursor_sync_requested: false,
             cpr_synced: false,
@@ -166,6 +174,20 @@ impl TerminalState {
         let dirty = self.buffer_dirty;
         self.buffer_dirty = false;
         dirty
+    }
+
+    /// Returns true if the most recent buffer-update event has not yet been
+    /// followed by a display-changing op in the parser stream. This signals
+    /// to the proxy that the terminal display has not yet been redrawn to
+    /// reflect the new buffer state, and that triggering the popup now would
+    /// position it from stale cursor geometry.
+    ///
+    /// The flag is `false` if no buffer event has been seen yet, or if any
+    /// display-changing op has been processed since the last buffer event.
+    /// Reading does not clear the flag — the proxy's deferral only resolves
+    /// once the parser observes a real display update.
+    pub fn buffer_pending_display(&self) -> bool {
+        self.buffer_pending_display
     }
 
     /// Returns true if the CWD changed since the last check,
@@ -490,6 +512,7 @@ impl TerminalState {
         self.command_buffer = Some(buffer);
         self.buffer_cursor = clamped;
         self.buffer_dirty = true;
+        self.buffer_pending_display = true;
     }
 
     pub(crate) fn clear_command_buffer(&mut self) {
@@ -542,6 +565,7 @@ impl TerminalState {
 
     fn mark_display_dirty(&mut self) {
         self.display_dirty = true;
+        self.buffer_pending_display = false;
     }
 
     fn wrap_to_next_line(&mut self) {
@@ -846,6 +870,53 @@ mod tests {
         assert_eq!(dropped, 1);
         assert_eq!(state.cpr_queue_len(), 1);
         assert_eq!(state.claim_next_cpr(), Some(CprOwner::Shell));
+    }
+
+    #[test]
+    fn buffer_pending_display_initially_false() {
+        let state = TerminalState::new(24, 80);
+        assert!(!state.buffer_pending_display());
+    }
+
+    #[test]
+    fn buffer_pending_display_set_by_buffer_update() {
+        let mut state = TerminalState::new(24, 80);
+        state.set_command_buffer("git ".to_string(), 4);
+        assert!(state.buffer_pending_display());
+        assert!(state.take_buffer_dirty());
+    }
+
+    #[test]
+    fn buffer_pending_display_cleared_by_display_op_after_buffer_update() {
+        let mut state = TerminalState::new(24, 80);
+        state.set_command_buffer("git ".to_string(), 4);
+        assert!(state.buffer_pending_display());
+        state.advance_col(1);
+        assert!(
+            !state.buffer_pending_display(),
+            "any display-changing op must clear the pending flag"
+        );
+    }
+
+    #[test]
+    fn buffer_pending_display_re_armed_by_subsequent_buffer_update() {
+        let mut state = TerminalState::new(24, 80);
+        state.set_command_buffer("git ".to_string(), 4);
+        state.advance_col(1);
+        assert!(!state.buffer_pending_display());
+        state.set_command_buffer("git c".to_string(), 5);
+        assert!(state.buffer_pending_display());
+    }
+
+    #[test]
+    fn buffer_pending_display_unaffected_by_take_buffer_dirty() {
+        let mut state = TerminalState::new(24, 80);
+        state.set_command_buffer("git ".to_string(), 4);
+        let _ = state.take_buffer_dirty();
+        assert!(
+            state.buffer_pending_display(),
+            "draining buffer_dirty must not advance the pending-display flag"
+        );
     }
 
     #[test]

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -500,6 +500,10 @@ impl TerminalState {
         }
     }
 
+    /// Apply a shell-reported buffer state (typically from OSC 7770/7772).
+    /// Raises `buffer_dirty` (signals "recompute suggestions") and
+    /// `buffer_pending_display` (signals "wait for the matching redraw before
+    /// placing the popup").
     pub(crate) fn set_command_buffer(&mut self, buffer: String, cursor: usize) {
         let clamped = cursor.min(buffer.chars().count());
         self.command_buffer = Some(buffer);

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -567,8 +567,11 @@ impl TerminalState {
     }
 
     /// Marks the display dirty AND clears `buffer_pending_display` — every
-    /// cursor- or screen-affecting mutation must funnel through here so the
-    /// proxy's deferred-trigger gate can resolve once the redraw lands.
+    /// shell-driven mutation that advances the visible display funnels
+    /// through here so the proxy's deferred-trigger gate can resolve once
+    /// the redraw lands. CPR responses (`set_cursor_from_report`) and
+    /// SIGWINCH (`update_dimensions`) intentionally bypass this helper
+    /// because they reflect terminal state rather than a fresh redraw.
     fn mark_display_dirty(&mut self) {
         self.display_dirty = true;
         self.buffer_pending_display = false;

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -56,8 +56,12 @@ pub struct TerminalState {
     command_buffer: Option<String>,
     buffer_cursor: usize,
     buffer_dirty: bool,
-    /// Set when a shell-side buffer report (OSC 7770/7772) updates the buffer
-    /// ahead of the matching display redraw; cleared when display catches up.
+    /// True iff the most recent buffer event has not yet been followed by ANY
+    /// display-changing op. Best-effort proxy for "shell ZLE redraw has applied" —
+    /// the proxy treats the next display op as evidence the redraw landed, so
+    /// the popup is anchored to fresh cursor geometry.
+    /// Set sites: `set_command_buffer`. Clear sites: `clear_command_buffer`,
+    /// `mark_display_dirty`.
     buffer_pending_display: bool,
     cwd_dirty: bool,
     cursor_sync_requested: bool,
@@ -172,6 +176,9 @@ impl TerminalState {
         dirty
     }
 
+    /// True while a buffer report is awaiting a display-changing byte. Callers
+    /// (notably the proxy's trigger gate) should suppress popup placement on
+    /// `true` to avoid anchoring to stale cursor geometry.
     pub fn buffer_pending_display(&self) -> bool {
         self.buffer_pending_display
     }
@@ -501,6 +508,10 @@ impl TerminalState {
         self.buffer_pending_display = true;
     }
 
+    /// Resets buffer state to absent. `buffer_dirty` and `buffer_pending_display`
+    /// describe events on the (now-cleared) buffer, so they are dropped here —
+    /// otherwise a pending consumer would act on a stale event for a buffer that
+    /// no longer exists. Mirrors `set_command_buffer`, which raises both flags.
     pub(crate) fn clear_command_buffer(&mut self) {
         self.command_buffer = None;
         self.buffer_cursor = 0;
@@ -551,6 +562,9 @@ impl TerminalState {
         }
     }
 
+    /// Marks the display dirty AND clears `buffer_pending_display` — every
+    /// cursor- or screen-affecting mutation must funnel through here so the
+    /// proxy's deferred-trigger gate can resolve once the redraw lands.
     fn mark_display_dirty(&mut self) {
         self.display_dirty = true;
         self.buffer_pending_display = false;
@@ -882,7 +896,7 @@ mod tests {
         state.advance_col(1);
         assert!(
             !state.buffer_pending_display(),
-            "any display-changing op must clear the pending flag"
+            "advance_col must clear the pending-display flag (representative of any op that funnels through mark_display_dirty)"
         );
     }
 
@@ -909,14 +923,34 @@ mod tests {
 
     #[test]
     fn buffer_pending_display_via_process_bytes_osc_then_print() {
-        // Mirrors the proxy's actual byte-stream path: OSC buffer report
-        // followed by a printable byte in a single batch should set the
-        // flag on the OSC and clear it on the printable.
+        // OSC sets the flag, the printable byte after it clears the flag — this
+        // is the in-frame fast path the proxy relies on.
         let mut p = crate::TerminalParser::new(24, 80);
-        p.process_bytes(b"\x1b]7770;3;git\x07");
-        assert!(p.state().buffer_pending_display());
-        p.process_bytes(b"x");
+        p.process_bytes(b"\x1b]7770;3;git\x07x");
         assert!(!p.state().buffer_pending_display());
+    }
+
+    #[test]
+    fn clear_command_buffer_resets_dirty_and_pending_flags() {
+        let mut state = TerminalState::new(24, 80);
+        state.set_command_buffer("git ".to_string(), 4);
+        assert!(state.buffer_pending_display());
+        state.clear_command_buffer();
+        assert!(!state.take_buffer_dirty());
+        assert!(!state.buffer_pending_display());
+    }
+
+    #[test]
+    fn predict_command_buffer_does_not_set_or_clear_pending_display() {
+        let mut state = TerminalState::new(24, 80);
+        // From clean state, predict must not arm the flag.
+        state.predict_command_buffer("ls".to_string(), 2);
+        assert!(!state.buffer_pending_display());
+        // With the flag armed by a prior shell report, predict must not clear it.
+        state.set_command_buffer("git ".to_string(), 4);
+        assert!(state.buffer_pending_display());
+        state.predict_command_buffer("git st".to_string(), 6);
+        assert!(state.buffer_pending_display());
     }
 
     #[test]

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -483,6 +483,11 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let debounce_notify_b = Arc::clone(&debounce_notify);
     let stdout_handle = tokio::task::spawn_blocking(move || {
         let mut buf = [0u8; 8192];
+        // Stashes a buffer-dirty action that observed `buffer_pending_display`
+        // and could not safely trigger this batch. Resolved on a later batch
+        // once the parser confirms the display has caught up to the new
+        // buffer state (i.e., the ZLE redraw has been processed).
+        let mut pending_trigger: Option<PendingTrigger> = None;
         loop {
             let n = match reader.read(&mut buf) {
                 Ok(0) => break, // PTY closed
@@ -607,12 +612,20 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            // Check if shell reported a buffer update via OSC 7770.
-            // Trigger suggestions here (Task B) instead of Task A to ensure
-            // we have the shell's updated buffer, fixing the stale-buffer bug.
-            let buffer_dirty = {
+            // Check if shell reported a buffer update via OSC 7772, and
+            // whether that update is still waiting for a redraw to catch up
+            // in the terminal display. The pair `(buffer_dirty,
+            // buffer_pending_display)` distinguishes:
+            //   (true,  false) → OSC + redraw in same batch → trigger now
+            //   (true,  true ) → OSC arrived alone → defer until next display
+            //   (false, false) → routine display update → resolve any prior defer
+            //   (false, true ) → pure passthrough mid-defer → keep waiting
+            let (buffer_dirty, buffer_pending_display) = {
                 match parser_for_stdout.lock() {
-                    Ok(mut p) => p.state_mut().take_buffer_dirty(),
+                    Ok(mut p) => {
+                        let state = p.state_mut();
+                        (state.take_buffer_dirty(), state.buffer_pending_display())
+                    }
                     Err(e) => {
                         tracing::warn!("parser mutex poisoned in stdout task: {e}");
                         break;
@@ -636,16 +649,30 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         delay_ms,
                         h.auto_trigger_enabled(),
                         h.is_debounce_suppressed(),
+                        buffer_pending_display,
                     );
                     if had_pending_trigger {
                         h.clear_trigger_request();
                     }
                     match action {
                         BufferDirtyAction::Trigger => {
-                            h.trigger(&parser_for_stdout, &mut render_buf)
+                            pending_trigger = None;
+                            h.trigger(&parser_for_stdout, &mut render_buf);
                         }
-                        BufferDirtyAction::Debounce => debounce_notify_b.notify_one(),
-                        BufferDirtyAction::Ignore => {}
+                        BufferDirtyAction::Debounce => {
+                            pending_trigger = None;
+                            debounce_notify_b.notify_one();
+                        }
+                        BufferDirtyAction::Defer(p) => {
+                            // Stash for the next batch where the redraw
+                            // arrives. Overwriting any prior pending entry
+                            // is intentional: a fresh buffer event
+                            // supersedes the old one.
+                            pending_trigger = Some(p);
+                        }
+                        BufferDirtyAction::Ignore => {
+                            pending_trigger = None;
+                        }
                     }
                     h.overlay_write_ticket()
                 };
@@ -654,6 +681,47 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         write_overlay_if_current(&handler_for_stdout, render_ticket, &render_buf)
                     {
                         tracing::debug!("Task B overlay write/flush failed: {e}");
+                        break;
+                    }
+                }
+            }
+
+            // Resolve any deferred trigger now that the parser has confirmed
+            // a display update applied AFTER the most recent buffer event.
+            // `buffer_pending_display == false` is the parser-side guarantee
+            // that cursor geometry now reflects the current buffer, so the
+            // popup can render at the correct row/column.
+            if pending_trigger.is_some() && !buffer_pending_display {
+                let mut render_buf = Vec::new();
+                let render_ticket = {
+                    let mut h = match handler_for_stdout.lock() {
+                        Ok(h) => h,
+                        Err(e) => {
+                            tracing::warn!("handler mutex poisoned in stdout task: {e}");
+                            break;
+                        }
+                    };
+                    let resolved = resolve_pending_trigger(
+                        &mut pending_trigger,
+                        h.auto_trigger_enabled(),
+                        h.is_debounce_suppressed(),
+                    );
+                    match resolved {
+                        Some(PendingTrigger::Trigger) => {
+                            h.trigger(&parser_for_stdout, &mut render_buf);
+                        }
+                        Some(PendingTrigger::Debounce) => {
+                            debounce_notify_b.notify_one();
+                        }
+                        None => {}
+                    }
+                    h.overlay_write_ticket()
+                };
+                if !render_buf.is_empty() {
+                    if let Err(e) =
+                        write_overlay_if_current(&handler_for_stdout, render_ticket, &render_buf)
+                    {
+                        tracing::debug!("Task B deferred overlay write/flush failed: {e}");
                         break;
                     }
                 }
@@ -913,11 +981,32 @@ fn poll_until(
     }
 }
 
+/// What the proxy should do once it has observed a `buffer_dirty` event.
+///
+/// `Defer` is the addition that closes #107: when the OSC 7772 buffer
+/// report arrives in a PTY read that does not also include the matching
+/// ZLE redraw, triggering immediately renders the popup from a stale
+/// cursor row/column. The parser's `buffer_pending_display` flag tells
+/// us whether the redraw has been observed yet; if not, the action is
+/// stashed via [`PendingTrigger`] and resolved on a later batch where
+/// `display_dirty` proves the terminal display has caught up.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BufferDirtyAction {
     Trigger,
     Debounce,
+    Defer(PendingTrigger),
     Ignore,
+}
+
+/// What action a deferred `buffer_dirty` should perform when the proxy
+/// observes the next display-changing batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingTrigger {
+    /// Resolve into [`BufferDirtyAction::Trigger`] (immediate render).
+    Trigger,
+    /// Resolve into [`BufferDirtyAction::Debounce`] (notify the debounce
+    /// task, which then waits `delay_ms` before triggering).
+    Debounce,
 }
 
 fn buffer_dirty_action(
@@ -925,20 +1014,58 @@ fn buffer_dirty_action(
     delay_ms: u64,
     auto_trigger_enabled: bool,
     debounce_suppressed: bool,
+    buffer_pending_display: bool,
 ) -> BufferDirtyAction {
     if !auto_trigger_enabled {
         return BufferDirtyAction::Ignore;
     }
     if has_pending_trigger {
-        return BufferDirtyAction::Trigger;
+        return if buffer_pending_display {
+            BufferDirtyAction::Defer(PendingTrigger::Trigger)
+        } else {
+            BufferDirtyAction::Trigger
+        };
     }
     if debounce_suppressed {
         return BufferDirtyAction::Ignore;
     }
     if delay_ms == 0 {
-        BufferDirtyAction::Trigger
+        if buffer_pending_display {
+            BufferDirtyAction::Defer(PendingTrigger::Trigger)
+        } else {
+            BufferDirtyAction::Trigger
+        }
+    } else if buffer_pending_display {
+        BufferDirtyAction::Defer(PendingTrigger::Debounce)
     } else {
         BufferDirtyAction::Debounce
+    }
+}
+
+/// Resolve a deferred trigger once `display_dirty` has been observed in a
+/// later batch. Returns `None` if no pending trigger was stashed, or if the
+/// handler has since toggled into a state (auto disabled, debounce
+/// suppressed for a Debounce-class deferral) where the original action no
+/// longer applies. Always clears the pending slot so a stale entry cannot
+/// fire later.
+fn resolve_pending_trigger(
+    pending: &mut Option<PendingTrigger>,
+    auto_trigger_enabled: bool,
+    debounce_suppressed: bool,
+) -> Option<PendingTrigger> {
+    let action = pending.take()?;
+    if !auto_trigger_enabled {
+        return None;
+    }
+    match action {
+        PendingTrigger::Trigger => Some(PendingTrigger::Trigger),
+        PendingTrigger::Debounce => {
+            if debounce_suppressed {
+                None
+            } else {
+                Some(PendingTrigger::Debounce)
+            }
+        }
     }
 }
 
@@ -1300,43 +1427,124 @@ mod tests {
     }
 
     #[test]
-    fn buffer_dirty_action_triggers_immediately_when_delay_zero() {
+    fn buffer_dirty_action_triggers_immediately_when_delay_zero_and_display_caught_up() {
+        // OSC + redraw landed in same batch → buffer_pending_display=false
         assert_eq!(
-            buffer_dirty_action(false, 0, true, false),
+            buffer_dirty_action(false, 0, true, false, false),
             BufferDirtyAction::Trigger
+        );
+    }
+
+    #[test]
+    fn buffer_dirty_action_defers_when_delay_zero_and_display_pending() {
+        // OSC arrived alone, redraw hasn't been processed yet
+        assert_eq!(
+            buffer_dirty_action(false, 0, true, false, true),
+            BufferDirtyAction::Defer(PendingTrigger::Trigger)
         );
     }
 
     #[test]
     fn buffer_dirty_action_ignores_when_auto_trigger_disabled() {
-        assert_eq!(
-            buffer_dirty_action(false, 0, false, false),
-            BufferDirtyAction::Ignore
-        );
+        for pending in [false, true] {
+            assert_eq!(
+                buffer_dirty_action(false, 0, false, false, pending),
+                BufferDirtyAction::Ignore,
+                "auto-disabled must dominate regardless of buffer_pending_display={pending}"
+            );
+        }
     }
 
     #[test]
-    fn buffer_dirty_action_ignores_when_debounce_suppressed() {
-        assert_eq!(
-            buffer_dirty_action(false, 0, true, true),
-            BufferDirtyAction::Ignore
-        );
+    fn buffer_dirty_action_ignores_when_debounce_suppressed_and_no_pending_trigger() {
+        for pending in [false, true] {
+            assert_eq!(
+                buffer_dirty_action(false, 0, true, true, pending),
+                BufferDirtyAction::Ignore
+            );
+        }
     }
 
     #[test]
-    fn buffer_dirty_action_debounces_when_delay_positive() {
+    fn buffer_dirty_action_debounces_when_delay_positive_and_display_caught_up() {
         assert_eq!(
-            buffer_dirty_action(false, 150, true, false),
+            buffer_dirty_action(false, 150, true, false, false),
             BufferDirtyAction::Debounce
         );
     }
 
     #[test]
-    fn buffer_dirty_action_prefers_pending_trigger() {
+    fn buffer_dirty_action_defers_to_debounce_when_delay_positive_and_display_pending() {
         assert_eq!(
-            buffer_dirty_action(true, 150, true, true),
+            buffer_dirty_action(false, 150, true, false, true),
+            BufferDirtyAction::Defer(PendingTrigger::Debounce)
+        );
+    }
+
+    #[test]
+    fn buffer_dirty_action_prefers_pending_trigger_when_display_caught_up() {
+        // Pending trigger from input handler bypasses debounce_suppressed
+        assert_eq!(
+            buffer_dirty_action(true, 150, true, true, false),
             BufferDirtyAction::Trigger
         );
+    }
+
+    #[test]
+    fn buffer_dirty_action_defers_pending_trigger_when_display_pending() {
+        // Pending trigger but redraw hasn't applied yet — must defer to
+        // avoid rendering popup at stale cursor position (issue #107).
+        assert_eq!(
+            buffer_dirty_action(true, 150, true, true, true),
+            BufferDirtyAction::Defer(PendingTrigger::Trigger)
+        );
+    }
+
+    #[test]
+    fn resolve_pending_trigger_returns_none_when_empty() {
+        let mut pending: Option<PendingTrigger> = None;
+        assert_eq!(resolve_pending_trigger(&mut pending, true, false), None);
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn resolve_pending_trigger_clears_slot_on_resolution() {
+        let mut pending = Some(PendingTrigger::Trigger);
+        let resolved = resolve_pending_trigger(&mut pending, true, false);
+        assert_eq!(resolved, Some(PendingTrigger::Trigger));
+        assert!(
+            pending.is_none(),
+            "slot must be cleared so a stale entry cannot fire later"
+        );
+    }
+
+    #[test]
+    fn resolve_pending_trigger_drops_when_auto_trigger_disabled() {
+        let mut pending = Some(PendingTrigger::Trigger);
+        assert_eq!(resolve_pending_trigger(&mut pending, false, false), None);
+        assert!(
+            pending.is_none(),
+            "disabled auto-trigger must drain the slot, not leave it for a later batch"
+        );
+    }
+
+    #[test]
+    fn resolve_pending_trigger_skips_debounce_when_suppressed() {
+        let mut pending = Some(PendingTrigger::Debounce);
+        assert_eq!(resolve_pending_trigger(&mut pending, true, true), None);
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn resolve_pending_trigger_keeps_immediate_trigger_under_debounce_suppression() {
+        // PendingTrigger::Trigger came from has_pending_trigger or delay_ms=0.
+        // Both bypass debounce_suppressed, so the resolve path must too.
+        let mut pending = Some(PendingTrigger::Trigger);
+        assert_eq!(
+            resolve_pending_trigger(&mut pending, true, true),
+            Some(PendingTrigger::Trigger)
+        );
+        assert!(pending.is_none());
     }
 
     use gc_parser::TerminalParser;

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -961,9 +961,11 @@ fn poll_until(
 /// independent of timing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Action {
-    /// Fire suggestions synchronously (bypasses debounce_suppressed: stashed
-    /// only via `has_pending_trigger` or `delay_ms == 0`, both of which
-    /// already passed the suppression gate before reaching this point).
+    /// Fire suggestions synchronously. Bypasses `debounce_suppressed` because
+    /// the variant is only produced by paths that already cleared that gate —
+    /// `has_pending_trigger=true` (returns Trigger before the suppression
+    /// check) or `delay_ms == 0` (only reached when the suppression check
+    /// returned false).
     Trigger,
     /// Notify the debounce loop; the loop re-checks suppression at fire time.
     Debounce,
@@ -978,7 +980,7 @@ enum BufferDirtyAction {
     /// ensures popup geometry is computed against a current cursor.
     Defer(Action),
     /// Drop the buffer event (auto-trigger disabled, or debounce suppressed
-    /// without an upgrading pending_trigger).
+    /// with no pending user-trigger to bypass it).
     Ignore,
 }
 
@@ -1054,8 +1056,7 @@ impl PendingTrigger {
 
     /// Clear the slot if a fresher non-Defer action superseded it. Logs at
     /// trace so a Defer(Trigger)→Debounce/Ignore demotion is visible at
-    /// `RUST_LOG=trace` (the user keystroke that set up the Trigger has
-    /// already cleared `h.trigger_requested`).
+    /// `RUST_LOG=trace`.
     fn clear_for_supersede(&mut self, reason: &'static str) {
         if let Some(prior) = self.0.take() {
             tracing::trace!(?prior, reason, "PendingTrigger: clearing on supersede");
@@ -1492,11 +1493,19 @@ mod tests {
 
     #[test]
     fn buffer_dirty_action_ignores_when_debounce_suppressed_and_no_pending_trigger() {
-        for pending in [false, true] {
-            assert_eq!(
-                buffer_dirty_action(false, 0, true, true, pending),
-                BufferDirtyAction::Ignore
-            );
+        // Exhaustive over delay_ms × buffer_pending_display. The early
+        // `if debounce_suppressed { return Ignore }` returns regardless of
+        // delay_ms; iterating both cells guards against a future refactor that
+        // hoists the delay_ms != 0 branch above the suppression check and
+        // silently flips delay_ms=150 to Defer/Immediate(Debounce).
+        for delay_ms in [0u64, 150] {
+            for pending in [false, true] {
+                assert_eq!(
+                    buffer_dirty_action(false, delay_ms, true, true, pending),
+                    BufferDirtyAction::Ignore,
+                    "suppressed must dominate (delay_ms={delay_ms}, pending_display={pending})"
+                );
+            }
         }
     }
 
@@ -1562,6 +1571,17 @@ mod tests {
             !pending.is_pending(),
             "disabled auto-trigger must drain the slot, not leave it for a later batch"
         );
+    }
+
+    #[test]
+    fn pending_trigger_resolve_drops_debounce_when_auto_trigger_disabled() {
+        // Pins that the auto_trigger check gates Debounce too — guards against
+        // a refactor that moves the auto_trigger_enabled check inside the
+        // match arms and silently lets stashed Debounce fire.
+        let mut pending = PendingTrigger::new();
+        pending.stash(Action::Debounce);
+        assert_eq!(pending.resolve(false, false), None);
+        assert!(!pending.is_pending());
     }
 
     #[test]

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -483,11 +483,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let debounce_notify_b = Arc::clone(&debounce_notify);
     let stdout_handle = tokio::task::spawn_blocking(move || {
         let mut buf = [0u8; 8192];
-        // Stashes a buffer-dirty action that observed `buffer_pending_display`
-        // and could not safely trigger this batch. Resolved on a later batch
-        // once the parser confirms the display has caught up to the new
-        // buffer state (i.e., the ZLE redraw has been processed).
-        let mut pending_trigger: Option<PendingTrigger> = None;
+        let mut pending_trigger: Option<DeferredAction> = None;
         loop {
             let n = match reader.read(&mut buf) {
                 Ok(0) => break, // PTY closed
@@ -612,14 +608,6 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            // Check if shell reported a buffer update via OSC 7772, and
-            // whether that update is still waiting for a redraw to catch up
-            // in the terminal display. The pair `(buffer_dirty,
-            // buffer_pending_display)` distinguishes:
-            //   (true,  false) → OSC + redraw in same batch → trigger now
-            //   (true,  true ) → OSC arrived alone → defer until next display
-            //   (false, false) → routine display update → resolve any prior defer
-            //   (false, true ) → pure passthrough mid-defer → keep waiting
             let (buffer_dirty, buffer_pending_display) = {
                 match parser_for_stdout.lock() {
                     Ok(mut p) => {
@@ -664,11 +652,8 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                             debounce_notify_b.notify_one();
                         }
                         BufferDirtyAction::Defer(p) => {
-                            // Stash for the next batch where the redraw
-                            // arrives. Overwriting any prior pending entry
-                            // is intentional: a fresh buffer event
-                            // supersedes the old one.
-                            pending_trigger = Some(p);
+                            // Newer buffer event supersedes any prior stash.
+                            stash_pending(&mut pending_trigger, p);
                         }
                         BufferDirtyAction::Ignore => {
                             pending_trigger = None;
@@ -686,11 +671,6 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            // Resolve any deferred trigger now that the parser has confirmed
-            // a display update applied AFTER the most recent buffer event.
-            // `buffer_pending_display == false` is the parser-side guarantee
-            // that cursor geometry now reflects the current buffer, so the
-            // popup can render at the correct row/column.
             if pending_trigger.is_some() && !buffer_pending_display {
                 let mut render_buf = Vec::new();
                 let render_ticket = {
@@ -707,10 +687,10 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         h.is_debounce_suppressed(),
                     );
                     match resolved {
-                        Some(PendingTrigger::Trigger) => {
+                        Some(DeferredAction::Trigger) => {
                             h.trigger(&parser_for_stdout, &mut render_buf);
                         }
-                        Some(PendingTrigger::Debounce) => {
+                        Some(DeferredAction::Debounce) => {
                             debounce_notify_b.notify_one();
                         }
                         None => {}
@@ -981,31 +961,19 @@ fn poll_until(
     }
 }
 
-/// What the proxy should do once it has observed a `buffer_dirty` event.
-///
-/// `Defer` is the addition that closes #107: when the OSC 7772 buffer
-/// report arrives in a PTY read that does not also include the matching
-/// ZLE redraw, triggering immediately renders the popup from a stale
-/// cursor row/column. The parser's `buffer_pending_display` flag tells
-/// us whether the redraw has been observed yet; if not, the action is
-/// stashed via [`PendingTrigger`] and resolved on a later batch where
-/// `display_dirty` proves the terminal display has caught up.
+/// Defer covers the case where the buffer report arrives before the display redraw, which would otherwise place the popup at stale cursor geometry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BufferDirtyAction {
     Trigger,
     Debounce,
-    Defer(PendingTrigger),
+    Defer(DeferredAction),
     Ignore,
 }
 
-/// What action a deferred `buffer_dirty` should perform when the proxy
-/// observes the next display-changing batch.
+/// Action stashed by buffer_dirty_action when the display redraw must be observed before triggering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PendingTrigger {
-    /// Resolve into [`BufferDirtyAction::Trigger`] (immediate render).
+enum DeferredAction {
     Trigger,
-    /// Resolve into [`BufferDirtyAction::Debounce`] (notify the debounce
-    /// task, which then waits `delay_ms` before triggering).
     Debounce,
 }
 
@@ -1021,7 +989,7 @@ fn buffer_dirty_action(
     }
     if has_pending_trigger {
         return if buffer_pending_display {
-            BufferDirtyAction::Defer(PendingTrigger::Trigger)
+            BufferDirtyAction::Defer(DeferredAction::Trigger)
         } else {
             BufferDirtyAction::Trigger
         };
@@ -1031,42 +999,42 @@ fn buffer_dirty_action(
     }
     if delay_ms == 0 {
         if buffer_pending_display {
-            BufferDirtyAction::Defer(PendingTrigger::Trigger)
+            BufferDirtyAction::Defer(DeferredAction::Trigger)
         } else {
             BufferDirtyAction::Trigger
         }
     } else if buffer_pending_display {
-        BufferDirtyAction::Defer(PendingTrigger::Debounce)
+        BufferDirtyAction::Defer(DeferredAction::Debounce)
     } else {
         BufferDirtyAction::Debounce
     }
 }
 
-/// Resolve a deferred trigger once `display_dirty` has been observed in a
-/// later batch. Returns `None` if no pending trigger was stashed, or if the
-/// handler has since toggled into a state (auto disabled, debounce
-/// suppressed for a Debounce-class deferral) where the original action no
-/// longer applies. Always clears the pending slot so a stale entry cannot
-/// fire later.
+/// Always drains the pending slot; gating may still drop the action.
 fn resolve_pending_trigger(
-    pending: &mut Option<PendingTrigger>,
+    pending: &mut Option<DeferredAction>,
     auto_trigger_enabled: bool,
     debounce_suppressed: bool,
-) -> Option<PendingTrigger> {
+) -> Option<DeferredAction> {
     let action = pending.take()?;
     if !auto_trigger_enabled {
         return None;
     }
     match action {
-        PendingTrigger::Trigger => Some(PendingTrigger::Trigger),
-        PendingTrigger::Debounce => {
+        DeferredAction::Trigger => Some(DeferredAction::Trigger),
+        DeferredAction::Debounce => {
             if debounce_suppressed {
                 None
             } else {
-                Some(PendingTrigger::Debounce)
+                Some(DeferredAction::Debounce)
             }
         }
     }
+}
+
+/// A fresh defer always overwrites; comparing or merging would let stale geometry win.
+fn stash_pending(slot: &mut Option<DeferredAction>, action: DeferredAction) {
+    *slot = Some(action);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1440,7 +1408,7 @@ mod tests {
         // OSC arrived alone, redraw hasn't been processed yet
         assert_eq!(
             buffer_dirty_action(false, 0, true, false, true),
-            BufferDirtyAction::Defer(PendingTrigger::Trigger)
+            BufferDirtyAction::Defer(DeferredAction::Trigger)
         );
     }
 
@@ -1477,7 +1445,7 @@ mod tests {
     fn buffer_dirty_action_defers_to_debounce_when_delay_positive_and_display_pending() {
         assert_eq!(
             buffer_dirty_action(false, 150, true, false, true),
-            BufferDirtyAction::Defer(PendingTrigger::Debounce)
+            BufferDirtyAction::Defer(DeferredAction::Debounce)
         );
     }
 
@@ -1492,26 +1460,25 @@ mod tests {
 
     #[test]
     fn buffer_dirty_action_defers_pending_trigger_when_display_pending() {
-        // Pending trigger but redraw hasn't applied yet — must defer to
-        // avoid rendering popup at stale cursor position (issue #107).
+        // Pending trigger but redraw hasn't applied yet — must defer to avoid stale cursor.
         assert_eq!(
             buffer_dirty_action(true, 150, true, true, true),
-            BufferDirtyAction::Defer(PendingTrigger::Trigger)
+            BufferDirtyAction::Defer(DeferredAction::Trigger)
         );
     }
 
     #[test]
     fn resolve_pending_trigger_returns_none_when_empty() {
-        let mut pending: Option<PendingTrigger> = None;
+        let mut pending: Option<DeferredAction> = None;
         assert_eq!(resolve_pending_trigger(&mut pending, true, false), None);
         assert!(pending.is_none());
     }
 
     #[test]
     fn resolve_pending_trigger_clears_slot_on_resolution() {
-        let mut pending = Some(PendingTrigger::Trigger);
+        let mut pending = Some(DeferredAction::Trigger);
         let resolved = resolve_pending_trigger(&mut pending, true, false);
-        assert_eq!(resolved, Some(PendingTrigger::Trigger));
+        assert_eq!(resolved, Some(DeferredAction::Trigger));
         assert!(
             pending.is_none(),
             "slot must be cleared so a stale entry cannot fire later"
@@ -1520,7 +1487,7 @@ mod tests {
 
     #[test]
     fn resolve_pending_trigger_drops_when_auto_trigger_disabled() {
-        let mut pending = Some(PendingTrigger::Trigger);
+        let mut pending = Some(DeferredAction::Trigger);
         assert_eq!(resolve_pending_trigger(&mut pending, false, false), None);
         assert!(
             pending.is_none(),
@@ -1530,21 +1497,59 @@ mod tests {
 
     #[test]
     fn resolve_pending_trigger_skips_debounce_when_suppressed() {
-        let mut pending = Some(PendingTrigger::Debounce);
+        let mut pending = Some(DeferredAction::Debounce);
         assert_eq!(resolve_pending_trigger(&mut pending, true, true), None);
         assert!(pending.is_none());
     }
 
     #[test]
     fn resolve_pending_trigger_keeps_immediate_trigger_under_debounce_suppression() {
-        // PendingTrigger::Trigger came from has_pending_trigger or delay_ms=0.
+        // DeferredAction::Trigger came from has_pending_trigger or delay_ms=0.
         // Both bypass debounce_suppressed, so the resolve path must too.
-        let mut pending = Some(PendingTrigger::Trigger);
+        let mut pending = Some(DeferredAction::Trigger);
         assert_eq!(
             resolve_pending_trigger(&mut pending, true, true),
-            Some(PendingTrigger::Trigger)
+            Some(DeferredAction::Trigger)
         );
         assert!(pending.is_none());
+    }
+
+    #[test]
+    fn stash_pending_supersedes_prior_entry() {
+        // A stale defer must never out-survive a fresh one — the second buffer
+        // event reflects newer cursor geometry.
+        let mut slot: Option<DeferredAction> = None;
+        stash_pending(&mut slot, DeferredAction::Trigger);
+        assert_eq!(slot, Some(DeferredAction::Trigger));
+        stash_pending(&mut slot, DeferredAction::Debounce);
+        assert_eq!(
+            slot,
+            Some(DeferredAction::Debounce),
+            "newer Defer must overwrite the prior stash, not merge or be discarded"
+        );
+    }
+
+    #[test]
+    fn resolved_defer_debounce_drives_notify_one() {
+        // Mirrors the stdout-task wiring: resolve_pending_trigger →
+        // Some(Debounce) → debounce_notify.notify_one(). A waiter parked on
+        // .notified() must complete after that single notify_one.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        rt.block_on(async {
+            let notify = Arc::new(Notify::new());
+            let mut pending = Some(DeferredAction::Debounce);
+            let resolved = resolve_pending_trigger(&mut pending, true, false);
+            assert_eq!(resolved, Some(DeferredAction::Debounce));
+            if let Some(DeferredAction::Debounce) = resolved {
+                notify.notify_one();
+            }
+            tokio::time::timeout(std::time::Duration::from_millis(100), notify.notified())
+                .await
+                .expect("notify_one must wake a parked waiter");
+        });
     }
 
     use gc_parser::TerminalParser;

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -483,7 +483,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     let debounce_notify_b = Arc::clone(&debounce_notify);
     let stdout_handle = tokio::task::spawn_blocking(move || {
         let mut buf = [0u8; 8192];
-        let mut pending_trigger: Option<DeferredAction> = None;
+        let mut pending_trigger = PendingTrigger::new();
         loop {
             let n = match reader.read(&mut buf) {
                 Ok(0) => break, // PTY closed
@@ -643,20 +643,19 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                         h.clear_trigger_request();
                     }
                     match action {
-                        BufferDirtyAction::Trigger => {
-                            pending_trigger = None;
+                        BufferDirtyAction::Immediate(Action::Trigger) => {
+                            pending_trigger.clear_for_supersede("immediate Trigger");
                             h.trigger(&parser_for_stdout, &mut render_buf);
                         }
-                        BufferDirtyAction::Debounce => {
-                            pending_trigger = None;
+                        BufferDirtyAction::Immediate(Action::Debounce) => {
+                            pending_trigger.clear_for_supersede("immediate Debounce");
                             debounce_notify_b.notify_one();
                         }
-                        BufferDirtyAction::Defer(p) => {
-                            // Newer buffer event supersedes any prior stash.
-                            stash_pending(&mut pending_trigger, p);
+                        BufferDirtyAction::Defer(action) => {
+                            pending_trigger.stash(action);
                         }
                         BufferDirtyAction::Ignore => {
-                            pending_trigger = None;
+                            pending_trigger.clear_for_supersede("Ignore");
                         }
                     }
                     h.overlay_write_ticket()
@@ -671,7 +670,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 }
             }
 
-            if pending_trigger.is_some() && !buffer_pending_display {
+            if pending_trigger.is_pending() && !buffer_pending_display {
                 let mut render_buf = Vec::new();
                 let render_ticket = {
                     let mut h = match handler_for_stdout.lock() {
@@ -681,16 +680,13 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                             break;
                         }
                     };
-                    let resolved = resolve_pending_trigger(
-                        &mut pending_trigger,
-                        h.auto_trigger_enabled(),
-                        h.is_debounce_suppressed(),
-                    );
+                    let resolved = pending_trigger
+                        .resolve(h.auto_trigger_enabled(), h.is_debounce_suppressed());
                     match resolved {
-                        Some(DeferredAction::Trigger) => {
+                        Some(Action::Trigger) => {
                             h.trigger(&parser_for_stdout, &mut render_buf);
                         }
-                        Some(DeferredAction::Debounce) => {
+                        Some(Action::Debounce) => {
                             debounce_notify_b.notify_one();
                         }
                         None => {}
@@ -961,20 +957,29 @@ fn poll_until(
     }
 }
 
-/// Defer covers the case where the buffer report arrives before the display redraw, which would otherwise place the popup at stale cursor geometry.
+/// What the dispatcher should do with a single suggestion-relevant action,
+/// independent of timing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BufferDirtyAction {
+enum Action {
+    /// Fire suggestions synchronously (bypasses debounce_suppressed: stashed
+    /// only via `has_pending_trigger` or `delay_ms == 0`, both of which
+    /// already passed the suppression gate before reaching this point).
     Trigger,
+    /// Notify the debounce loop; the loop re-checks suppression at fire time.
     Debounce,
-    Defer(DeferredAction),
-    Ignore,
 }
 
-/// Action stashed by buffer_dirty_action when the display redraw must be observed before triggering.
+/// Outcome of `buffer_dirty_action` — three-way split over the action axis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DeferredAction {
-    Trigger,
-    Debounce,
+enum BufferDirtyAction {
+    /// Apply the action immediately; the display has caught up to the buffer report.
+    Immediate(Action),
+    /// Stash the action until the parser observes a display-changing byte;
+    /// ensures popup geometry is computed against a current cursor.
+    Defer(Action),
+    /// Drop the buffer event (auto-trigger disabled, or debounce suppressed
+    /// without an upgrading pending_trigger).
+    Ignore,
 }
 
 fn buffer_dirty_action(
@@ -989,9 +994,9 @@ fn buffer_dirty_action(
     }
     if has_pending_trigger {
         return if buffer_pending_display {
-            BufferDirtyAction::Defer(DeferredAction::Trigger)
+            BufferDirtyAction::Defer(Action::Trigger)
         } else {
-            BufferDirtyAction::Trigger
+            BufferDirtyAction::Immediate(Action::Trigger)
         };
     }
     if debounce_suppressed {
@@ -999,42 +1004,92 @@ fn buffer_dirty_action(
     }
     if delay_ms == 0 {
         if buffer_pending_display {
-            BufferDirtyAction::Defer(DeferredAction::Trigger)
+            BufferDirtyAction::Defer(Action::Trigger)
         } else {
-            BufferDirtyAction::Trigger
+            BufferDirtyAction::Immediate(Action::Trigger)
         }
     } else if buffer_pending_display {
-        BufferDirtyAction::Defer(DeferredAction::Debounce)
+        BufferDirtyAction::Defer(Action::Debounce)
     } else {
-        BufferDirtyAction::Debounce
+        BufferDirtyAction::Immediate(Action::Debounce)
     }
 }
 
-/// Always drains the pending slot; gating may still drop the action.
-fn resolve_pending_trigger(
-    pending: &mut Option<DeferredAction>,
-    auto_trigger_enabled: bool,
-    debounce_suppressed: bool,
-) -> Option<DeferredAction> {
-    let action = pending.take()?;
-    if !auto_trigger_enabled {
-        return None;
+/// Single-slot stash for a deferred `Action`. Encapsulates the three
+/// invariants that the stdout task relies on:
+///
+/// 1. `stash` unconditionally overwrites — a newer buffer event always
+///    reflects newer cursor geometry, so merging or keeping the old entry
+///    would let stale geometry win.
+/// 2. `resolve` always drains the slot when present, even when gating drops
+///    the action — leaving an entry behind would let it fire on a later
+///    redraw cycle that no longer matches the user's intent.
+/// 3. The asymmetry between Trigger and Debounce on debounce-suppression is
+///    documented on `resolve` — Trigger came from a code path that already
+///    bypassed the suppression check, so re-checking here would lose the
+///    invariant.
+#[derive(Debug, Default)]
+struct PendingTrigger(Option<Action>);
+
+impl PendingTrigger {
+    fn new() -> Self {
+        Self(None)
     }
-    match action {
-        DeferredAction::Trigger => Some(DeferredAction::Trigger),
-        DeferredAction::Debounce => {
-            if debounce_suppressed {
-                None
-            } else {
-                Some(DeferredAction::Debounce)
+
+    /// Stash a deferred action. Logs at trace when an existing stash is
+    /// overwritten so a developer can correlate "the popup didn't fire"
+    /// with a defer-overwrites-defer race.
+    fn stash(&mut self, action: Action) {
+        if let Some(prior) = self.0 {
+            tracing::trace!(?prior, new = ?action, "PendingTrigger: overwriting prior stash");
+        } else {
+            tracing::trace!(new = ?action, "PendingTrigger: stashing");
+        }
+        self.0 = Some(action);
+    }
+
+    fn is_pending(&self) -> bool {
+        self.0.is_some()
+    }
+
+    /// Clear the slot if a fresher non-Defer action superseded it. Logs at
+    /// trace so a Defer(Trigger)→Debounce/Ignore demotion is visible at
+    /// `RUST_LOG=trace` (the user keystroke that set up the Trigger has
+    /// already cleared `h.trigger_requested`).
+    fn clear_for_supersede(&mut self, reason: &'static str) {
+        if let Some(prior) = self.0.take() {
+            tracing::trace!(?prior, reason, "PendingTrigger: clearing on supersede");
+        }
+    }
+
+    /// Drain the slot if non-empty. Returns None when auto_trigger is
+    /// disabled. Returns None for a stashed Debounce when debounce is
+    /// suppressed; a stashed Trigger always survives (it originated from
+    /// a path — `has_pending_trigger` or `delay_ms == 0` — that already
+    /// bypasses `debounce_suppressed`, so re-checking would lose the
+    /// user-explicit-trigger-bypasses-debounce invariant).
+    fn resolve(&mut self, auto_trigger_enabled: bool, debounce_suppressed: bool) -> Option<Action> {
+        let action = self.0.take()?;
+        if !auto_trigger_enabled {
+            tracing::trace!(?action, "PendingTrigger: dropped (auto_trigger disabled)");
+            return None;
+        }
+        match action {
+            Action::Trigger => {
+                tracing::trace!("PendingTrigger: fired Trigger");
+                Some(Action::Trigger)
+            }
+            Action::Debounce => {
+                if debounce_suppressed {
+                    tracing::trace!("PendingTrigger: dropped Debounce (suppressed)");
+                    None
+                } else {
+                    tracing::trace!("PendingTrigger: fired Debounce");
+                    Some(Action::Debounce)
+                }
             }
         }
     }
-}
-
-/// A fresh defer always overwrites; comparing or merging would let stale geometry win.
-fn stash_pending(slot: &mut Option<DeferredAction>, action: DeferredAction) {
-    *slot = Some(action);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1399,7 +1454,7 @@ mod tests {
         // OSC + redraw landed in same batch → buffer_pending_display=false
         assert_eq!(
             buffer_dirty_action(false, 0, true, false, false),
-            BufferDirtyAction::Trigger
+            BufferDirtyAction::Immediate(Action::Trigger)
         );
     }
 
@@ -1408,18 +1463,30 @@ mod tests {
         // OSC arrived alone, redraw hasn't been processed yet
         assert_eq!(
             buffer_dirty_action(false, 0, true, false, true),
-            BufferDirtyAction::Defer(DeferredAction::Trigger)
+            BufferDirtyAction::Defer(Action::Trigger)
         );
     }
 
     #[test]
     fn buffer_dirty_action_ignores_when_auto_trigger_disabled() {
-        for pending in [false, true] {
-            assert_eq!(
-                buffer_dirty_action(false, 0, false, false, pending),
-                BufferDirtyAction::Ignore,
-                "auto-disabled must dominate regardless of buffer_pending_display={pending}"
-            );
+        // Exhaustive over has_pending_trigger × buffer_pending_display × delay_ms.
+        // auto_disabled must dominate every combination — guards against a
+        // future refactor that hoists has_pending_trigger above the
+        // auto-disabled check.
+        for has_pending in [false, true] {
+            for pending in [false, true] {
+                for delay_ms in [0u64, 150] {
+                    for suppressed in [false, true] {
+                        assert_eq!(
+                            buffer_dirty_action(has_pending, delay_ms, false, suppressed, pending),
+                            BufferDirtyAction::Ignore,
+                            "auto-disabled must dominate (has_pending={has_pending}, \
+                             delay_ms={delay_ms}, suppressed={suppressed}, \
+                             pending_display={pending})"
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -1437,7 +1504,7 @@ mod tests {
     fn buffer_dirty_action_debounces_when_delay_positive_and_display_caught_up() {
         assert_eq!(
             buffer_dirty_action(false, 150, true, false, false),
-            BufferDirtyAction::Debounce
+            BufferDirtyAction::Immediate(Action::Debounce)
         );
     }
 
@@ -1445,7 +1512,7 @@ mod tests {
     fn buffer_dirty_action_defers_to_debounce_when_delay_positive_and_display_pending() {
         assert_eq!(
             buffer_dirty_action(false, 150, true, false, true),
-            BufferDirtyAction::Defer(DeferredAction::Debounce)
+            BufferDirtyAction::Defer(Action::Debounce)
         );
     }
 
@@ -1454,7 +1521,7 @@ mod tests {
         // Pending trigger from input handler bypasses debounce_suppressed
         assert_eq!(
             buffer_dirty_action(true, 150, true, true, false),
-            BufferDirtyAction::Trigger
+            BufferDirtyAction::Immediate(Action::Trigger)
         );
     }
 
@@ -1463,75 +1530,130 @@ mod tests {
         // Pending trigger but redraw hasn't applied yet — must defer to avoid stale cursor.
         assert_eq!(
             buffer_dirty_action(true, 150, true, true, true),
-            BufferDirtyAction::Defer(DeferredAction::Trigger)
+            BufferDirtyAction::Defer(Action::Trigger)
         );
     }
 
     #[test]
-    fn resolve_pending_trigger_returns_none_when_empty() {
-        let mut pending: Option<DeferredAction> = None;
-        assert_eq!(resolve_pending_trigger(&mut pending, true, false), None);
-        assert!(pending.is_none());
+    fn pending_trigger_resolve_returns_none_when_empty() {
+        let mut pending = PendingTrigger::new();
+        assert_eq!(pending.resolve(true, false), None);
+        assert!(!pending.is_pending());
     }
 
     #[test]
-    fn resolve_pending_trigger_clears_slot_on_resolution() {
-        let mut pending = Some(DeferredAction::Trigger);
-        let resolved = resolve_pending_trigger(&mut pending, true, false);
-        assert_eq!(resolved, Some(DeferredAction::Trigger));
+    fn pending_trigger_resolve_clears_slot_on_resolution() {
+        let mut pending = PendingTrigger::new();
+        pending.stash(Action::Trigger);
+        let resolved = pending.resolve(true, false);
+        assert_eq!(resolved, Some(Action::Trigger));
         assert!(
-            pending.is_none(),
+            !pending.is_pending(),
             "slot must be cleared so a stale entry cannot fire later"
         );
     }
 
     #[test]
-    fn resolve_pending_trigger_drops_when_auto_trigger_disabled() {
-        let mut pending = Some(DeferredAction::Trigger);
-        assert_eq!(resolve_pending_trigger(&mut pending, false, false), None);
+    fn pending_trigger_resolve_drops_when_auto_trigger_disabled() {
+        let mut pending = PendingTrigger::new();
+        pending.stash(Action::Trigger);
+        assert_eq!(pending.resolve(false, false), None);
         assert!(
-            pending.is_none(),
+            !pending.is_pending(),
             "disabled auto-trigger must drain the slot, not leave it for a later batch"
         );
     }
 
     #[test]
-    fn resolve_pending_trigger_skips_debounce_when_suppressed() {
-        let mut pending = Some(DeferredAction::Debounce);
-        assert_eq!(resolve_pending_trigger(&mut pending, true, true), None);
-        assert!(pending.is_none());
+    fn pending_trigger_resolve_skips_debounce_when_suppressed() {
+        let mut pending = PendingTrigger::new();
+        pending.stash(Action::Debounce);
+        assert_eq!(pending.resolve(true, true), None);
+        assert!(!pending.is_pending());
     }
 
     #[test]
-    fn resolve_pending_trigger_keeps_immediate_trigger_under_debounce_suppression() {
-        // DeferredAction::Trigger came from has_pending_trigger or delay_ms=0.
+    fn pending_trigger_resolve_keeps_immediate_trigger_under_debounce_suppression() {
+        // Action::Trigger was stashed by has_pending_trigger or delay_ms=0.
         // Both bypass debounce_suppressed, so the resolve path must too.
-        let mut pending = Some(DeferredAction::Trigger);
-        assert_eq!(
-            resolve_pending_trigger(&mut pending, true, true),
-            Some(DeferredAction::Trigger)
-        );
-        assert!(pending.is_none());
+        let mut pending = PendingTrigger::new();
+        pending.stash(Action::Trigger);
+        assert_eq!(pending.resolve(true, true), Some(Action::Trigger));
+        assert!(!pending.is_pending());
     }
 
     #[test]
-    fn stash_pending_supersedes_prior_entry() {
+    fn pending_trigger_stash_supersedes_prior_entry() {
         // A stale defer must never out-survive a fresh one — the second buffer
         // event reflects newer cursor geometry.
-        let mut slot: Option<DeferredAction> = None;
-        stash_pending(&mut slot, DeferredAction::Trigger);
-        assert_eq!(slot, Some(DeferredAction::Trigger));
-        stash_pending(&mut slot, DeferredAction::Debounce);
+        let mut pending = PendingTrigger::new();
+        pending.stash(Action::Trigger);
+        assert!(pending.is_pending());
+        pending.stash(Action::Debounce);
         assert_eq!(
-            slot,
-            Some(DeferredAction::Debounce),
+            pending.resolve(true, false),
+            Some(Action::Debounce),
             "newer Defer must overwrite the prior stash, not merge or be discarded"
         );
     }
 
+    /// Exercise the dispatcher's `pending_trigger` reset wiring: the stdout
+    /// task clears the slot on every non-Defer arm so a stashed entry from a
+    /// prior iteration cannot survive a newer Trigger/Debounce/Ignore and
+    /// fire spuriously when display catches up later.
+    fn apply_buffer_dirty_action(slot: &mut PendingTrigger, action: BufferDirtyAction) {
+        match action {
+            BufferDirtyAction::Immediate(_) => slot.clear_for_supersede("immediate"),
+            BufferDirtyAction::Defer(a) => slot.stash(a),
+            BufferDirtyAction::Ignore => slot.clear_for_supersede("ignore"),
+        }
+    }
+
+    #[test]
+    fn pending_trigger_cleared_by_immediate_trigger() {
+        let mut slot = PendingTrigger::new();
+        slot.stash(Action::Trigger);
+        apply_buffer_dirty_action(&mut slot, BufferDirtyAction::Immediate(Action::Trigger));
+        assert!(
+            !slot.is_pending(),
+            "immediate Trigger must drain prior stash"
+        );
+    }
+
+    #[test]
+    fn pending_trigger_cleared_by_immediate_debounce() {
+        let mut slot = PendingTrigger::new();
+        slot.stash(Action::Trigger);
+        apply_buffer_dirty_action(&mut slot, BufferDirtyAction::Immediate(Action::Debounce));
+        assert!(
+            !slot.is_pending(),
+            "immediate Debounce must drain prior Trigger stash even though it demotes the user intent"
+        );
+    }
+
+    #[test]
+    fn pending_trigger_cleared_by_ignore() {
+        let mut slot = PendingTrigger::new();
+        slot.stash(Action::Trigger);
+        apply_buffer_dirty_action(&mut slot, BufferDirtyAction::Ignore);
+        assert!(!slot.is_pending(), "Ignore must drain prior stash");
+    }
+
+    #[test]
+    fn pending_trigger_overwritten_by_defer() {
+        let mut slot = PendingTrigger::new();
+        slot.stash(Action::Trigger);
+        apply_buffer_dirty_action(&mut slot, BufferDirtyAction::Defer(Action::Debounce));
+        assert!(
+            slot.is_pending(),
+            "Defer must keep slot populated (with overwritten action)"
+        );
+        assert_eq!(slot.resolve(true, false), Some(Action::Debounce));
+    }
+
     #[test]
     fn resolved_defer_debounce_drives_notify_one() {
-        // Mirrors the stdout-task wiring: resolve_pending_trigger →
+        // Mirrors the stdout-task wiring: PendingTrigger::resolve →
         // Some(Debounce) → debounce_notify.notify_one(). A waiter parked on
         // .notified() must complete after that single notify_one.
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -1540,10 +1662,11 @@ mod tests {
             .expect("current-thread runtime");
         rt.block_on(async {
             let notify = Arc::new(Notify::new());
-            let mut pending = Some(DeferredAction::Debounce);
-            let resolved = resolve_pending_trigger(&mut pending, true, false);
-            assert_eq!(resolved, Some(DeferredAction::Debounce));
-            if let Some(DeferredAction::Debounce) = resolved {
+            let mut pending = PendingTrigger::new();
+            pending.stash(Action::Debounce);
+            let resolved = pending.resolve(true, false);
+            assert_eq!(resolved, Some(Action::Debounce));
+            if let Some(Action::Debounce) = resolved {
                 notify.notify_one();
             }
             tokio::time::timeout(std::time::Duration::from_millis(100), notify.notified())

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -4,9 +4,11 @@ use harness::GhostProcess;
 use std::thread;
 use std::time::Duration;
 
-/// DECSC — first byte emitted by render_popup.
+/// DECSC. Emitted by both `render_popup` and `clear_popup`; presence after a
+/// clean baseline indicates popup activity (not uniquely a fresh render).
 const POPUP_RENDER_MARKER: &[u8] = b"\x1b7";
-/// DECRC — last byte emitted by clear_popup.
+/// DECRC. Emitted near the end of `clear_popup` (an end-sync sequence may
+/// follow), so its appearance after a dismiss signals the teardown ran.
 const POPUP_TEARDOWN_MARKER: &[u8] = b"\x1b8";
 /// Long enough for any unblocked render to land; short enough to keep tests quick.
 const NO_RENDER_WINDOW: Duration = Duration::from_millis(500);
@@ -33,7 +35,14 @@ fn assert_no_popup_render_after(proc: &GhostProcess, mark: usize, context: &str)
     }
 }
 
-/// Drives a printable byte through the shell's pending read so the parser sees a display update without leaking into the next command.
+/// Drives a printable byte through the shell's pending read so the parser sees
+/// a display update without leaking into the next command.
+///
+/// Depends on the inner shell's TTY layer being in cooked mode with ECHO on:
+/// the byte we write to the master is consumed by `read` and only reaches the
+/// parser via the kernel echo. Do not call this against a shell that disables
+/// echo (e.g. `read -s`, `stty -echo`, or an init script that flips raw mode);
+/// the deferred trigger will never resolve and the test will time out.
 fn advance_display(proc: &mut GhostProcess) -> usize {
     let mark = proc.output_len();
     proc.write_raw(b"x");
@@ -376,7 +385,10 @@ fn test_popup_defers_until_display_after_osc_only_pty_read() {
 
     let mark_before_osc = proc.output_len();
 
-    // OSC 7770 raw framing avoids `printf` percent-format interpretation; `read` blocks the shell from emitting follow-up display bytes.
+    // `printf` interprets the `\033`/`\007` backslash escapes into ESC/BEL,
+    // which is what frames the OSC sequence; `read` then parks the shell so
+    // it cannot emit follow-up display bytes that would resolve the defer on
+    // their own.
     proc.send_line(r"printf '\033]7770;4;git \007'; read _gc_defer_gate");
 
     assert_no_popup_render_after(&proc, mark_before_osc, "OSC-only PTY read defer");
@@ -393,7 +405,7 @@ fn test_popup_defers_until_display_after_osc_only_pty_read() {
         let since_redraw = &snapshot[mark_before_redraw..];
         panic!(
             "Deferred trigger failed to resolve into a popup render after \
-             display advanced. This is the issue #107 fix regression check.\n\
+             display advanced.\n\
              Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
             since_redraw.len(),
             String::from_utf8_lossy(since_redraw),
@@ -407,7 +419,7 @@ fn test_popup_defers_until_display_after_osc_only_pty_read() {
 }
 
 #[test]
-fn test_popup_renders_when_osc_and_display_share_pty_read() {
+fn test_popup_renders_for_osc_with_inline_display_byte() {
     let mut proc = GhostProcess::spawn();
 
     proc.send_line("echo inline_smoke_ready_marker");
@@ -415,9 +427,11 @@ fn test_popup_renders_when_osc_and_display_share_pty_read() {
 
     let mark_before_trigger = proc.output_len();
 
-    // OSC + printable byte in the same `printf` — they coalesce into one PTY
-    // chunk, so the parser observes the display update alongside the buffer
-    // report and the trigger must fire without any external `advance_display`.
+    // OSC + printable byte in a single `printf` payload. The shell emits both
+    // before parking on `read`, so the popup must eventually render without
+    // any external `advance_display` nudge. Same-batch coalescing into one
+    // PTY read is not asserted here — kernel chunking can split the bytes
+    // across reads and the proxy's deferred path is allowed to resolve it.
     proc.send_line(r"printf '\033]7770;4;git \007X'; read _gc_inline_gate");
 
     let popup_rendered = proc.wait_for_bytes_after(
@@ -429,7 +443,7 @@ fn test_popup_renders_when_osc_and_display_share_pty_read() {
         let snapshot = proc.output_snapshot();
         let since_mark = &snapshot[mark_before_trigger..];
         panic!(
-            "Popup did not render within 5s when OSC and display update shared a PTY read.\n\
+            "Popup did not render within 5s for OSC with inline display byte.\n\
              Bytes since mark ({} bytes, lossy UTF-8):\n{:?}",
             since_mark.len(),
             String::from_utf8_lossy(since_mark),

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -4,6 +4,19 @@ use harness::GhostProcess;
 use std::thread;
 use std::time::Duration;
 
+/// First byte sequence emitted by `gc-overlay::render_popup`: DECSC (save
+/// cursor). Seeing it after a marked offset proves a popup render ran.
+const POPUP_RENDER_MARKER: &[u8] = b"\x1b7";
+/// Last byte sequence emitted by `gc-overlay::clear_popup`: DECRC (restore
+/// cursor). Seeing it after a marked offset proves a teardown ran.
+const POPUP_TEARDOWN_MARKER: &[u8] = b"\x1b8";
+/// Window during which we assert the popup must NOT render. Long enough that
+/// any unblocked render path would have completed; short enough that test
+/// time stays reasonable. The popup-defer behavior (issue #107) keeps the
+/// popup invisible across this entire window when only an OSC report has
+/// been observed and no display update has followed.
+const NO_RENDER_WINDOW: Duration = Duration::from_millis(500);
+
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     if needle.is_empty() {
         return Some(0);
@@ -11,6 +24,37 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack
         .windows(needle.len())
         .position(|window| window == needle)
+}
+
+/// Asserts the popup did NOT render within `NO_RENDER_WINDOW` after the
+/// given offset, panicking with captured bytes for diagnosis if it did.
+/// Covers the issue-#107 invariant: an OSC 7770/7772 buffer report observed
+/// in isolation (no following ZLE redraw bytes in the same PTY read) must
+/// not produce a popup until the next display update lands.
+fn assert_no_popup_render_after(proc: &GhostProcess, mark: usize, context: &str) {
+    if proc.wait_for_bytes_after(POPUP_RENDER_MARKER, mark, NO_RENDER_WINDOW) {
+        let snapshot = proc.output_snapshot();
+        let since_mark = &snapshot[mark..];
+        panic!(
+            "Popup rendered before display advanced during {context}. \
+             Issue #107 regression: trigger fired on stale cursor geometry.\n\
+             Bytes since mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_mark.len(),
+            String::from_utf8_lossy(since_mark),
+        );
+    }
+}
+
+/// Advances the parser's display state from the test driver. Writes a single
+/// printable byte that the shell will echo back, producing CSI/print bytes
+/// the parser interprets as `display_dirty`. The byte is consumed by the
+/// shell's pending `read` so it doesn't leak into a follow-up command.
+/// Returns the output offset captured immediately before the byte was
+/// written, so subsequent assertions can require activity strictly after.
+fn advance_display(proc: &mut GhostProcess) -> usize {
+    let mark = proc.output_len();
+    proc.write_raw(b"x");
+    mark
 }
 
 #[test]
@@ -194,28 +238,44 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
     //     OSC ] 7770 ; <cursor-char-offset> ; <buffer> BEL
     //     \x1b]7770;4;git \x07
     // The shell executes printf, emits the raw bytes to stdout, gc-parser
-    // consumes them and sets command_buffer = "git " with cursor = 4.
-    // The buffer_dirty flag causes Task B to auto-fire trigger().
+    // consumes them and sets command_buffer = "git " with cursor = 4. The
+    // buffer_dirty flag is observed by Task B alongside `buffer_pending_display`
+    // (set because no display-changing op has followed); per issue #107 the
+    // proxy must defer the trigger until the parser sees a real redraw.
     //
     // Keep the shell command blocked after the OSC write. If the command
     // exits immediately, the shell prints a new prompt, and the proxy now
     // correctly tears down the popup before forwarding that prompt output.
     proc.send_line(r"printf '\033]7770;4;git \007'; read _ghost_popup_hold");
 
-    // Wait for the popup render. The overlay's first emitted byte sequence
-    // is DECSC (`\x1b7` = save cursor). Seeing it after mark_before_trigger
-    // proves that the OSC 7770 -> auto-trigger -> render_popup pipeline ran.
-    let popup_rendered =
-        proc.wait_for_bytes_after(b"\x1b7", mark_before_trigger, Duration::from_secs(5));
+    // Phase 1: OSC alone — popup must NOT render yet. This is the issue
+    // #107 regression check: prior versions rendered immediately and then
+    // had the popup torn down by the next display_dirty batch.
+    assert_no_popup_render_after(&proc, mark_before_trigger, "git OSC injection");
+
+    // Phase 2: advance display. Writing a printable byte through to the
+    // shell's pending `read` causes the shell's PTY layer to echo it back,
+    // producing display-changing bytes that clear `buffer_pending_display`
+    // in the parser and unblock the deferred trigger.
+    let mark_before_redraw = advance_display(&mut proc);
+
+    // Phase 3: deferred trigger fires now. The overlay's first emitted byte
+    // sequence is DECSC (`\x1b7` = save cursor). Seeing it after the redraw
+    // mark proves the deferred buffer-dirty action resolved cleanly.
+    let popup_rendered = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        mark_before_redraw,
+        Duration::from_secs(5),
+    );
 
     if !popup_rendered {
         let snapshot = proc.output_snapshot();
-        let since_trigger = &snapshot[mark_before_trigger..];
+        let since_redraw = &snapshot[mark_before_redraw..];
         panic!(
-            "Popup did not render within 5s after OSC 7770 injection.\n\
-             Bytes since trigger mark ({} bytes, lossy UTF-8):\n{:?}",
-            since_trigger.len(),
-            String::from_utf8_lossy(since_trigger),
+            "Popup did not render within 5s after display advanced post-OSC 7770.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
         );
     }
 
@@ -252,7 +312,11 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
 
     // clear_popup emits DECSC + movement + blanks + DECRC. The DECRC
     // (`\x1b8`) appearing after the ESC mark is the dismiss signal.
-    let dismissed = proc.wait_for_bytes_after(b"\x1b8", mark_before_esc, Duration::from_secs(5));
+    let dismissed = proc.wait_for_bytes_after(
+        POPUP_TEARDOWN_MARKER,
+        mark_before_esc,
+        Duration::from_secs(5),
+    );
 
     if !dismissed {
         let snapshot = proc.output_snapshot();
@@ -282,16 +346,24 @@ fn test_popup_is_cleared_before_later_shell_output() {
     let mark_before_trigger = proc.output_len();
     proc.send_line(r"printf '\033]7770;4;git \007'; read _gc_smoke_gate");
 
-    let popup_rendered =
-        proc.wait_for_bytes_after(b"\x1b7", mark_before_trigger, Duration::from_secs(5));
+    // Issue #107 deferral: OSC alone must not render. Advance display so
+    // the deferred trigger can resolve.
+    assert_no_popup_render_after(&proc, mark_before_trigger, "prompt-repaint cleanup setup");
+    let mark_before_redraw = advance_display(&mut proc);
+
+    let popup_rendered = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        mark_before_redraw,
+        Duration::from_secs(5),
+    );
     if !popup_rendered {
         let snapshot = proc.output_snapshot();
-        let since_trigger = &snapshot[mark_before_trigger..];
+        let since_redraw = &snapshot[mark_before_redraw..];
         panic!(
-            "Popup did not render before prompt repaint.\n\
-             Bytes since trigger mark ({} bytes, lossy UTF-8):\n{:?}",
-            since_trigger.len(),
-            String::from_utf8_lossy(since_trigger),
+            "Popup did not render after display advanced post-OSC, before prompt repaint.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
         );
     }
 
@@ -331,5 +403,74 @@ fn test_popup_is_cleared_before_later_shell_output() {
         String::from_utf8_lossy(after_marker),
     );
 
+    proc.exit_with_code(0);
+}
+
+/// Issue #107 regression: when the OSC 7772 buffer report and the matching
+/// ZLE redraw arrive in *separate* PTY reads (a timing pattern that varies
+/// by macOS version, CPU, and PTY scheduler), prior versions rendered the
+/// popup on the first read at stale cursor geometry and then immediately
+/// tore it down on the second read's `display_dirty`. Users perceived this
+/// as the popup appearing only on alternating keystrokes.
+///
+/// This test exercises the OSC-only PTY read path explicitly:
+///   1. `printf` writes ONLY the OSC 7772 bytes — no follow-up display ops.
+///   2. The shell blocks on `read`, guaranteeing no further output until we
+///      drive a printable byte through.
+///   3. Assert: popup did NOT render (defer is in effect — `buffer_pending_display`
+///      is set in the parser, the proxy stashes a `PendingTrigger`).
+///   4. Send a printable byte → shell echo path produces display bytes →
+///      parser clears `buffer_pending_display` → proxy resolves the deferred
+///      trigger and renders the popup at the now-correct cursor position.
+///   5. Assert: popup rendered after the redraw mark.
+///
+/// Without the fix, step 3 would fail (popup rendered immediately) and the
+/// teardown-by-display_dirty in the next batch would be the failure mode
+/// the user's video documents.
+#[test]
+fn test_popup_defers_until_display_after_osc_only_pty_read() {
+    let mut proc = GhostProcess::spawn();
+
+    proc.send_line("echo defer_smoke_ready_marker");
+    proc.expect_output("defer_smoke_ready_marker");
+
+    let mark_before_osc = proc.output_len();
+
+    // OSC alone, immediately followed by `read` — no display-changing bytes
+    // emitted by the shell after the OSC until we drive a keystroke. Using
+    // OSC 7770 (legacy raw framing) so `printf` doesn't interpret a `%`
+    // sequence as a format specifier the way OSC 7772 percent-encoding would.
+    proc.send_line(r"printf '\033]7770;4;git \007'; read _gc_defer_gate");
+
+    // Phase 1: defer holds. No popup despite buffer_dirty=true.
+    assert_no_popup_render_after(&proc, mark_before_osc, "OSC-only PTY read defer");
+
+    // Phase 2: drive a printable byte; shell echo provides the display
+    // update that clears `buffer_pending_display` and resolves the defer.
+    let mark_before_redraw = advance_display(&mut proc);
+
+    // Phase 3: deferred trigger resolves and the popup renders. Allow
+    // generous timeout because the trigger goes through the full suggest
+    // pipeline (spec resolution, fuzzy ranking, layout, render).
+    let popup_rendered = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        mark_before_redraw,
+        Duration::from_secs(5),
+    );
+    if !popup_rendered {
+        let snapshot = proc.output_snapshot();
+        let since_redraw = &snapshot[mark_before_redraw..];
+        panic!(
+            "Deferred trigger failed to resolve into a popup render after \
+             display advanced. This is the issue #107 fix regression check.\n\
+             Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_redraw.len(),
+            String::from_utf8_lossy(since_redraw),
+        );
+    }
+
+    // Drain anything still in flight, then unblock the shell's read.
+    proc.write_raw(&[0x1B]); // ESC dismisses the popup so a clean prompt repaint can happen.
+    proc.send_line("");
     proc.exit_with_code(0);
 }

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -4,17 +4,11 @@ use harness::GhostProcess;
 use std::thread;
 use std::time::Duration;
 
-/// First byte sequence emitted by `gc-overlay::render_popup`: DECSC (save
-/// cursor). Seeing it after a marked offset proves a popup render ran.
+/// DECSC — first byte emitted by render_popup.
 const POPUP_RENDER_MARKER: &[u8] = b"\x1b7";
-/// Last byte sequence emitted by `gc-overlay::clear_popup`: DECRC (restore
-/// cursor). Seeing it after a marked offset proves a teardown ran.
+/// DECRC — last byte emitted by clear_popup.
 const POPUP_TEARDOWN_MARKER: &[u8] = b"\x1b8";
-/// Window during which we assert the popup must NOT render. Long enough that
-/// any unblocked render path would have completed; short enough that test
-/// time stays reasonable. The popup-defer behavior (issue #107) keeps the
-/// popup invisible across this entire window when only an OSC report has
-/// been observed and no display update has followed.
+/// Long enough for any unblocked render to land; short enough to keep tests quick.
 const NO_RENDER_WINDOW: Duration = Duration::from_millis(500);
 
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -26,18 +20,12 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-/// Asserts the popup did NOT render within `NO_RENDER_WINDOW` after the
-/// given offset, panicking with captured bytes for diagnosis if it did.
-/// Covers the issue-#107 invariant: an OSC 7770/7772 buffer report observed
-/// in isolation (no following ZLE redraw bytes in the same PTY read) must
-/// not produce a popup until the next display update lands.
 fn assert_no_popup_render_after(proc: &GhostProcess, mark: usize, context: &str) {
     if proc.wait_for_bytes_after(POPUP_RENDER_MARKER, mark, NO_RENDER_WINDOW) {
         let snapshot = proc.output_snapshot();
         let since_mark = &snapshot[mark..];
         panic!(
-            "Popup rendered before display advanced during {context}. \
-             Issue #107 regression: trigger fired on stale cursor geometry.\n\
+            "Popup rendered before display advanced during {context}.\n\
              Bytes since mark ({} bytes, lossy UTF-8):\n{:?}",
             since_mark.len(),
             String::from_utf8_lossy(since_mark),
@@ -45,12 +33,7 @@ fn assert_no_popup_render_after(proc: &GhostProcess, mark: usize, context: &str)
     }
 }
 
-/// Advances the parser's display state from the test driver. Writes a single
-/// printable byte that the shell will echo back, producing CSI/print bytes
-/// the parser interprets as `display_dirty`. The byte is consumed by the
-/// shell's pending `read` so it doesn't leak into a follow-up command.
-/// Returns the output offset captured immediately before the byte was
-/// written, so subsequent assertions can require activity strictly after.
+/// Drives a printable byte through the shell's pending read so the parser sees a display update without leaking into the next command.
 fn advance_display(proc: &mut GhostProcess) -> usize {
     let mark = proc.output_len();
     proc.write_raw(b"x");
@@ -234,34 +217,14 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
     // Mark the pre-trigger offset — popup render bytes must appear after.
     let mark_before_trigger = proc.output_len();
 
-    // Inject OSC 7770 via shell printf. Format:
-    //     OSC ] 7770 ; <cursor-char-offset> ; <buffer> BEL
-    //     \x1b]7770;4;git \x07
-    // The shell executes printf, emits the raw bytes to stdout, gc-parser
-    // consumes them and sets command_buffer = "git " with cursor = 4. The
-    // buffer_dirty flag is observed by Task B alongside `buffer_pending_display`
-    // (set because no display-changing op has followed); per issue #107 the
-    // proxy must defer the trigger until the parser sees a real redraw.
-    //
-    // Keep the shell command blocked after the OSC write. If the command
-    // exits immediately, the shell prints a new prompt, and the proxy now
-    // correctly tears down the popup before forwarding that prompt output.
+    // OSC ]7770;<cursor>;<buffer>BEL — the `read` keeps the shell from
+    // emitting a new prompt that would tear down the popup mid-test.
     proc.send_line(r"printf '\033]7770;4;git \007'; read _ghost_popup_hold");
 
-    // Phase 1: OSC alone — popup must NOT render yet. This is the issue
-    // #107 regression check: prior versions rendered immediately and then
-    // had the popup torn down by the next display_dirty batch.
     assert_no_popup_render_after(&proc, mark_before_trigger, "git OSC injection");
 
-    // Phase 2: advance display. Writing a printable byte through to the
-    // shell's pending `read` causes the shell's PTY layer to echo it back,
-    // producing display-changing bytes that clear `buffer_pending_display`
-    // in the parser and unblock the deferred trigger.
     let mark_before_redraw = advance_display(&mut proc);
 
-    // Phase 3: deferred trigger fires now. The overlay's first emitted byte
-    // sequence is DECSC (`\x1b7` = save cursor). Seeing it after the redraw
-    // mark proves the deferred buffer-dirty action resolved cleanly.
     let popup_rendered = proc.wait_for_bytes_after(
         POPUP_RENDER_MARKER,
         mark_before_redraw,
@@ -346,8 +309,6 @@ fn test_popup_is_cleared_before_later_shell_output() {
     let mark_before_trigger = proc.output_len();
     proc.send_line(r"printf '\033]7770;4;git \007'; read _gc_smoke_gate");
 
-    // Issue #107 deferral: OSC alone must not render. Advance display so
-    // the deferred trigger can resolve.
     assert_no_popup_render_after(&proc, mark_before_trigger, "prompt-repaint cleanup setup");
     let mark_before_redraw = advance_display(&mut proc);
 
@@ -406,27 +367,6 @@ fn test_popup_is_cleared_before_later_shell_output() {
     proc.exit_with_code(0);
 }
 
-/// Issue #107 regression: when the OSC 7772 buffer report and the matching
-/// ZLE redraw arrive in *separate* PTY reads (a timing pattern that varies
-/// by macOS version, CPU, and PTY scheduler), prior versions rendered the
-/// popup on the first read at stale cursor geometry and then immediately
-/// tore it down on the second read's `display_dirty`. Users perceived this
-/// as the popup appearing only on alternating keystrokes.
-///
-/// This test exercises the OSC-only PTY read path explicitly:
-///   1. `printf` writes ONLY the OSC 7772 bytes — no follow-up display ops.
-///   2. The shell blocks on `read`, guaranteeing no further output until we
-///      drive a printable byte through.
-///   3. Assert: popup did NOT render (defer is in effect — `buffer_pending_display`
-///      is set in the parser, the proxy stashes a `PendingTrigger`).
-///   4. Send a printable byte → shell echo path produces display bytes →
-///      parser clears `buffer_pending_display` → proxy resolves the deferred
-///      trigger and renders the popup at the now-correct cursor position.
-///   5. Assert: popup rendered after the redraw mark.
-///
-/// Without the fix, step 3 would fail (popup rendered immediately) and the
-/// teardown-by-display_dirty in the next batch would be the failure mode
-/// the user's video documents.
 #[test]
 fn test_popup_defers_until_display_after_osc_only_pty_read() {
     let mut proc = GhostProcess::spawn();
@@ -436,22 +376,13 @@ fn test_popup_defers_until_display_after_osc_only_pty_read() {
 
     let mark_before_osc = proc.output_len();
 
-    // OSC alone, immediately followed by `read` — no display-changing bytes
-    // emitted by the shell after the OSC until we drive a keystroke. Using
-    // OSC 7770 (legacy raw framing) so `printf` doesn't interpret a `%`
-    // sequence as a format specifier the way OSC 7772 percent-encoding would.
+    // OSC 7770 raw framing avoids `printf` percent-format interpretation; `read` blocks the shell from emitting follow-up display bytes.
     proc.send_line(r"printf '\033]7770;4;git \007'; read _gc_defer_gate");
 
-    // Phase 1: defer holds. No popup despite buffer_dirty=true.
     assert_no_popup_render_after(&proc, mark_before_osc, "OSC-only PTY read defer");
 
-    // Phase 2: drive a printable byte; shell echo provides the display
-    // update that clears `buffer_pending_display` and resolves the defer.
     let mark_before_redraw = advance_display(&mut proc);
 
-    // Phase 3: deferred trigger resolves and the popup renders. Allow
-    // generous timeout because the trigger goes through the full suggest
-    // pipeline (spec resolution, fuzzy ranking, layout, render).
     let popup_rendered = proc.wait_for_bytes_after(
         POPUP_RENDER_MARKER,
         mark_before_redraw,
@@ -471,6 +402,41 @@ fn test_popup_defers_until_display_after_osc_only_pty_read() {
 
     // Drain anything still in flight, then unblock the shell's read.
     proc.write_raw(&[0x1B]); // ESC dismisses the popup so a clean prompt repaint can happen.
+    proc.send_line("");
+    proc.exit_with_code(0);
+}
+
+#[test]
+fn test_popup_renders_when_osc_and_display_share_pty_read() {
+    let mut proc = GhostProcess::spawn();
+
+    proc.send_line("echo inline_smoke_ready_marker");
+    proc.expect_output("inline_smoke_ready_marker");
+
+    let mark_before_trigger = proc.output_len();
+
+    // OSC + printable byte in the same `printf` — they coalesce into one PTY
+    // chunk, so the parser observes the display update alongside the buffer
+    // report and the trigger must fire without any external `advance_display`.
+    proc.send_line(r"printf '\033]7770;4;git \007X'; read _gc_inline_gate");
+
+    let popup_rendered = proc.wait_for_bytes_after(
+        POPUP_RENDER_MARKER,
+        mark_before_trigger,
+        Duration::from_secs(5),
+    );
+    if !popup_rendered {
+        let snapshot = proc.output_snapshot();
+        let since_mark = &snapshot[mark_before_trigger..];
+        panic!(
+            "Popup did not render within 5s when OSC and display update shared a PTY read.\n\
+             Bytes since mark ({} bytes, lossy UTF-8):\n{:?}",
+            since_mark.len(),
+            String::from_utf8_lossy(since_mark),
+        );
+    }
+
+    proc.write_raw(&[0x1B]);
     proc.send_line("");
     proc.exit_with_code(0);
 }


### PR DESCRIPTION
Closes #107.

## Symptom
On the secondary machine (M3 / macOS 15.3, but reproduced from a fresh `cargo install --path` of master too), typing in the prompt produced a popup that flickered on and off with each keystroke. On faster hardware (M2 Pro / macOS 26) the bug stayed hidden.

## Root cause
A race in the proxy's stdout task between the OSC 7772 buffer report (sets `buffer_dirty=true` in the parser) and the ZLE redraw (sets `display_dirty=true`):

1. Whether zsh's per-keystroke `[OSC 7772][redraw]` write lands in **one** PTY `read()` or **two** is decided by the kernel's PTY write-coalescing — varies by macOS version, CPU, and load.
2. When both arrive together: `handle_terminal_output` tears down any visible popup, raw bytes are written, then `buffer_dirty` triggers a fresh popup. ✅
3. When OSC arrives **alone**: `buffer_dirty` fires the trigger immediately at the **stale** cursor position (display hasn't been updated). The next batch carries the redraw, `display_dirty` fires, `handle_terminal_output` tears down the just-rendered popup, and there is no more `buffer_dirty` to retrigger. ❌

PR #105 introduced the immediate-trigger branch (`delay_ms == 0` and `has_pending_trigger`) that hits this race; before #105 every path was either gated by `pending_trigger` (set inline) or debounced (mask the race with a 150 ms delay).

## Fix design
Track a single boolean **`buffer_pending_display`** in `gc_parser::TerminalState`:
- Set in `set_command_buffer()` (the only path that sets `buffer_dirty`).
- Cleared in `mark_display_dirty()` (every cursor move, char print, line clear, etc.).

The flag is end-of-batch authoritative: `false` means the parser has applied at least one display op since the most recent buffer event, so cursor geometry now reflects the new buffer; `true` means the redraw is still pending.

In `gc-pty/src/proxy.rs`:
- `buffer_dirty_action(...)` takes a new `buffer_pending_display: bool` param. When the buffer report has not yet been redrawn it returns a new `BufferDirtyAction::Defer(PendingTrigger)` variant instead of `Trigger` / `Debounce`.
- The stdout task carries a small `Option<PendingTrigger>` slot. `Defer` stashes; subsequent batches that observe `!buffer_pending_display` resolve via `resolve_pending_trigger(...)`. Trigger / Debounce / Ignore each clear the slot.
- `resolve_pending_trigger` enforces the same gates as the immediate path (auto-trigger disabled drops; `Debounce` variants are dropped if `debounce_suppressed`; immediate `Trigger` variants bypass debounce suppression — same semantics as `has_pending_trigger`).

## Why this approach over byte-by-byte epoch tracking
The same race could be detected with a per-byte `display_epoch` counter and `latest_buffer_epoch` snapshot inside the parser-driven byte loop. That works but:
- forces the proxy to call `parser.process_bytes(...)` once per byte (much more lock acquisition under typing), and
- duplicates ordering state the parser already enforces internally via its callback ordering.

A single boolean updated by the parser's existing `set_command_buffer` / `mark_display_dirty` calls captures the same invariant for the actual zsh OSC-then-redraw pattern, costs nothing in the hot path, and the test surface (5 parser unit tests + 13 proxy state-machine tests + 1 PTY-level smoke test) is small.

## Tests
| Layer | What's covered |
|---|---|
| `gc-parser` unit | Flag default, set on buffer update, cleared by display op, re-armed by next buffer update, isolation from `take_buffer_dirty()`. |
| `gc-pty` unit | All five `BufferDirtyAction` variants (`Trigger`, `Debounce`, `Defer(Trigger)`, `Defer(Debounce)`, `Ignore`) across the matrix of `buffer_pending_display × auto_trigger × debounce_suppressed × has_pending_trigger`. Five `resolve_pending_trigger` cases including auto-disabled drain and debounce-suppressed drop for `Debounce` variants only. |
| `ghost-complete` smoke | New `test_popup_defers_until_display_after_osc_only_pty_read` drives a real `/bin/sh` PTY: shell `printf`s the OSC alone, asserts popup does **not** render for 500 ms, drives a printable byte to advance display, asserts popup **then** renders. The two pre-existing popup tests are updated to the new defer→advance→render contract. |

## Validation
- `cargo test --workspace` — passes
- `cargo test -p ghost-complete --test smoke -- --test-threads=1` — 13/13 (parallel runs hit unrelated PTY-allocation pressure on `test_pipe_passthrough` / `test_environment_preserved`)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Independence from PR #106
This branch is based directly on `master` (`d9288f5`). The fix does **not** share code or tests with `codex/defer-popup-trigger-until-redraw` — different state representation (parser-side single boolean vs proxy-side per-byte epoch counters), different test scaffolding, different naming. Either approach addresses the bug; this one keeps batch parsing and lives mostly in the parser invariant layer.

## Test plan
- [ ] Build and install on the M3 / macOS 15.3 secondary that reproduces the bug; type into a fresh prompt and confirm the popup persists across every keystroke.
- [ ] Build on the M2 Pro / macOS 26 primary; confirm no regression in the always-coalesced read path.