### PR TITLE
feat(performance-fix): Add opt-in spec cache eviction for better memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- **Lazy spec loading drops idle memory from ~330 MB to ~5 MB.** Pre-fix the
-  spec loader eagerly parsed every embedded spec into `Arc<CompletionSpec>`
-  at startup. The AWS spec alone (~36 MB minified, 17 K subcommands, 116 K
-  descriptions) ballooned the daemon's physical footprint to 333 MB on
-  first load. The loader now defers `serde_json::from_str` to the first
-  `SpecEntry::spec()` call: each entry holds its source as either a
-  filesystem `PathBuf` or an `&'static str` slice into the embedded
-  corpus, and a `OnceLock<Result<Arc<CompletionSpec>, String>>` pins the
-  parse result on first touch. Failures are sticky and surface via
-  `SpecEntry::load_error`. Benchmarks: `load_with_embedded` ~183 µs,
-  warm `SpecStore::get` ~11 ns, first-touch parse of the AWS spec
-  ~150 ms (paid only when the user actually types `aws `).
+- **Opt-in TTL/LRU eviction for parsed completion specs.** The
+  `[suggest.spec_cache]` config section accepts `idle_ttl_secs`,
+  `sweep_interval_secs`, `keep_warm`, and `max_resident_mb`. Eviction is
+  disabled by default (`idle_ttl_secs = 0`), preserving the v0.12.4
+  "parse once, hold forever" contract for users who do not opt in.
+- **Spec cache status and doctor diagnostics.** `ghost-complete status
+  --json` now includes `parsed_resident`, `estimated_resident_bytes`,
+  `spec_cache`, and `last_sweep` under `specs`. `ghost-complete doctor`
+  warns when a `keep_warm` entry does not match a registered spec alias
+  and when resident heap exceeds 90% of `max_resident_mb`.
 
 ### Changed
 
+- **Spec lookups return owned specs.** `SpecStore::get` and
+  `SpecEntry::spec` now return `Option<Arc<CompletionSpec>>` instead of
+  `Option<&CompletionSpec>`. The parsed slot can now transition between
+  `Loaded` and `Evicted`; callers keep a cloned `Arc` so their resolved
+  spec remains valid across cache mutations.
 - **Runtime no longer materialises embedded specs to disk.** Previous
   versions wrote `~/.cache/ghost-complete/embedded-specs/` on first run
   after a binary upgrade (~25 MB write, sentinel-versioned). v0.12.4
@@ -38,6 +41,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   after force-loading and lists each error inline. `validate-specs`
   continues to parse configured spec directories directly through its
   separate validator.
+
+### Fixed
+
+- **Lazy spec loading drops idle memory from ~330 MB to ~5 MB.** Pre-fix the
+  spec loader eagerly parsed every embedded spec into `Arc<CompletionSpec>`
+  at startup. The AWS spec alone (~36 MB minified, 17 K subcommands, 116 K
+  descriptions) ballooned the daemon's physical footprint to 333 MB on
+  first load. The loader now defers `serde_json::from_str` to the first
+  `SpecEntry::spec()` call: each entry holds its source as either a
+  filesystem `PathBuf` or an `&'static str` slice into the embedded
+  corpus, and a `RwLock<ParsedSlot>` holds the lazy parse result.
+  Failures are sticky and surface via `SpecEntry::load_error`.
+  Benchmarks: `load_with_embedded` ~183 µs, warm `SpecStore::get` stays
+  under the 50 ns hot-path budget, and first-touch parse of the AWS spec
+  is ~150 ms (paid only when the user actually types `aws `).
 
 ## [0.12.3] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Opt-in TTL/LRU eviction for parsed completion specs.** The
   `[suggest.spec_cache]` config section accepts `idle_ttl_secs`,
   `sweep_interval_secs`, `keep_warm`, and `max_resident_mb`. Eviction is
-  disabled by default (`idle_ttl_secs = 0`), preserving the v0.12.4
-  "parse once, hold forever" contract for users who do not opt in.
+  disabled by default (`idle_ttl_secs = 0`), preserving the lazy-loading
+  layer's "parse once, hold forever" behavior for users who do not opt in.
 - **Spec cache status and doctor diagnostics.** `ghost-complete status
-  --json` now includes `parsed_resident`, `estimated_resident_bytes`,
-  `spec_cache`, and `last_sweep` under `specs`. `ghost-complete doctor`
-  warns when a `keep_warm` entry does not match a registered spec alias
-  and when resident heap exceeds 90% of `max_resident_mb`.
+  --json` bumps `schema_version` from `1.3` to `1.5` and adds a top-level
+  `specs` block exposing `registered`, `addressable_aliases`, and a
+  `spec_cache` policy reflection (`enabled`, `idle_ttl_secs`,
+  `sweep_interval_secs`, `keep_warm`, `max_resident_mb`). The `specs`
+  block is corpus-structural and policy-level only — it does not claim
+  to reflect the running daemon's live parse state, since `status` runs
+  in its own short-lived process. `ghost-complete doctor` warns when a
+  `keep_warm` entry does not match a registered spec alias and when
+  estimated resident heap exceeds 90% of `max_resident_mb`.
 
 ### Changed
 
@@ -29,12 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spec remains valid across cache mutations.
 - **Runtime no longer materialises embedded specs to disk.** Previous
   versions wrote `~/.cache/ghost-complete/embedded-specs/` on first run
-  after a binary upgrade (~25 MB write, sentinel-versioned). v0.12.4
-  consumes the embedded corpus in-memory via `SpecStore::load_with_embedded`
-  — same precedence semantics, no disk I/O, no version sentinel to keep
-  in sync. `ghost-complete install` and `ghost-complete uninstall` now
-  remove the legacy cache directory if a pre-v0.12.4 binary left it
-  behind.
+  after a binary upgrade (~25 MB write, sentinel-versioned). The runtime
+  now consumes the embedded corpus in-memory via
+  `SpecStore::load_with_embedded` — same precedence semantics, no disk
+  I/O, no version sentinel to keep in sync. `ghost-complete install` and
+  `ghost-complete uninstall` now remove the legacy cache directory if an
+  earlier binary left it behind.
 - **`status` now reports lazy parse errors.** A spec that fails to parse
   no longer crashes loading — it stays registered and surfaces through
   `SpecEntry::load_error()`. `ghost-complete status` walks the entries

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1", features = [
     "signal",
     "time",
     "sync",
+    "test-util",
 ] }
 anyhow = "1"
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ tokio = { version = "1", features = [
     "signal",
     "time",
     "sync",
-    "test-util",
 ] }
 anyhow = "1"
 tracing = "0.1"

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -568,8 +568,7 @@ impl GhostConfig {
                 );
                 self.suggest.spec_cache.sweep_interval_secs = 60;
             }
-            if self.suggest.spec_cache.sweep_interval_secs
-                >= self.suggest.spec_cache.idle_ttl_secs
+            if self.suggest.spec_cache.sweep_interval_secs >= self.suggest.spec_cache.idle_ttl_secs
             {
                 tracing::warn!(
                     sweep_interval = self.suggest.spec_cache.sweep_interval_secs,

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -150,6 +150,7 @@ pub struct SuggestConfig {
     /// indefinitely. Default: 5000 ms.
     pub generator_timeout_ms: u64,
     pub providers: ProvidersConfig,
+    pub spec_cache: SpecCacheConfig,
 }
 
 impl Default for SuggestConfig {
@@ -159,6 +160,7 @@ impl Default for SuggestConfig {
             max_history_results: 5,
             generator_timeout_ms: 5000,
             providers: ProvidersConfig::default(),
+            spec_cache: SpecCacheConfig::default(),
         }
     }
 }
@@ -192,6 +194,55 @@ impl Default for ProvidersConfig {
             git: true,
             js_runtime: true,
         }
+    }
+}
+
+/// Cache eviction policy for parsed completion specs. Eviction is opt-in:
+/// `idle_ttl_secs = 0` (default) preserves the v0.12.4 "parse once, hold
+/// forever" contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SpecCacheConfig {
+    /// Seconds after last access before a successfully-parsed spec is
+    /// evicted from the in-memory cache. `0` (default) disables eviction.
+    pub idle_ttl_secs: u64,
+    /// How often the background sweep wakes to scan for idle entries.
+    /// Default 60s. Ignored when `idle_ttl_secs == 0`.
+    pub sweep_interval_secs: u64,
+    /// Spec aliases (filename stems or `CompletionSpec.name` values) that
+    /// must never be evicted. Shell aliases are NOT walked; pin specs by
+    /// their registered name. Default empty.
+    pub keep_warm: Vec<String>,
+    /// LRU backstop: after TTL eviction, if total estimated resident heap
+    /// exceeds this cap, evict more entries oldest-access-first until under
+    /// cap. `keep_warm` entries are exempt. `0` (default) disables.
+    pub max_resident_mb: u64,
+}
+
+impl Default for SpecCacheConfig {
+    fn default() -> Self {
+        Self {
+            idle_ttl_secs: 0,
+            sweep_interval_secs: 60,
+            keep_warm: Vec::new(),
+            max_resident_mb: 0,
+        }
+    }
+}
+
+impl SpecCacheConfig {
+    /// Convert `max_resident_mb` to a byte cap. `None` when disabled.
+    pub fn max_resident_bytes(&self) -> Option<u64> {
+        if self.max_resident_mb == 0 {
+            None
+        } else {
+            Some(self.max_resident_mb * 1024 * 1024)
+        }
+    }
+
+    /// True when eviction is enabled (`idle_ttl_secs > 0`).
+    pub fn enabled(&self) -> bool {
+        self.idle_ttl_secs > 0
     }
 }
 
@@ -663,6 +714,47 @@ max_visible = 5
         // Everything else should be default
         assert_eq!(config.trigger.auto_chars, vec![' ', '/', '-', '.']);
         assert_eq!(config.suggest.max_results, 50);
+    }
+
+    #[test]
+    fn spec_cache_config_defaults() {
+        let config = SpecCacheConfig::default();
+        assert_eq!(config.idle_ttl_secs, 0, "eviction must be opt-in (TTL=0)");
+        assert_eq!(config.sweep_interval_secs, 60);
+        assert!(config.keep_warm.is_empty());
+        assert_eq!(config.max_resident_mb, 0);
+        assert_eq!(config.max_resident_bytes(), None);
+    }
+
+    #[test]
+    fn spec_cache_config_max_resident_bytes_translates_mb() {
+        let config = SpecCacheConfig {
+            max_resident_mb: 100,
+            ..Default::default()
+        };
+        assert_eq!(config.max_resident_bytes(), Some(100 * 1024 * 1024));
+    }
+
+    #[test]
+    fn suggest_config_includes_spec_cache_with_defaults() {
+        let config = SuggestConfig::default();
+        assert_eq!(config.spec_cache.idle_ttl_secs, 0);
+    }
+
+    #[test]
+    fn spec_cache_deserializes_from_toml() {
+        let toml = r#"
+[suggest.spec_cache]
+idle_ttl_secs = 300
+sweep_interval_secs = 30
+keep_warm = ["git", "cd"]
+max_resident_mb = 100
+"#;
+        let parsed: GhostConfig = toml::from_str(toml).unwrap();
+        assert_eq!(parsed.suggest.spec_cache.idle_ttl_secs, 300);
+        assert_eq!(parsed.suggest.spec_cache.sweep_interval_secs, 30);
+        assert_eq!(parsed.suggest.spec_cache.keep_warm, vec!["git", "cd"]);
+        assert_eq!(parsed.suggest.spec_cache.max_resident_mb, 100);
     }
 
     #[test]

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -555,6 +555,28 @@ impl GhostConfig {
             );
             self.popup.feedback_dismiss_ms = FEEDBACK_DISMISS_MS_UPPER;
         }
+        // Spec cache sanity. Only apply when eviction is enabled —
+        // a config with idle_ttl_secs=0 means the user opted out and
+        // the other fields are unused.
+        if self.suggest.spec_cache.idle_ttl_secs > 0 {
+            if self.suggest.spec_cache.sweep_interval_secs == 0 {
+                tracing::warn!(
+                    "suggest.spec_cache.sweep_interval_secs=0 with eviction enabled \
+                     is invalid; clamping to 60"
+                );
+                self.suggest.spec_cache.sweep_interval_secs = 60;
+            }
+            if self.suggest.spec_cache.sweep_interval_secs
+                >= self.suggest.spec_cache.idle_ttl_secs
+            {
+                tracing::warn!(
+                    sweep_interval = self.suggest.spec_cache.sweep_interval_secs,
+                    idle_ttl = self.suggest.spec_cache.idle_ttl_secs,
+                    "sweep_interval_secs >= idle_ttl_secs — eviction will lag the \
+                     configured TTL"
+                );
+            }
+        }
     }
 
     pub fn load(path: Option<&str>) -> Result<Self> {
@@ -755,6 +777,38 @@ max_resident_mb = 100
         assert_eq!(parsed.suggest.spec_cache.sweep_interval_secs, 30);
         assert_eq!(parsed.suggest.spec_cache.keep_warm, vec!["git", "cd"]);
         assert_eq!(parsed.suggest.spec_cache.max_resident_mb, 100);
+    }
+
+    #[test]
+    fn spec_cache_normalize_clamps_zero_sweep_interval_when_eviction_enabled() {
+        let mut config = GhostConfig {
+            suggest: SuggestConfig {
+                spec_cache: SpecCacheConfig {
+                    idle_ttl_secs: 300,
+                    sweep_interval_secs: 0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        config.normalize();
+        assert_eq!(
+            config.suggest.spec_cache.sweep_interval_secs, 60,
+            "sweep_interval_secs=0 with eviction enabled must clamp to 60"
+        );
+    }
+
+    #[test]
+    fn spec_cache_normalize_does_not_touch_disabled_eviction() {
+        let mut config = GhostConfig::default();
+        // idle_ttl_secs=0 (eviction disabled) — no normalization triggered.
+        config.suggest.spec_cache.sweep_interval_secs = 0;
+        config.normalize();
+        assert_eq!(
+            config.suggest.spec_cache.sweep_interval_secs, 0,
+            "disabled eviction should not auto-fix sweep_interval"
+        );
     }
 
     #[test]

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -232,11 +232,13 @@ impl Default for SpecCacheConfig {
 
 impl SpecCacheConfig {
     /// Convert `max_resident_mb` to a byte cap. `None` when disabled.
+    /// Saturates at `u64::MAX` for pathological user input instead of
+    /// wrapping to a too-small cap.
     pub fn max_resident_bytes(&self) -> Option<u64> {
         if self.max_resident_mb == 0 {
             None
         } else {
-            Some(self.max_resident_mb * 1024 * 1024)
+            Some(self.max_resident_mb.saturating_mul(1024 * 1024))
         }
     }
 
@@ -755,6 +757,15 @@ max_visible = 5
             ..Default::default()
         };
         assert_eq!(config.max_resident_bytes(), Some(100 * 1024 * 1024));
+    }
+
+    #[test]
+    fn spec_cache_config_max_resident_bytes_saturates_on_overflow() {
+        let config = SpecCacheConfig {
+            max_resident_mb: u64::MAX,
+            ..Default::default()
+        };
+        assert_eq!(config.max_resident_bytes(), Some(u64::MAX));
     }
 
     #[test]

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -198,8 +198,8 @@ impl Default for ProvidersConfig {
 }
 
 /// Cache eviction policy for parsed completion specs. Eviction is opt-in:
-/// `idle_ttl_secs = 0` (default) preserves the v0.12.4 "parse once, hold
-/// forever" contract.
+/// `idle_ttl_secs = 0` (default) preserves the lazy-loading layer's
+/// "parse once, hold forever" behavior.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SpecCacheConfig {

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -13,7 +13,7 @@ use gc_overlay::{
     PopupTheme,
 };
 use gc_parser::TerminalParser;
-use gc_suggest::{Suggestion, SuggestionEngine};
+use gc_suggest::{SpecCacheSweep, Suggestion, SuggestionEngine};
 use gc_terminal::TerminalProfile;
 use tokio::sync::{mpsc, Notify};
 
@@ -370,6 +370,15 @@ impl InputHandler {
 
     pub fn feedback_tick_notify(&self) -> Arc<Notify> {
         Arc::clone(&self.feedback_tick_notify)
+    }
+
+    /// Spawn the cache-eviction sweep using the provided config. Returns
+    /// `None` when eviction is disabled.
+    pub fn spawn_spec_cache_sweep(
+        &self,
+        cfg: gc_config::SpecCacheConfig,
+    ) -> Option<SpecCacheSweep> {
+        self.engine.spawn_spec_cache_sweep(cfg)
     }
 
     pub fn with_popup_config(mut self, max_visible: usize) -> Self {

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -285,6 +285,22 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
         feedback_tick_loop(feedback_notify, handler_for_feedback).await;
     });
 
+    // Background sweep task for the spec cache. Held in scope for the
+    // duration of the proxy event loop; dropped when run_proxy returns,
+    // which cancels the task.
+    let _spec_cache_sweep = {
+        let h = match handler.lock() {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!("handler mutex poisoned during spec-cache sweep setup: {e}");
+                anyhow::bail!(
+                    "handler mutex poisoned during spec-cache sweep setup — cannot start proxy"
+                );
+            }
+        };
+        h.spawn_spec_cache_sweep(config.suggest.spec_cache.clone())
+    };
+
     // Channel to signal that one of the I/O tasks has finished
     let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
 

--- a/crates/gc-suggest/Cargo.toml
+++ b/crates/gc-suggest/Cargo.toml
@@ -32,6 +32,7 @@ tempfile = "3"
 filetime = "0.2"
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
+tokio = { workspace = true, features = ["test-util"] }
 tracing-core = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -322,9 +322,8 @@ fn memory_benchmarks(c: &mut Criterion) {
 ///   pay when they first type `aws ` — it's ~exactly the work the eager
 ///   loader was doing for *every* spec at startup pre-fix.
 /// - `warm_get_git` measures the steady-state lookup cost after the
-///   `OnceLock` is populated. This is what users pay on every subsequent
-///   lookup of the same spec — should be ~5-10 ns (HashMap lookup +
-///   OnceLock read + borrow).
+///   `ParsedSlot` is populated. This is what users pay on every subsequent
+///   lookup of the same spec.
 fn lazy_load_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("lazy_load");
 
@@ -362,7 +361,7 @@ fn lazy_load_benchmarks(c: &mut Criterion) {
     });
 
     // Warm path: build the store once outside the timed loop and time
-    // only the lookup. The OnceLock is populated by the first iter, every
+    // only the lookup. The ParsedSlot is populated by the first iter, every
     // subsequent iter takes the fast path.
     let warm_result =
         SpecStore::load_with_embedded(&[]).expect("embedded corpus must load for warm bench");
@@ -373,6 +372,81 @@ fn lazy_load_benchmarks(c: &mut Criterion) {
         b.iter(|| {
             let spec = warm_store.get("git").expect("git spec must resolve");
             std::hint::black_box(spec);
+        });
+    });
+
+    // After v0.12.5 the warm path goes through RwLock<ParsedSlot> + an
+    // AtomicU64 timestamp bump. This pins the new eviction-aware hot path.
+    group.bench_function("warm_get_git_under_eviction_path", |b| {
+        let result = SpecStore::load_with_embedded(&[]).expect("embedded corpus must load");
+        let store = result.store;
+        let _ = store.get("git"); // prime
+        b.iter(|| {
+            let spec = store.get("git").expect("git spec must resolve");
+            std::hint::black_box(spec);
+        });
+    });
+
+    group.bench_function("evict_then_get_aws", |b| {
+        b.iter_custom(|iters| {
+            let mut total = std::time::Duration::ZERO;
+            let result = SpecStore::load_with_embedded(&[]).expect("embedded corpus must load");
+            let store = result.store;
+            for _ in 0..iters {
+                let _ = store.get("aws"); // ensure Loaded
+                let entry = store
+                    .entries()
+                    .iter()
+                    .find(|e| e.id == "aws")
+                    .unwrap()
+                    .clone();
+                entry.set_last_accessed_for_test(
+                    std::time::SystemTime::now() - std::time::Duration::from_secs(3600),
+                );
+                let _ = store.evict_idle(
+                    std::time::Duration::from_secs(60),
+                    None,
+                    &std::collections::HashSet::new(),
+                );
+                let start = std::time::Instant::now();
+                let spec = store
+                    .get("aws")
+                    .expect("aws must re-resolve after eviction");
+                total += start.elapsed();
+                std::hint::black_box(spec);
+            }
+            total
+        });
+    });
+
+    group.bench_function("evict_idle_700_specs_no_op", |b| {
+        let result = SpecStore::load_with_embedded(&[]).expect("embedded corpus must load");
+        let store = result.store;
+        // Force every entry through Loaded; bump timestamps to "just now".
+        for (id, _) in store.iter() {
+            let _ = id;
+        }
+        let keep_warm = std::collections::HashSet::new();
+        b.iter(|| {
+            let report = store.evict_idle(std::time::Duration::from_secs(3600), None, &keep_warm);
+            std::hint::black_box(report);
+        });
+    });
+
+    group.bench_function("evict_idle_700_specs_evict_all", |b| {
+        // Re-build per iter so each iter starts from "everything Loaded".
+        b.iter_custom(|iters| {
+            let mut total = std::time::Duration::ZERO;
+            for _ in 0..iters {
+                let result = SpecStore::load_with_embedded(&[]).expect("embedded corpus must load");
+                let store = result.store;
+                for (_, _) in store.iter() {} // force-load all
+                let keep_warm = std::collections::HashSet::new();
+                let start = std::time::Instant::now();
+                let _ = store.evict_idle(std::time::Duration::ZERO, None, &keep_warm);
+                total += start.elapsed();
+            }
+            total
         });
     });
 

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -89,13 +89,13 @@ fn resolution_benchmarks(c: &mut Criterion) {
     let git_spec = store.get("git").expect("git spec must exist");
     let shallow_ctx = make_ctx(Some("git"), vec!["checkout"], "", 2);
     group.bench_function("shallow", |b| {
-        b.iter(|| specs::resolve_spec(git_spec, &shallow_ctx));
+        b.iter(|| specs::resolve_spec(git_spec.as_ref(), &shallow_ctx));
     });
 
     let docker_spec = store.get("docker").expect("docker spec must exist");
     let deep_ctx = make_ctx(Some("docker"), vec!["compose", "up"], "--", 3);
     group.bench_function("deep", |b| {
-        b.iter(|| specs::resolve_spec(docker_spec, &deep_ctx));
+        b.iter(|| specs::resolve_spec(docker_spec.as_ref(), &deep_ctx));
     });
 
     // tar c --atime-preserve <TAB> — exercises the preceding_flag path with
@@ -115,7 +115,7 @@ fn resolution_benchmarks(c: &mut Criterion) {
         is_first_segment: true,
     };
     group.bench_function("with_static_suggestions_tar", |b| {
-        b.iter(|| specs::resolve_spec(tar_spec, &static_ctx));
+        b.iter(|| specs::resolve_spec(tar_spec.as_ref(), &static_ctx));
     });
 
     group.finish();

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -301,7 +301,7 @@ fn memory_benchmarks(c: &mut Criterion) {
         b.iter(|| {
             let total: usize = store
                 .iter()
-                .map(|(_, s)| specs::estimated_heap_bytes(s))
+                .map(|(_, s)| specs::estimated_heap_bytes(s.as_ref()))
                 .sum();
             std::hint::black_box(total)
         });

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -375,18 +375,6 @@ fn lazy_load_benchmarks(c: &mut Criterion) {
         });
     });
 
-    // With opt-in eviction, the warm path goes through RwLock<ParsedSlot> +
-    // an AtomicU64 timestamp bump. This pins the new eviction-aware hot path.
-    group.bench_function("warm_get_git_under_eviction_path", |b| {
-        let result = SpecStore::load_with_embedded(&[]).expect("embedded corpus must load");
-        let store = result.store;
-        let _ = store.get("git"); // prime
-        b.iter(|| {
-            let spec = store.get("git").expect("git spec must resolve");
-            std::hint::black_box(spec);
-        });
-    });
-
     group.bench_function("evict_then_get_aws", |b| {
         b.iter_custom(|iters| {
             let mut total = std::time::Duration::ZERO;

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -309,7 +309,7 @@ fn memory_benchmarks(c: &mut Criterion) {
     group.finish();
 }
 
-/// Lazy-loading benchmarks pinning the v0.12.4 contract:
+/// Lazy-loading benchmarks pinning the lazy-loading contract:
 ///
 /// - `load_with_embedded_no_parse` quantifies the cost of registering the
 ///   entire embedded corpus as `SpecSource::Embedded` entries without

--- a/crates/gc-suggest/benches/suggest_bench.rs
+++ b/crates/gc-suggest/benches/suggest_bench.rs
@@ -341,7 +341,7 @@ fn lazy_load_benchmarks(c: &mut Criterion) {
     // First-touch parse benchmarks: each iter() rebuilds the store so
     // every iteration measures the cost of registering + first-touching
     // a single spec from scratch. Without rebuilding we'd hit the
-    // OnceLock cache after iter #1 and report the warm-path latency.
+    // parse slot after iter #1 and report the warm-path latency.
     group.bench_function("first_get_git", |b| {
         b.iter(|| {
             let result = SpecStore::load_with_embedded(&[]).expect("embedded corpus must load");
@@ -375,8 +375,8 @@ fn lazy_load_benchmarks(c: &mut Criterion) {
         });
     });
 
-    // After v0.12.5 the warm path goes through RwLock<ParsedSlot> + an
-    // AtomicU64 timestamp bump. This pins the new eviction-aware hot path.
+    // With opt-in eviction, the warm path goes through RwLock<ParsedSlot> +
+    // an AtomicU64 timestamp bump. This pins the new eviction-aware hot path.
     group.bench_function("warm_get_git_under_eviction_path", |b| {
         let result = SpecStore::load_with_embedded(&[]).expect("embedded corpus must load");
         let store = result.store;

--- a/crates/gc-suggest/src/embedded.rs
+++ b/crates/gc-suggest/src/embedded.rs
@@ -188,14 +188,14 @@ mod tests {
             .get("appwrite")
             .expect("appwrite stem must resolve through embedded corpus");
         assert_eq!(by_stem.name, "index");
-        let stem_ptr = by_stem as *const _;
 
         let by_alias = store
             .get("index")
             .expect("appwrite name alias must resolve through embedded corpus");
         assert_eq!(by_alias.name, "index");
         assert_eq!(
-            stem_ptr, by_alias as *const _,
+            by_stem.as_ref() as *const _,
+            by_alias.as_ref() as *const _,
             "stem and name alias must resolve to the same parsed embedded spec"
         );
     }

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -250,7 +250,7 @@ mod sync_result_tests {
 }
 
 pub struct SuggestionEngine {
-    spec_store: SpecStore,
+    spec_store: Arc<SpecStore>,
     filesystem_provider: FilesystemProvider,
     history_provider: HistoryProvider,
     commands_provider: CommandsProvider,
@@ -300,7 +300,7 @@ impl SuggestionEngine {
             );
         }
         Ok(Self {
-            spec_store: result.store,
+            spec_store: Arc::new(result.store),
             filesystem_provider: FilesystemProvider::new(),
             history_provider: HistoryProvider::load(DEFAULT_MAX_HISTORY_ENTRIES),
             commands_provider: CommandsProvider::from_path_env(),
@@ -354,7 +354,7 @@ impl SuggestionEngine {
         commands_provider: CommandsProvider,
     ) -> Self {
         Self {
-            spec_store,
+            spec_store: Arc::new(spec_store),
             filesystem_provider: FilesystemProvider::new(),
             history_provider,
             commands_provider,
@@ -941,7 +941,7 @@ impl SuggestionEngine {
             return Ok(Vec::new());
         };
         let resolve_ctx = self.resolve_ctx_for_spec_walk(ctx);
-        let resolution = specs::resolve_spec(spec, resolve_ctx.as_ref());
+        let resolution = specs::resolve_spec(spec.as_ref(), resolve_ctx.as_ref());
         let spec_name = ctx.command.as_deref().unwrap_or("<unknown>");
         let generators =
             filter_supported_script_generators(spec_name, resolution.script_generators);
@@ -1038,7 +1038,7 @@ impl SuggestionEngine {
         if let Some(spec) = self.spec_for_ctx(ctx) {
             // Walk the alias target's spec subtree, not the literal alias name's.
             let resolve_ctx = self.resolve_ctx_for_spec_walk(ctx);
-            let resolution = specs::resolve_spec(spec, resolve_ctx.as_ref());
+            let resolution = specs::resolve_spec(spec.as_ref(), resolve_ctx.as_ref());
             candidates.extend(resolution.subcommands);
             candidates.extend(resolution.options);
         }
@@ -1140,7 +1140,7 @@ impl SuggestionEngine {
     /// Resolve the alias-aware spec for this command context, if any.
     /// Centralizes the alias lookup + spec_store probe so callers don't
     /// repeat it.
-    fn spec_for_ctx(&self, ctx: &CommandContext) -> Option<&specs::CompletionSpec> {
+    fn spec_for_ctx(&self, ctx: &CommandContext) -> Option<Arc<specs::CompletionSpec>> {
         if !self.providers_specs {
             return None;
         }
@@ -1184,7 +1184,7 @@ impl SuggestionEngine {
             preceding_flag_has_args,
             past_double_dash,
             static_suggestions,
-        } = specs::resolve_spec(spec, resolve_ctx.as_ref());
+        } = specs::resolve_spec(spec.as_ref(), resolve_ctx.as_ref());
 
         let git_generators = self.git_generators_from(&native_generators);
 

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -380,6 +380,16 @@ impl SuggestionEngine {
         self
     }
 
+    /// Spawn the cache-eviction sweep task using the provided config.
+    /// Returns `None` when eviction is disabled. The caller must keep
+    /// the returned guard alive for the lifetime of the engine.
+    pub fn spawn_spec_cache_sweep(
+        &self,
+        cfg: gc_config::SpecCacheConfig,
+    ) -> Option<crate::specs::SpecCacheSweep> {
+        crate::specs::spawn_spec_cache_sweep(Arc::clone(&self.spec_store), cfg)
+    }
+
     #[doc(hidden)]
     pub fn with_ssh_host_cache_path(mut self, path: std::path::PathBuf) -> Self {
         self.ssh_host_cache = Some(SshHostCache::new(path));

--- a/crates/gc-suggest/src/lib.rs
+++ b/crates/gc-suggest/src/lib.rs
@@ -37,7 +37,8 @@ pub use pipeline::try_run_pipeline;
 pub use specs::{
     check_json_depth, parse_spec_checked_and_sanitized, sanitize_spec_strings, AliasConflict,
     AliasConflictDisposition, AliasConflictKind, AliasOwner, CompletionSpec, EvictionReport,
-    SpecEntry, SpecEntryLoadError, SpecLoadResult, SpecLocation, SpecLookupError, SpecStore,
-    SweepReport, MAX_SPEC_JSON_DEPTH,
+    spawn_spec_cache_sweep, spawn_spec_cache_sweep_for_test, SpecCacheSweep, SpecEntry,
+    SpecEntryLoadError, SpecLoadResult, SpecLocation, SpecLookupError, SpecStore, SweepReport,
+    MAX_SPEC_JSON_DEPTH,
 };
 pub use types::{Suggestion, SuggestionKind, SuggestionSource};

--- a/crates/gc-suggest/src/lib.rs
+++ b/crates/gc-suggest/src/lib.rs
@@ -35,10 +35,10 @@ pub use engine::{SuggestionEngine, SyncResult};
 pub use json_path::{JsonPath, JsonPathSegment};
 pub use pipeline::try_run_pipeline;
 pub use specs::{
-    check_json_depth, parse_spec_checked_and_sanitized, sanitize_spec_strings, AliasConflict,
+    check_json_depth, parse_spec_checked_and_sanitized, sanitize_spec_strings,
+    spawn_spec_cache_sweep, spawn_spec_cache_sweep_for_test, AliasConflict,
     AliasConflictDisposition, AliasConflictKind, AliasOwner, CompletionSpec, EvictionReport,
-    spawn_spec_cache_sweep, spawn_spec_cache_sweep_for_test, SpecCacheSweep, SpecEntry,
-    SpecEntryLoadError, SpecLoadResult, SpecLocation, SpecLookupError, SpecStore, SweepReport,
-    MAX_SPEC_JSON_DEPTH,
+    SpecCacheSweep, SpecEntry, SpecEntryLoadError, SpecLoadResult, SpecLocation, SpecLookupError,
+    SpecStore, SweepReport, MAX_SPEC_JSON_DEPTH,
 };
 pub use types::{Suggestion, SuggestionKind, SuggestionSource};

--- a/crates/gc-suggest/src/lib.rs
+++ b/crates/gc-suggest/src/lib.rs
@@ -36,8 +36,8 @@ pub use json_path::{JsonPath, JsonPathSegment};
 pub use pipeline::try_run_pipeline;
 pub use specs::{
     check_json_depth, parse_spec_checked_and_sanitized, sanitize_spec_strings, AliasConflict,
-    AliasConflictDisposition, AliasConflictKind, AliasOwner, CompletionSpec, SpecEntry,
-    SpecEntryLoadError, SpecLoadResult, SpecLocation, SpecLookupError, SpecStore,
-    MAX_SPEC_JSON_DEPTH,
+    AliasConflictDisposition, AliasConflictKind, AliasOwner, CompletionSpec, EvictionReport,
+    SpecEntry, SpecEntryLoadError, SpecLoadResult, SpecLocation, SpecLookupError, SpecStore,
+    SweepReport, MAX_SPEC_JSON_DEPTH,
 };
 pub use types::{Suggestion, SuggestionKind, SuggestionSource};

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -759,10 +759,7 @@ impl SpecEntry {
     /// `SystemTime`. Production code uses `bump_last_accessed` exclusively.
     #[doc(hidden)]
     pub fn set_last_accessed_for_test(&self, ts: SystemTime) {
-        let nanos = ts
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() as u64;
+        let nanos = ts.duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos() as u64;
         self.last_accessed_nanos.store(nanos, Ordering::Relaxed);
     }
 
@@ -1207,7 +1204,12 @@ impl SpecStore {
         max_resident_bytes: Option<u64>,
         keep_warm: &HashSet<String>,
     ) -> EvictionReport {
-        self.evict_idle_at(SystemTime::now(), idle_threshold, max_resident_bytes, keep_warm)
+        self.evict_idle_at(
+            SystemTime::now(),
+            idle_threshold,
+            max_resident_bytes,
+            keep_warm,
+        )
     }
 
     /// Internal helper that takes an explicit `now` for deterministic tests.

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1123,7 +1123,7 @@ impl SpecStore {
         &self,
         now: SystemTime,
         idle_threshold: Duration,
-        _max_resident_bytes: Option<u64>,
+        max_resident_bytes: Option<u64>,
         keep_warm: &HashSet<String>,
     ) -> EvictionReport {
         let mut evicted_idle = 0usize;
@@ -1156,8 +1156,53 @@ impl SpecStore {
             evicted_idle += 1;
         }
 
-        // Phase 2: backstop. Implemented in Task 8.
-        let evicted_backstop = 0usize;
+        // Phase 2: LRU backstop. Only when a cap is set AND we still exceed it.
+        let mut evicted_backstop = 0usize;
+        if let Some(cap) = max_resident_bytes {
+            let mut current = self.estimated_resident_bytes();
+            if current > cap {
+                // Snapshot eligible entries with their last_accessed
+                // timestamps. We sort outside any lock; per-entry write
+                // locks are taken when actually evicting.
+                let mut victims: Vec<(SystemTime, &Arc<SpecEntry>)> = self
+                    .entries
+                    .iter()
+                    .filter(|e| !e.has_warm_alias(keep_warm))
+                    .filter_map(|e| {
+                        let guard = e.parsed.read().unwrap_or_else(|p| p.into_inner());
+                        if guard.is_loaded() {
+                            Some((e.last_accessed(), e))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                victims.sort_by_key(|(ts, _)| *ts); // ascending — oldest first
+
+                for (_, entry) in &victims {
+                    if current <= cap {
+                        break;
+                    }
+                    let mut guard = entry.parsed.write().unwrap_or_else(|p| p.into_inner());
+                    let freed = match &*guard {
+                        ParsedSlot::Loaded(arc) => estimated_heap_bytes(arc.as_ref()) as u64,
+                        _ => continue, // raced — no longer Loaded
+                    };
+                    *guard = ParsedSlot::Evicted;
+                    current = current.saturating_sub(freed);
+                    evicted_backstop += 1;
+                }
+
+                if current > cap {
+                    tracing::warn!(
+                        resident_bytes = current,
+                        cap_bytes = cap,
+                        "spec_cache backstop unable to reach cap (likely keep_warm \
+                         pinned heap exceeds cap)"
+                    );
+                }
+            }
+        }
 
         let parsed_count = self.parsed_count();
         let resident = self.estimated_resident_bytes();

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -562,8 +562,9 @@ pub enum SpecSource {
 ///
 /// * `Empty` — registered, never accessed. Zero heap.
 /// * `Loaded(Arc)` — parsed and resident. The Arc is shared with any
-///   reader that called `spec_arc()`; eviction drops the slot's
-///   strong-ref but readers' clones survive.
+///   reader that resolved this entry (via `spec`, `spec_arc`,
+///   `spec_result`, or the `SpecStore::get*` lookups); eviction drops
+///   the slot's strong-ref but readers' clones survive.
 /// * `Evicted` — was `Loaded`, then a TTL/backstop sweep took the write
 ///   lock and released the Arc. Next access re-parses.
 /// * `Failed(error)` — parse failed; sticky, never retried, never evicted.
@@ -674,11 +675,11 @@ pub struct SpecEntry {
     parsed: RwLock<ParsedSlot>,
     /// Last access as a relaxed-ordering Unix-epoch nanosecond. Bumped on
     /// every successful read (any of `spec`, `spec_arc`, `spec_result`, or
-    /// `SpecStore::get`). Backed by a monotonic clock with a fixed offset
-    /// captured at startup; may drift from real wall clock under NTP
-    /// corrections, but eviction comparisons remain consistent because both
-    /// sides use the same clock. Used by the sweep task to identify
-    /// TTL-eligible entries.
+    /// `SpecStore::get`). Backed by a monotonic clock on macOS (captured
+    /// against a Unix-epoch base at startup) and `CLOCK_REALTIME` on other
+    /// Unix-like systems. Eviction comparisons mask backward jumps via
+    /// `duration_since(...).unwrap_or_default()`. Used by the sweep task
+    /// to identify TTL-eligible entries.
     last_accessed_nanos: AtomicU64,
 }
 
@@ -769,7 +770,8 @@ impl SpecEntry {
         self.parsed_result_arc().ok()
     }
 
-    /// Like [`Self::spec`] but returns the cached `Arc` directly.
+    /// Equivalent to [`Self::spec`]; retained for API stability with
+    /// pre-eviction callers.
     pub fn spec_arc(&self) -> Option<Arc<CompletionSpec>> {
         self.parsed_result_arc().ok()
     }
@@ -1028,14 +1030,6 @@ pub struct SweepReport {
 /// drop; the spawned task ends at its next select! arm.
 pub struct SpecCacheSweep {
     shutdown_tx: tokio::sync::watch::Sender<()>,
-    handle: tokio::task::JoinHandle<()>,
-}
-
-impl SpecCacheSweep {
-    /// Returns the join handle for testing or explicit await.
-    pub fn handle(&self) -> &tokio::task::JoinHandle<()> {
-        &self.handle
-    }
 }
 
 impl Drop for SpecCacheSweep {
@@ -1043,9 +1037,9 @@ impl Drop for SpecCacheSweep {
         // Best-effort cancel signal. If the receiver is already gone
         // (task ended on its own), send returns Err — ignored.
         let _ = self.shutdown_tx.send(());
-        // Do NOT block-on-handle here: if drop runs on the same tokio
-        // runtime as the task, that deadlocks. The cancel signal makes
-        // the task end at its next iteration; the runtime reaps it.
+        // Do NOT block-on the join handle here: if drop runs on the same
+        // tokio runtime as the task, that deadlocks. The cancel signal
+        // makes the task end at its next iteration; the runtime reaps it.
     }
 }
 
@@ -1068,7 +1062,7 @@ pub fn spawn_spec_cache_sweep(
     let max_bytes = cfg.max_resident_bytes();
     let keep_warm: HashSet<String> = cfg.keep_warm.iter().cloned().collect();
 
-    let handle = tokio::spawn(async move {
+    tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         // Skip the first immediate tick; the first sweep should fire after
@@ -1095,10 +1089,7 @@ pub fn spawn_spec_cache_sweep(
         }
     });
 
-    Some(SpecCacheSweep {
-        shutdown_tx: tx,
-        handle,
-    })
+    Some(SpecCacheSweep { shutdown_tx: tx })
 }
 
 /// Test-only spawn entry. Identical to [`spawn_spec_cache_sweep`] but

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
@@ -741,11 +741,8 @@ impl SpecEntry {
     }
 
     fn bump_last_accessed(&self) {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() as u64;
-        self.last_accessed_nanos.store(nanos, Ordering::Relaxed);
+        self.last_accessed_nanos
+            .store(now_unix_nanos(), Ordering::Relaxed);
     }
 
     /// Last access timestamp as `SystemTime`. Returns `UNIX_EPOCH` when
@@ -836,6 +833,70 @@ fn parse_entry_source(source: &SpecSource) -> Result<Arc<CompletionSpec>, String
 fn entry_is_idle_at(entry: &SpecEntry, now: SystemTime, threshold: Duration) -> bool {
     let last = entry.last_accessed();
     now.duration_since(last).unwrap_or_default() >= threshold
+}
+
+#[cfg(target_os = "macos")]
+fn now_unix_nanos() -> u64 {
+    static BASE_UNIX_NANOS: OnceLock<u64> = OnceLock::new();
+
+    let mono = monotonic_nanos();
+    let base = *BASE_UNIX_NANOS.get_or_init(|| system_time_unix_nanos().saturating_sub(mono));
+    base.saturating_add(mono)
+}
+
+#[cfg(target_os = "macos")]
+#[allow(deprecated)]
+fn monotonic_nanos() -> u64 {
+    // SAFETY: mach_absolute_time is thread-safe and takes no pointers.
+    let ticks = unsafe { libc::mach_absolute_time() };
+    let (numer, denom) = mach_timebase();
+    ((ticks as u128).saturating_mul(numer as u128) / denom as u128).min(u64::MAX as u128) as u64
+}
+
+#[cfg(target_os = "macos")]
+#[allow(deprecated)]
+fn mach_timebase() -> (u64, u64) {
+    static TIMEBASE: OnceLock<(u64, u64)> = OnceLock::new();
+    *TIMEBASE.get_or_init(|| {
+        let mut info = std::mem::MaybeUninit::<libc::mach_timebase_info>::uninit();
+        // SAFETY: info points to valid, writable storage for libc to initialize.
+        let rc = unsafe { libc::mach_timebase_info(info.as_mut_ptr()) };
+        if rc == 0 {
+            // SAFETY: mach_timebase_info succeeded and initialized info.
+            let info = unsafe { info.assume_init() };
+            (u64::from(info.numer), u64::from(info.denom.max(1)))
+        } else {
+            (1, 1)
+        }
+    })
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn now_unix_nanos() -> u64 {
+    let mut ts = std::mem::MaybeUninit::<libc::timespec>::uninit();
+    // SAFETY: ts points to valid, writable storage for libc to initialize.
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, ts.as_mut_ptr()) };
+    if rc == 0 {
+        // SAFETY: clock_gettime succeeded and initialized ts.
+        let ts = unsafe { ts.assume_init() };
+        (ts.tv_sec as u64)
+            .saturating_mul(1_000_000_000)
+            .saturating_add(ts.tv_nsec as u64)
+    } else {
+        system_time_unix_nanos()
+    }
+}
+
+#[cfg(not(unix))]
+fn now_unix_nanos() -> u64 {
+    system_time_unix_nanos()
+}
+
+fn system_time_unix_nanos() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64
 }
 
 /// One alias collision detected during loading. `winner` and `loser`
@@ -1204,12 +1265,8 @@ impl SpecStore {
         max_resident_bytes: Option<u64>,
         keep_warm: &HashSet<String>,
     ) -> EvictionReport {
-        self.evict_idle_at(
-            SystemTime::now(),
-            idle_threshold,
-            max_resident_bytes,
-            keep_warm,
-        )
+        let now = UNIX_EPOCH + Duration::from_nanos(now_unix_nanos());
+        self.evict_idle_at(now, idle_threshold, max_resident_bytes, keep_warm)
     }
 
     /// Internal helper that takes an explicit `now` for deterministic tests.

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -953,6 +953,97 @@ pub struct SweepReport {
     pub estimated_resident_bytes_after: u64,
 }
 
+/// RAII guard for the cache-eviction sweep task. Cancellation fires on
+/// drop; the spawned task ends at its next select! arm.
+pub struct SpecCacheSweep {
+    shutdown_tx: tokio::sync::watch::Sender<()>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl SpecCacheSweep {
+    /// Returns the join handle for testing or explicit await.
+    pub fn handle(&self) -> &tokio::task::JoinHandle<()> {
+        &self.handle
+    }
+}
+
+impl Drop for SpecCacheSweep {
+    fn drop(&mut self) {
+        // Best-effort cancel signal. If the receiver is already gone
+        // (task ended on its own), send returns Err — ignored.
+        let _ = self.shutdown_tx.send(());
+        // Do NOT block-on-handle here: if drop runs on the same tokio
+        // runtime as the task, that deadlocks. The cancel signal makes
+        // the task end at its next iteration; the runtime reaps it.
+    }
+}
+
+/// Spawn a background sweep that periodically calls
+/// [`SpecStore::evict_idle`] using the policy in `cfg`. Returns the RAII
+/// guard the caller must keep alive for the duration of the engine.
+///
+/// Returns `None` when `cfg.idle_ttl_secs == 0` — eviction is opt-in;
+/// disabled is a no-op.
+pub fn spawn_spec_cache_sweep(
+    spec_store: Arc<SpecStore>,
+    cfg: gc_config::SpecCacheConfig,
+) -> Option<SpecCacheSweep> {
+    if !cfg.enabled() {
+        return None;
+    }
+    let (tx, mut rx) = tokio::sync::watch::channel(());
+    let interval_secs = cfg.sweep_interval_secs.max(1);
+    let idle_ttl = Duration::from_secs(cfg.idle_ttl_secs);
+    let max_bytes = cfg.max_resident_bytes();
+    let keep_warm: HashSet<String> = cfg.keep_warm.iter().cloned().collect();
+
+    let handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Skip the first immediate tick; the first sweep should fire after
+        // one full interval, not at startup.
+        interval.tick().await;
+
+        loop {
+            tokio::select! {
+                _ = rx.changed() => break,
+                _ = interval.tick() => {
+                    let report = spec_store.evict_idle(idle_ttl, max_bytes, &keep_warm);
+                    if report.evicted_idle_count > 0 || report.evicted_backstop_count > 0 {
+                        tracing::debug!(
+                            evicted_idle = report.evicted_idle_count,
+                            evicted_backstop = report.evicted_backstop_count,
+                            kept_warm = report.kept_warm_count,
+                            parsed = report.parsed_count_after,
+                            bytes = report.estimated_resident_bytes_after,
+                            "spec_cache sweep"
+                        );
+                    }
+                }
+            }
+        }
+    });
+
+    Some(SpecCacheSweep {
+        shutdown_tx: tx,
+        handle,
+    })
+}
+
+/// Test-only spawn entry. Identical to [`spawn_spec_cache_sweep`] but
+/// returns the guard unconditionally so tests can verify cancel behaviour
+/// without hitting the `enabled()` short-circuit.
+#[doc(hidden)]
+pub fn spawn_spec_cache_sweep_for_test(
+    spec_store: Arc<SpecStore>,
+    mut cfg: gc_config::SpecCacheConfig,
+) -> SpecCacheSweep {
+    if cfg.idle_ttl_secs == 0 {
+        cfg.idle_ttl_secs = 1;
+    }
+    spawn_spec_cache_sweep(spec_store, cfg).expect("test helper guarantees enabled() returns true")
+}
+
 impl SpecStore {
     /// Load specs from multiple directories into a precedence-ordered alias
     /// index. A spec from an earlier directory is the primary candidate when

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1015,7 +1015,14 @@ pub struct EvictionReport {
     pub estimated_resident_bytes_after: u64,
 }
 
-/// Persisted sweep report, surfaced to `ghost-complete status`.
+/// Persisted snapshot of the most recent eviction sweep.
+///
+/// Available via [`SpecStore::last_sweep`] for diagnostic callers; not
+/// currently rendered by any user-facing CLI. The status schema 1.5
+/// removed the `last_sweep` field from `ghost-complete status --json`
+/// because the transient store built by the status binary never reflected
+/// the running daemon's eviction state. Today the field is read mainly
+/// by the eviction tests; future in-process tooling may surface it.
 #[derive(Debug, Clone)]
 pub struct SweepReport {
     pub timestamp: SystemTime,
@@ -1903,10 +1910,12 @@ fn register_entries(
         }
 
         // Append the alias by rebuilding the Arc<SpecEntry>.
-        // SpecEntry's fields are not interior-mutable; the rebuild is
-        // confined to load time so the steady-state hot path never
-        // pays this cost. Critically, the parse slot stays empty in the
-        // new entry — parsing is still deferred to first SpecEntry::spec().
+        // `aliases` is an owned `Vec<String>` with no interior mutability,
+        // so appending requires a fresh entry. Confined to load time so
+        // the steady-state hot path never pays this cost. Critically,
+        // the parse slot stays empty in the new entry — parsing is still
+        // deferred to first SpecEntry::spec(), and `last_accessed_nanos`
+        // resets to zero so the new entry starts unmarked for eviction.
         let prev = Arc::clone(&entries[idx]);
         let mut new_aliases = prev.aliases.clone();
         new_aliases.push(name.clone());

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -672,9 +672,13 @@ pub struct SpecEntry {
     shallow_parse_error: Option<String>,
     /// Mutable parse slot. See [`ParsedSlot`] for state semantics.
     parsed: RwLock<ParsedSlot>,
-    /// Last access (read or write) as a relaxed-ordering Unix-epoch
-    /// nanosecond. Bumped on every successful `spec_arc()` hit. Used by
-    /// the sweep task to identify TTL-eligible entries.
+    /// Last access as a relaxed-ordering Unix-epoch nanosecond. Bumped on
+    /// every successful read (any of `spec`, `spec_arc`, `spec_result`, or
+    /// `SpecStore::get`). Backed by a monotonic clock with a fixed offset
+    /// captured at startup; may drift from real wall clock under NTP
+    /// corrections, but eviction comparisons remain consistent because both
+    /// sides use the same clock. Used by the sweep task to identify
+    /// TTL-eligible entries.
     last_accessed_nanos: AtomicU64,
 }
 
@@ -775,7 +779,10 @@ impl SpecEntry {
         self.parsed_result_arc()
     }
 
-    /// Returns the parse error message if the lazy load failed.
+    /// Returns the parse error message if the lazy load failed. Returns
+    /// `None` for Empty, Loaded, or Evicted slots — disambiguate via
+    /// [`Self::is_parsed`] (Empty vs. parsed) and [`Self::spec`]
+    /// (Loaded/Evicted vs. Failed).
     pub fn load_error(&self) -> Option<String> {
         let guard = self.parsed.read().unwrap_or_else(|p| p.into_inner());
         match &*guard {
@@ -972,7 +979,11 @@ pub struct SpecStore {
     conflicts: Vec<AliasConflict>,
     /// Last completed sweep report. `None` until first sweep runs.
     last_sweep: RwLock<Option<SweepReport>>,
-    /// Ensures an unreachable resident cap does not warn on every sweep.
+    /// One-shot warn-once guard for the lifetime of this `SpecStore`. The
+    /// first sweep that finds the resident cap unreachable logs a warning
+    /// and flips this flag; subsequent sweeps stay silent. Intentionally
+    /// not reset: the goal is diagnostic signal without per-tick log spam,
+    /// and `keep_warm` reconfiguration ships through a daemon restart.
     backstop_cap_warned: AtomicBool,
 }
 
@@ -1269,9 +1280,9 @@ impl SpecStore {
         self.evict_idle_at(now, idle_threshold, max_resident_bytes, keep_warm)
     }
 
-    /// Internal helper that takes an explicit `now` for deterministic tests.
-    /// Public for integration-test access; production callers use
-    /// [`Self::evict_idle`].
+    /// Test-visible variant of `evict_idle` that takes an explicit `now` so
+    /// tests can drive eviction with a deterministic clock. Production
+    /// callers use [`Self::evict_idle`].
     #[doc(hidden)]
     pub fn evict_idle_at(
         &self,
@@ -1333,7 +1344,7 @@ impl SpecStore {
                     .collect();
                 victims.sort_by_key(|(ts, _)| *ts); // ascending — oldest first
 
-                for (_, entry) in &victims {
+                for (snapshot_ts, entry) in &victims {
                     if current <= cap {
                         break;
                     }
@@ -1342,6 +1353,13 @@ impl SpecStore {
                         ParsedSlot::Loaded(arc) => estimated_heap_bytes(arc.as_ref()) as u64,
                         _ => continue, // raced — no longer Loaded
                     };
+                    // Re-check under the lock — a reader may have bumped the
+                    // timestamp between the snapshot and the write-lock
+                    // acquisition. Mirrors the Phase 1 guard so a just-warmed
+                    // entry isn't evicted on stale ordering.
+                    if entry.last_accessed() > *snapshot_ts {
+                        continue;
+                    }
                     *guard = ParsedSlot::Evicted;
                     current = current.saturating_sub(freed);
                     evicted_backstop += 1;

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1018,11 +1018,12 @@ pub struct EvictionReport {
 /// Persisted snapshot of the most recent eviction sweep.
 ///
 /// Available via [`SpecStore::last_sweep`] for diagnostic callers; not
-/// currently rendered by any user-facing CLI. The status schema 1.5
-/// removed the `last_sweep` field from `ghost-complete status --json`
-/// because the transient store built by the status binary never reflected
-/// the running daemon's eviction state. Today the field is read mainly
-/// by the eviction tests; future in-process tooling may surface it.
+/// currently rendered by any user-facing CLI. The 1.5 status schema
+/// design intentionally omits `last_sweep` from `ghost-complete status
+/// --json` because the transient store built by the status binary never
+/// reflects the running daemon's eviction state. Today the field is read
+/// mainly by the eviction tests; future in-process tooling may surface
+/// it.
 #[derive(Debug, Clone)]
 pub struct SweepReport {
     pub timestamp: SystemTime,
@@ -1915,7 +1916,8 @@ fn register_entries(
         // the steady-state hot path never pays this cost. Critically,
         // the parse slot stays empty in the new entry — parsing is still
         // deferred to first SpecEntry::spec(), and `last_accessed_nanos`
-        // resets to zero so the new entry starts unmarked for eviction.
+        // resets to zero so its first parse stamps a fresh timestamp via
+        // `bump_last_accessed`.
         let prev = Arc::clone(&entries[idx]);
         let mut new_aliases = prev.aliases.clone();
         new_aliases.push(name.clone());

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -555,6 +557,33 @@ pub enum SpecSource {
     Embedded(&'static str),
 }
 
+/// Mutable parse state for a [`SpecEntry`]. Encodes the four states a
+/// lazy-parsed spec can be in:
+///
+/// * `Empty` — registered, never accessed. Zero heap.
+/// * `Loaded(Arc)` — parsed and resident. The Arc is shared with any
+///   reader that called `spec_arc()`; eviction drops the slot's
+///   strong-ref but readers' clones survive.
+/// * `Evicted` — was `Loaded`, then a TTL/backstop sweep took the write
+///   lock and released the Arc. Next access re-parses.
+/// * `Failed(error)` — parse failed; sticky, never retried, never evicted.
+///   Sweep skips this variant.
+#[derive(Debug)]
+pub(crate) enum ParsedSlot {
+    Empty,
+    Loaded(Arc<CompletionSpec>),
+    Evicted,
+    Failed(String),
+}
+
+impl ParsedSlot {
+    /// True when the slot holds a parsed `Arc`. Used by the sweep task
+    /// to filter eligible entries.
+    pub(crate) fn is_loaded(&self) -> bool {
+        matches!(self, ParsedSlot::Loaded(_))
+    }
+}
+
 /// Explicit source location for a registered spec entry.
 ///
 /// Filesystem specs have a real path. Embedded specs are in-memory slices
@@ -641,9 +670,12 @@ pub struct SpecEntry {
     /// registration. Stored separately so diagnostics stay lazy: the error is
     /// copied into `parsed` only when the entry is first touched.
     shallow_parse_error: Option<String>,
-    /// Lazy parse target. `Ok(Arc<CompletionSpec>)` on success;
-    /// `Err(error_message)` on parse failure (sticky — never retried).
-    parsed: OnceLock<Result<Arc<CompletionSpec>, String>>,
+    /// Mutable parse slot. See [`ParsedSlot`] for state semantics.
+    parsed: RwLock<ParsedSlot>,
+    /// Last access (read or write) as a relaxed-ordering Unix-epoch
+    /// nanosecond. Bumped on every successful `spec_arc()` hit. Used by
+    /// the sweep task to identify TTL-eligible entries.
+    last_accessed_nanos: AtomicU64,
 }
 
 impl SpecEntry {
@@ -654,62 +686,104 @@ impl SpecEntry {
         }
     }
 
-    fn parsed_result(&self) -> std::result::Result<&Arc<CompletionSpec>, &str> {
-        self.parsed
-            .get_or_init(|| {
-                let parsed = if let Some(err) = &self.shallow_parse_error {
-                    Err(err.clone())
-                } else {
-                    parse_entry_source(&self.source)
-                };
-                if let Err(err) = &parsed {
-                    tracing::warn!(
-                        spec_id = %self.id,
-                        source = %self.source_label(),
-                        error = %err,
-                        "spec lazy load failed"
-                    );
+    /// Lazy-parse the entry and return an owned `Arc<CompletionSpec>` clone.
+    /// Errors are sticky — a parse failure is recorded once and never
+    /// retried. Eviction (`ParsedSlot::Evicted`) does not affect
+    /// stickiness; only successful loads can be evicted.
+    fn parsed_result_arc(&self) -> std::result::Result<Arc<CompletionSpec>, String> {
+        // Fast path: read lock. Uncontended in steady state.
+        {
+            let guard = self.parsed.read().unwrap_or_else(|p| p.into_inner());
+            match &*guard {
+                ParsedSlot::Loaded(arc) => {
+                    self.bump_last_accessed();
+                    return Ok(Arc::clone(arc));
                 }
-                parsed
-            })
-            .as_ref()
-            .map_err(String::as_str)
+                ParsedSlot::Failed(err) => return Err(err.clone()),
+                ParsedSlot::Empty | ParsedSlot::Evicted => {}
+            }
+        }
+
+        // Slow path: write lock. Re-check (another writer may have
+        // filled the slot between our drop and re-acquire).
+        let mut guard = self.parsed.write().unwrap_or_else(|p| p.into_inner());
+        match &*guard {
+            ParsedSlot::Loaded(arc) => {
+                self.bump_last_accessed();
+                return Ok(Arc::clone(arc));
+            }
+            ParsedSlot::Failed(err) => return Err(err.clone()),
+            ParsedSlot::Empty | ParsedSlot::Evicted => {}
+        }
+        let parsed = if let Some(err) = &self.shallow_parse_error {
+            Err(err.clone())
+        } else {
+            parse_entry_source(&self.source)
+        };
+        match parsed {
+            Ok(arc) => {
+                *guard = ParsedSlot::Loaded(Arc::clone(&arc));
+                self.bump_last_accessed();
+                Ok(arc)
+            }
+            Err(err) => {
+                tracing::warn!(
+                    spec_id = %self.id,
+                    source = %self.source_label(),
+                    error = %err,
+                    "spec lazy load failed"
+                );
+                let cloned = err.clone();
+                *guard = ParsedSlot::Failed(err);
+                Err(cloned)
+            }
+        }
     }
 
-    /// Lazily parse and return the spec. Returns `None` if parsing
-    /// failed (the failure is recorded once and never retried — call
-    /// [`Self::load_error`] for diagnostics).
-    pub fn spec(&self) -> Option<&CompletionSpec> {
-        self.parsed_result().ok().map(|arc| arc.as_ref())
+    fn bump_last_accessed(&self) {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        self.last_accessed_nanos.store(nanos, Ordering::Relaxed);
     }
 
-    /// Like [`Self::spec`] but returns an owned clone of the cached
-    /// `Arc`. Use when the caller needs to hold the spec across a
-    /// boundary that requires `'static` lifetime; prefer [`Self::spec`]
-    /// otherwise.
+    /// Last access timestamp as `SystemTime`. Returns `UNIX_EPOCH` when
+    /// the entry has never been accessed.
+    pub fn last_accessed(&self) -> SystemTime {
+        let nanos = self.last_accessed_nanos.load(Ordering::Relaxed);
+        UNIX_EPOCH + Duration::from_nanos(nanos)
+    }
+
+    /// Lazily parse and return the spec. Returns `None` if parsing failed.
+    pub fn spec(&self) -> Option<Arc<CompletionSpec>> {
+        self.parsed_result_arc().ok()
+    }
+
+    /// Like [`Self::spec`] but returns the cached `Arc` directly.
     pub fn spec_arc(&self) -> Option<Arc<CompletionSpec>> {
-        self.parsed_result().ok().cloned()
+        self.parsed_result_arc().ok()
     }
 
-    /// Like [`Self::spec`] but preserves the lazy parse error instead of
-    /// collapsing it into `None`.
-    pub fn spec_result(&self) -> std::result::Result<&CompletionSpec, &str> {
-        self.parsed_result().map(|arc| arc.as_ref())
+    /// Like [`Self::spec`] but preserves the lazy parse error.
+    pub fn spec_result(&self) -> std::result::Result<Arc<CompletionSpec>, String> {
+        self.parsed_result_arc()
     }
 
     /// Returns the parse error message if the lazy load failed.
-    /// Returns `None` if the spec has not yet been touched OR loaded
-    /// successfully — disambiguate via [`Self::is_parsed`].
-    pub fn load_error(&self) -> Option<&str> {
-        self.parsed
-            .get()
-            .and_then(|r| r.as_ref().err())
-            .map(String::as_str)
+    pub fn load_error(&self) -> Option<String> {
+        let guard = self.parsed.read().unwrap_or_else(|p| p.into_inner());
+        match &*guard {
+            ParsedSlot::Failed(err) => Some(err.clone()),
+            _ => None,
+        }
     }
 
-    /// True iff this entry has been touched (lazy parse attempted).
+    /// True iff this entry has been touched (parse attempted), regardless
+    /// of outcome or current cache residence.
     pub fn is_parsed(&self) -> bool {
-        self.parsed.get().is_some()
+        let guard = self.parsed.read().unwrap_or_else(|p| p.into_inner());
+        !matches!(&*guard, ParsedSlot::Empty)
     }
 
     pub fn location(&self) -> SpecLocation {
@@ -727,7 +801,7 @@ impl SpecEntry {
 
 /// Parse the JSON behind a [`SpecSource`] into an `Arc<CompletionSpec>`.
 /// Wraps existing parse + sanitize machinery; returns the error as a
-/// `String` so the failure is `Send + Sync` and storable in `OnceLock`.
+/// `String` so the failure is `Send + Sync` and storable in the parse slot.
 fn parse_entry_source(source: &SpecSource) -> Result<Arc<CompletionSpec>, String> {
     let contents: std::borrow::Cow<'_, str> = match source {
         SpecSource::Filesystem(path) => std::borrow::Cow::Owned(
@@ -944,7 +1018,7 @@ impl SpecStore {
     /// no loaded spec advertises this alias OR when every candidate for
     /// that alias failed to parse. Use [`Self::get_result`] to distinguish
     /// unknown commands from parse failures.
-    pub fn get(&self, command: &str) -> Option<&CompletionSpec> {
+    pub fn get(&self, command: &str) -> Option<Arc<CompletionSpec>> {
         self.get_result(command).ok()
     }
 
@@ -955,7 +1029,7 @@ impl SpecStore {
     pub fn get_result(
         &self,
         command: &str,
-    ) -> std::result::Result<&CompletionSpec, SpecLookupError> {
+    ) -> std::result::Result<Arc<CompletionSpec>, SpecLookupError> {
         let Some(candidates) = self.by_alias.get(command) else {
             return Err(SpecLookupError::NoSuchSpec {
                 command: command.to_string(),
@@ -965,14 +1039,14 @@ impl SpecStore {
         let mut first_failure: Option<SpecLookupError> = None;
         for entry in candidates {
             match entry.spec_result() {
-                Ok(spec) => return Ok(spec),
+                Ok(arc) => return Ok(arc),
                 Err(err) => {
                     if first_failure.is_none() {
                         first_failure = Some(SpecLookupError::LoadFailed {
                             command: command.to_string(),
                             id: entry.id.clone(),
                             source: entry.location(),
-                            error: err.to_string(),
+                            error: err,
                         });
                     }
                 }
@@ -987,8 +1061,8 @@ impl SpecStore {
     }
 
     /// Force every entry through its lazy parse. Used by [`Self::iter`]
-    /// so diagnostic CLIs see fully-parsed specs. Idempotent — calls
-    /// after the first force-load are zero-cost OnceLock reads.
+    /// so diagnostic CLIs see fully-parsed specs. Idempotent while entries
+    /// remain loaded.
     fn force_load_all(&self) {
         for entry in &self.entries {
             let _ = entry.spec();
@@ -1007,7 +1081,7 @@ impl SpecStore {
                 entry.load_error().map(|error| SpecEntryLoadError {
                     id: entry.id.clone(),
                     source: entry.location(),
-                    error: error.to_string(),
+                    error,
                 })
             })
             .collect()
@@ -1046,7 +1120,7 @@ impl SpecStore {
     /// The first element is the canonical id (filename stem), NOT
     /// every alias — callers that want to enumerate aliases use
     /// [`SpecStore::entries`] directly.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &CompletionSpec)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&str, Arc<CompletionSpec>)> {
         self.resolved_entries()
             .filter_map(|e| e.spec().map(|s| (e.id.as_str(), s)))
     }
@@ -1385,7 +1459,8 @@ fn register_entries(
             aliases: vec![filename_stem.clone()],
             source,
             shallow_parse_error,
-            parsed: OnceLock::new(),
+            parsed: RwLock::new(ParsedSlot::Empty),
+            last_accessed_nanos: AtomicU64::new(0),
         });
         let idx = entries.len();
         entries.push(Arc::clone(&entry));
@@ -1455,7 +1530,7 @@ fn register_entries(
         // Append the alias by rebuilding the Arc<SpecEntry>.
         // SpecEntry's fields are not interior-mutable; the rebuild is
         // confined to load time so the steady-state hot path never
-        // pays this cost. Critically, the OnceLock stays empty in the
+        // pays this cost. Critically, the parse slot stays empty in the
         // new entry — parsing is still deferred to first SpecEntry::spec().
         let prev = Arc::clone(&entries[idx]);
         let mut new_aliases = prev.aliases.clone();
@@ -1467,7 +1542,8 @@ fn register_entries(
             aliases: new_aliases,
             source: prev.source.clone(),
             shallow_parse_error: prev.shallow_parse_error.clone(),
-            parsed: OnceLock::new(),
+            parsed: RwLock::new(ParsedSlot::Empty),
+            last_accessed_nanos: AtomicU64::new(0),
         };
         let new_arc = Arc::new(new_entry);
         replace_entry_arc(entries, by_alias, &prev, Arc::clone(&new_arc));
@@ -2297,6 +2373,68 @@ mod tests {
     }
 
     #[test]
+    fn parsed_slot_starts_empty_for_fresh_entry() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("foo.json"),
+            r#"{"name":"foo","subcommands":[],"options":[],"args":[]}"#,
+        )
+        .unwrap();
+        let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+        let entry = store.entries().iter().find(|e| e.id == "foo").unwrap();
+        assert!(!entry.is_parsed(), "fresh entry must be Empty (not parsed)");
+    }
+
+    #[test]
+    fn parsed_slot_loads_on_first_get_and_bumps_last_accessed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("foo.json"),
+            r#"{"name":"foo","subcommands":[],"options":[],"args":[]}"#,
+        )
+        .unwrap();
+        let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+        let before = std::time::SystemTime::now();
+        let _ = store.get("foo");
+        let entry = store.entries().iter().find(|e| e.id == "foo").unwrap();
+        assert!(entry.is_parsed());
+        assert!(
+            entry.last_accessed() >= before,
+            "first get() must bump last_accessed"
+        );
+    }
+
+    #[test]
+    fn parsed_slot_failed_is_sticky_across_repeated_gets() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("broken.json"), "{not valid json").unwrap();
+        let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+        assert!(store.get("broken").is_none());
+        let entry = store.entries().iter().find(|e| e.id == "broken").unwrap();
+        let first_err = entry.load_error().unwrap().to_string();
+        assert!(store.get("broken").is_none()); // does not retry
+        assert_eq!(entry.load_error().unwrap(), first_err);
+    }
+
+    #[test]
+    fn store_get_returns_arc_clone_independent_of_slot() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("foo.json"),
+            r#"{"name":"foo","subcommands":[],"options":[],"args":[]}"#,
+        )
+        .unwrap();
+        let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+        let arc1 = store.get("foo").expect("must resolve");
+        let arc2 = store.get("foo").expect("must resolve again");
+        assert!(
+            Arc::ptr_eq(&arc1, &arc2),
+            "two warm gets must return the same Arc identity"
+        );
+        assert_eq!(arc1.name, "foo");
+    }
+
+    #[test]
     fn test_curl_dash_o_resolve_spec_sets_wants_filepaths() {
         let spec_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs/curl.json");
         if !spec_path.exists() {
@@ -2675,7 +2813,7 @@ mod tests {
         // Force the lazy parse for every entry so failure modes surface
         // via SpecEntry::load_error.
         let _: Vec<_> = result.store.iter().collect();
-        let load_errors: Vec<(&str, &str)> = result
+        let load_errors: Vec<(&str, String)> = result
             .store
             .entries()
             .iter()
@@ -3410,8 +3548,8 @@ mod tests {
             .store
             .get("evil[2J")
             .expect("sanitized name should also resolve as alias");
-        assert!(std::ptr::eq(by_stem, by_alias));
-        let spec = by_stem;
+        assert!(Arc::ptr_eq(&by_stem, &by_alias));
+        let spec = by_stem.as_ref();
         assert!(
             !spec.name.contains('\x1b'),
             "name kept ESC: {:?}",
@@ -4224,7 +4362,10 @@ mod tests {
         const BUDGET_BYTES: usize = 128 * 1024 * 1024;
         let spec_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs");
         let store = SpecStore::load_from_dir(&spec_dir).unwrap().store;
-        let total: usize = store.iter().map(|(_, s)| estimated_heap_bytes(s)).sum();
+        let total: usize = store
+            .iter()
+            .map(|(_, s)| estimated_heap_bytes(s.as_ref()))
+            .sum();
         assert!(
             total < BUDGET_BYTES,
             "embedded specs heap {} bytes exceeds budget {} bytes — investigate before raising the limit",

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -914,6 +914,8 @@ pub struct SpecStore {
     conflicts: Vec<AliasConflict>,
     /// Last completed sweep report. `None` until first sweep runs.
     last_sweep: RwLock<Option<SweepReport>>,
+    /// Ensures an unreachable resident cap does not warn on every sweep.
+    backstop_cap_warned: AtomicBool,
 }
 
 pub struct SpecLoadResult {
@@ -1085,6 +1087,7 @@ impl SpecStore {
                 by_alias,
                 conflicts,
                 last_sweep: RwLock::new(None),
+                backstop_cap_warned: AtomicBool::new(false),
             },
             directory_errors,
         })
@@ -1154,6 +1157,7 @@ impl SpecStore {
                 by_alias,
                 conflicts,
                 last_sweep: RwLock::new(None),
+                backstop_cap_warned: AtomicBool::new(false),
             },
             directory_errors,
         })
@@ -1284,7 +1288,7 @@ impl SpecStore {
                     evicted_backstop += 1;
                 }
 
-                if current > cap {
+                if current > cap && !self.backstop_cap_warned.swap(true, Ordering::Relaxed) {
                     tracing::warn!(
                         resident_bytes = current,
                         cap_bytes = cap,

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -755,6 +755,17 @@ impl SpecEntry {
         UNIX_EPOCH + Duration::from_nanos(nanos)
     }
 
+    /// Test-only helper. Force-set `last_accessed_nanos` to a specific
+    /// `SystemTime`. Production code uses `bump_last_accessed` exclusively.
+    #[doc(hidden)]
+    pub fn set_last_accessed_for_test(&self, ts: SystemTime) {
+        let nanos = ts
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        self.last_accessed_nanos.store(nanos, Ordering::Relaxed);
+    }
+
     /// Lazily parse and return the spec. Returns `None` if parsing failed.
     pub fn spec(&self) -> Option<Arc<CompletionSpec>> {
         self.parsed_result_arc().ok()
@@ -784,6 +795,13 @@ impl SpecEntry {
     pub fn is_parsed(&self) -> bool {
         let guard = self.parsed.read().unwrap_or_else(|p| p.into_inner());
         !matches!(&*guard, ParsedSlot::Empty)
+    }
+
+    /// True iff any of the entry's registered aliases is in `keep_warm`.
+    /// Aliases come from `SpecEntry.aliases` (filename stem +
+    /// `CompletionSpec.name` when distinct). Shell aliases are NOT walked.
+    pub(crate) fn has_warm_alias(&self, keep_warm: &HashSet<String>) -> bool {
+        self.aliases.iter().any(|a| keep_warm.contains(a))
     }
 
     pub fn location(&self) -> SpecLocation {
@@ -816,6 +834,11 @@ fn parse_entry_source(source: &SpecSource) -> Result<Arc<CompletionSpec>, String
         tracing::warn!("{}: {w}", spec.name);
     }
     Ok(Arc::new(spec))
+}
+
+fn entry_is_idle_at(entry: &SpecEntry, now: SystemTime, threshold: Duration) -> bool {
+    let last = entry.last_accessed();
+    now.duration_since(last).unwrap_or_default() >= threshold
 }
 
 /// One alias collision detected during loading. `winner` and `loser`
@@ -889,6 +912,8 @@ pub struct SpecStore {
     entries: Vec<Arc<SpecEntry>>,
     by_alias: AliasIndex,
     conflicts: Vec<AliasConflict>,
+    /// Last completed sweep report. `None` until first sweep runs.
+    last_sweep: RwLock<Option<SweepReport>>,
 }
 
 pub struct SpecLoadResult {
@@ -898,6 +923,34 @@ pub struct SpecLoadResult {
     /// [`SpecStore::force_load_errors`] or [`SpecEntry::load_error`] after a
     /// lookup/force-load touches the entry.
     pub directory_errors: Vec<String>,
+}
+
+/// Sweep statistics returned to the caller of [`SpecStore::evict_idle`].
+#[derive(Debug, Clone, Default)]
+pub struct EvictionReport {
+    /// Entries transitioned from `Loaded` to `Evicted` because their
+    /// last-access timestamp exceeded the TTL.
+    pub evicted_idle_count: usize,
+    /// Additional entries evicted by the LRU backstop after Phase 1.
+    pub evicted_backstop_count: usize,
+    /// Entries that were eligible for eviction (idle past TTL) but were
+    /// pinned by a `keep_warm` alias match.
+    pub kept_warm_count: usize,
+    /// `Loaded` entries remaining after the sweep.
+    pub parsed_count_after: usize,
+    /// Estimated resident heap remaining after the sweep, in bytes.
+    pub estimated_resident_bytes_after: u64,
+}
+
+/// Persisted sweep report, surfaced to `ghost-complete status`.
+#[derive(Debug, Clone)]
+pub struct SweepReport {
+    pub timestamp: SystemTime,
+    pub evicted_idle_count: usize,
+    pub evicted_backstop_count: usize,
+    pub kept_warm_count: usize,
+    pub parsed_count_after: usize,
+    pub estimated_resident_bytes_after: u64,
 }
 
 impl SpecStore {
@@ -940,6 +993,7 @@ impl SpecStore {
                 entries,
                 by_alias,
                 conflicts,
+                last_sweep: RwLock::new(None),
             },
             directory_errors,
         })
@@ -1008,9 +1062,122 @@ impl SpecStore {
                 entries,
                 by_alias,
                 conflicts,
+                last_sweep: RwLock::new(None),
             },
             directory_errors,
         })
+    }
+
+    /// Last completed sweep report, or `None` until the first sweep.
+    pub fn last_sweep(&self) -> Option<SweepReport> {
+        self.last_sweep
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+    }
+
+    /// Number of entries currently in `ParsedSlot::Loaded`.
+    pub fn parsed_count(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|e| {
+                let guard = e.parsed.read().unwrap_or_else(|p| p.into_inner());
+                guard.is_loaded()
+            })
+            .count()
+    }
+
+    /// Sum of [`estimated_heap_bytes`] over every currently-loaded entry.
+    /// Approximate per the existing `estimated_heap_bytes` docstring.
+    pub fn estimated_resident_bytes(&self) -> u64 {
+        self.entries
+            .iter()
+            .map(|e| {
+                let guard = e.parsed.read().unwrap_or_else(|p| p.into_inner());
+                match &*guard {
+                    ParsedSlot::Loaded(arc) => estimated_heap_bytes(arc.as_ref()) as u64,
+                    _ => 0,
+                }
+            })
+            .sum()
+    }
+
+    /// Run a cache-eviction sweep. Phase 1 evicts entries idle past the
+    /// `idle_threshold`; Phase 2 (LRU backstop) evicts more entries
+    /// oldest-access-first if the resident heap exceeds `max_resident_bytes`.
+    /// `keep_warm` aliases are exempt from both phases.
+    pub fn evict_idle(
+        &self,
+        idle_threshold: Duration,
+        max_resident_bytes: Option<u64>,
+        keep_warm: &HashSet<String>,
+    ) -> EvictionReport {
+        self.evict_idle_at(SystemTime::now(), idle_threshold, max_resident_bytes, keep_warm)
+    }
+
+    /// Internal helper that takes an explicit `now` for deterministic tests.
+    /// Public for integration-test access; production callers use
+    /// [`Self::evict_idle`].
+    #[doc(hidden)]
+    pub fn evict_idle_at(
+        &self,
+        now: SystemTime,
+        idle_threshold: Duration,
+        _max_resident_bytes: Option<u64>,
+        keep_warm: &HashSet<String>,
+    ) -> EvictionReport {
+        let mut evicted_idle = 0usize;
+        let mut kept_warm = 0usize;
+
+        // Phase 1: TTL eviction.
+        for entry in &self.entries {
+            if entry.has_warm_alias(keep_warm) {
+                if entry_is_idle_at(entry, now, idle_threshold) {
+                    let guard = entry.parsed.read().unwrap_or_else(|p| p.into_inner());
+                    if guard.is_loaded() {
+                        kept_warm += 1;
+                    }
+                }
+                continue;
+            }
+            if !entry_is_idle_at(entry, now, idle_threshold) {
+                continue;
+            }
+            let mut guard = entry.parsed.write().unwrap_or_else(|p| p.into_inner());
+            if !guard.is_loaded() {
+                continue;
+            }
+            // Re-check under the lock — a reader may have bumped the
+            // timestamp between our peek and the write-lock acquisition.
+            if !entry_is_idle_at(entry, now, idle_threshold) {
+                continue;
+            }
+            *guard = ParsedSlot::Evicted;
+            evicted_idle += 1;
+        }
+
+        // Phase 2: backstop. Implemented in Task 8.
+        let evicted_backstop = 0usize;
+
+        let parsed_count = self.parsed_count();
+        let resident = self.estimated_resident_bytes();
+        let report = SweepReport {
+            timestamp: now,
+            evicted_idle_count: evicted_idle,
+            evicted_backstop_count: evicted_backstop,
+            kept_warm_count: kept_warm,
+            parsed_count_after: parsed_count,
+            estimated_resident_bytes_after: resident,
+        };
+        *self.last_sweep.write().unwrap_or_else(|p| p.into_inner()) = Some(report.clone());
+
+        EvictionReport {
+            evicted_idle_count: evicted_idle,
+            evicted_backstop_count: evicted_backstop,
+            kept_warm_count: kept_warm,
+            parsed_count_after: parsed_count,
+            estimated_resident_bytes_after: resident,
+        }
     }
 
     /// Resolve a command alias (filename stem or non-conflicting

--- a/crates/gc-suggest/tests/engine_spec_cache.rs
+++ b/crates/gc-suggest/tests/engine_spec_cache.rs
@@ -1,0 +1,42 @@
+//! Smoke tests for `SuggestionEngine::spawn_spec_cache_sweep` wiring.
+//!
+//! The engine method is a thin passthrough to
+//! [`gc_suggest::specs::spawn_spec_cache_sweep`]; these tests guard the
+//! `Arc<SpecStore>` clone and the `enabled()` short-circuit at the engine
+//! layer.
+
+use std::path::PathBuf;
+
+use gc_config::SpecCacheConfig;
+use gc_suggest::SuggestionEngine;
+
+fn engine() -> SuggestionEngine {
+    let spec_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../specs");
+    SuggestionEngine::new(&[spec_dir]).expect("engine must construct from workspace specs")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn engine_spawn_spec_cache_sweep_returns_none_when_disabled() {
+    let engine = engine();
+    let cfg = SpecCacheConfig::default(); // idle_ttl_secs = 0 → disabled
+    assert!(
+        engine.spawn_spec_cache_sweep(cfg).is_none(),
+        "engine wiring must honour the eviction-disabled short-circuit"
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn engine_spawn_spec_cache_sweep_returns_some_when_enabled() {
+    let engine = engine();
+    let cfg = SpecCacheConfig {
+        idle_ttl_secs: 1,
+        sweep_interval_secs: 1,
+        keep_warm: vec![],
+        max_resident_mb: 0,
+    };
+    let sweep = engine.spawn_spec_cache_sweep(cfg);
+    assert!(
+        sweep.is_some(),
+        "engine wiring must spawn a sweep guard when eviction is enabled"
+    );
+}

--- a/crates/gc-suggest/tests/eviction.rs
+++ b/crates/gc-suggest/tests/eviction.rs
@@ -438,6 +438,11 @@ async fn sweep_smoke_evicts_idle_after_interval() {
     };
     let _sweep = gc_suggest::spawn_spec_cache_sweep_for_test(Arc::clone(&store), cfg);
     tokio::task::yield_now().await; // let the task consume interval's initial tick
+    assert_eq!(
+        store.parsed_count(),
+        1,
+        "initial interval tick must be skipped; first sweep waits one full interval"
+    );
 
     // Advance virtual time past one sweep tick.
     tokio::time::advance(Duration::from_secs(3)).await;
@@ -452,6 +457,7 @@ async fn sweep_smoke_cancels_on_drop() {
     write_spec(dir.path(), "git.json", &minimal_spec("git"));
     let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
     let store = Arc::new(store);
+    let weak_store = Arc::downgrade(&store);
 
     let cfg = SpecCacheConfig {
         idle_ttl_secs: 1,
@@ -460,12 +466,15 @@ async fn sweep_smoke_cancels_on_drop() {
         max_resident_mb: 0,
     };
     let sweep = gc_suggest::spawn_spec_cache_sweep_for_test(Arc::clone(&store), cfg);
+    drop(store);
     drop(sweep);
 
     tokio::time::advance(Duration::from_secs(10)).await;
     tokio::task::yield_now().await;
-    // No assertion needed — if the task is leaked, tokio runtime drop
-    // would log; the test simply must not hang.
+    assert!(
+        weak_store.upgrade().is_none(),
+        "dropping the sweep guard must let the task exit and release its SpecStore Arc"
+    );
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/gc-suggest/tests/eviction.rs
+++ b/crates/gc-suggest/tests/eviction.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+use gc_config::SpecCacheConfig;
 use gc_suggest::SpecStore;
 use tempfile::TempDir;
 
@@ -306,15 +307,23 @@ fn backstop_evicts_oldest_first() {
     for i in 0..5 {
         let id = format!("cmd{i}");
         let entry = store.entries().iter().find(|e| e.id == id).unwrap().clone();
-        // cmd0 oldest, cmd4 newest.
-        entry.set_last_accessed_for_test(now - Duration::from_secs((5 - i as u64) * 100));
+        // Deliberately make cmd3 oldest so insertion-order eviction would fail.
+        let age_secs = match i {
+            3 => 500,
+            0 => 400,
+            1 => 300,
+            2 => 200,
+            4 => 100,
+            _ => unreachable!(),
+        };
+        entry.set_last_accessed_for_test(now - Duration::from_secs(age_secs));
     }
     assert_eq!(store.parsed_count(), 5);
     let resident_before = store.estimated_resident_bytes();
     assert!(resident_before > 1, "fixture specs should have non-zero heap estimate");
 
     // Cap just below the current estimate forces exactly the oldest entry
-    // out: freeing cmd0 is enough to get back under the cap.
+    // out: freeing cmd3 is enough to get back under the cap.
     let report = store.evict_idle_at(
         now,
         Duration::MAX,            // TTL phase: no-op
@@ -323,14 +332,20 @@ fn backstop_evicts_oldest_first() {
     );
     assert_eq!(report.evicted_backstop_count, 1);
 
-    // Specifically verify cmd0 (oldest) was evicted before cmd4 (newest).
+    // Specifically verify cmd3 (oldest) was evicted before cmd0 (first
+    // registered) and cmd4 (newest).
     // `is_parsed()` remains true for Evicted slots by design, so Arc identity
-    // is the public observable: cmd0 re-parses to a fresh Arc; cmd4 stays warm.
-    let cmd0_after = store.get("cmd0").expect("cmd0 must reparse");
+    // is the public observable: cmd3 re-parses to a fresh Arc; cmd0/cmd4 stay warm.
+    let cmd3_after = store.get("cmd3").expect("cmd3 must reparse");
+    let cmd0_after = store.get("cmd0").expect("cmd0 must remain available");
     let cmd4_after = store.get("cmd4").expect("cmd4 must remain available");
     assert!(
-        !Arc::ptr_eq(&loaded_arcs[0], &cmd0_after),
+        !Arc::ptr_eq(&loaded_arcs[3], &cmd3_after),
         "oldest entry must reparse after backstop eviction"
+    );
+    assert!(
+        Arc::ptr_eq(&loaded_arcs[0], &cmd0_after),
+        "first registered entry should remain resident when it is not oldest"
     );
     assert!(
         Arc::ptr_eq(&loaded_arcs[4], &cmd4_after),
@@ -403,4 +418,83 @@ fn backstop_warns_when_keep_warm_pin_exceeds_cap() {
         report.parsed_count_after, 3,
         "all three entries must remain Loaded"
     );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn sweep_smoke_evicts_idle_after_interval() {
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let store = Arc::new(store);
+    let _ = store.get("git");
+    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
+
+    let cfg = SpecCacheConfig {
+        idle_ttl_secs: 1,
+        sweep_interval_secs: 1,
+        keep_warm: vec![],
+        max_resident_mb: 0,
+    };
+    let _sweep = gc_suggest::spawn_spec_cache_sweep_for_test(Arc::clone(&store), cfg);
+    tokio::task::yield_now().await; // let the task consume interval's initial tick
+
+    // Advance virtual time past one sweep tick.
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await; // give the sweep task a chance to run
+
+    assert_eq!(store.parsed_count(), 0, "sweep task must have evicted the idle entry");
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn sweep_smoke_cancels_on_drop() {
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let store = Arc::new(store);
+
+    let cfg = SpecCacheConfig {
+        idle_ttl_secs: 1,
+        sweep_interval_secs: 1,
+        keep_warm: vec![],
+        max_resident_mb: 0,
+    };
+    let sweep = gc_suggest::spawn_spec_cache_sweep_for_test(Arc::clone(&store), cfg);
+    drop(sweep);
+
+    tokio::time::advance(Duration::from_secs(10)).await;
+    tokio::task::yield_now().await;
+    // No assertion needed — if the task is leaked, tokio runtime drop
+    // would log; the test simply must not hang.
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn sweep_smoke_no_log_spam_when_nothing_eligible() {
+    // The sweep loop's tracing::debug! must be gated on
+    // "evicted_idle_count > 0 || evicted_backstop_count > 0". A nothing-
+    // eligible sweep must not log. We assert the report itself shows
+    // zero evictions across N sweep ticks.
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let store = Arc::new(store);
+    let _ = store.get("git"); // Loaded, just-now timestamp
+
+    let cfg = SpecCacheConfig {
+        idle_ttl_secs: 3600, // 1h — git's just-now timestamp is not idle
+        sweep_interval_secs: 1,
+        keep_warm: vec![],
+        max_resident_mb: 0,
+    };
+    let _sweep = gc_suggest::spawn_spec_cache_sweep_for_test(Arc::clone(&store), cfg);
+    tokio::task::yield_now().await; // let the task consume interval's initial tick
+
+    // Advance past 5 sweep intervals; each is a no-op.
+    tokio::time::advance(Duration::from_secs(5)).await;
+    tokio::task::yield_now().await;
+
+    let report = store.last_sweep().expect("at least one sweep ran");
+    assert_eq!(report.evicted_idle_count, 0);
+    assert_eq!(report.evicted_backstop_count, 0);
+    assert_eq!(report.parsed_count_after, 1);
 }

--- a/crates/gc-suggest/tests/eviction.rs
+++ b/crates/gc-suggest/tests/eviction.rs
@@ -1,0 +1,280 @@
+//! Integration tests for the spec cache TTL eviction policy.
+//!
+//! Eviction is opt-in (idle_ttl_secs=0 disables it). These tests exercise
+//! the SpecStore::evict_idle policy directly with an explicit clock; the
+//! sweep task itself is covered by sweep_smoke_* tests later in this file.
+
+use std::collections::HashSet;
+use std::fs;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use gc_suggest::SpecStore;
+use tempfile::TempDir;
+
+fn write_spec(dir: &std::path::Path, filename: &str, body: &str) {
+    fs::write(dir.join(filename), body).unwrap();
+}
+
+fn minimal_spec(name: &str) -> String {
+    format!(r#"{{"name":"{name}","subcommands":[],"options":[],"args":[]}}"#)
+}
+
+fn empty_keep_warm() -> HashSet<String> {
+    HashSet::new()
+}
+
+#[test]
+fn eviction_disabled_preserves_v0_12_4_contract() {
+    // idle_threshold = MAX means no entry is ever idle long enough.
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let _ = store.get("git");
+    assert_eq!(store.parsed_count(), 1);
+
+    let report = store.evict_idle(Duration::MAX, None, &empty_keep_warm());
+    assert_eq!(report.evicted_idle_count, 0);
+    assert_eq!(store.parsed_count(), 1);
+}
+
+#[test]
+fn evict_idle_evicts_loaded_past_threshold() {
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let _ = store.get("git");
+    assert_eq!(store.parsed_count(), 1);
+
+    // Force last_accessed to a known-old time.
+    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    let an_hour_ago = SystemTime::now() - Duration::from_secs(3600);
+    entry.set_last_accessed_for_test(an_hour_ago);
+
+    let report = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(60),
+        None,
+        &empty_keep_warm(),
+    );
+    assert_eq!(report.evicted_idle_count, 1);
+    assert_eq!(store.parsed_count(), 0);
+}
+
+#[test]
+fn evict_idle_skips_keep_warm_by_filename_stem() {
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let _ = store.get("git");
+    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
+
+    let mut keep_warm = HashSet::new();
+    keep_warm.insert("git".to_string());
+    let report = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(60),
+        None,
+        &keep_warm,
+    );
+    assert_eq!(report.evicted_idle_count, 0);
+    assert_eq!(report.kept_warm_count, 1);
+    assert_eq!(store.parsed_count(), 1);
+}
+
+#[test]
+fn evict_idle_skips_keep_warm_by_completion_name() {
+    // A spec whose CompletionSpec.name differs from filename stem.
+    let dir = TempDir::new().unwrap();
+    write_spec(
+        dir.path(),
+        "my-tool.json",
+        r#"{"name":"mt","subcommands":[],"options":[],"args":[]}"#,
+    );
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let _ = store.get("mt");
+    let entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "my-tool")
+        .unwrap()
+        .clone();
+    entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
+
+    let mut keep_warm = HashSet::new();
+    keep_warm.insert("mt".to_string()); // matches CompletionSpec.name, not stem
+    let report = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(60),
+        None,
+        &keep_warm,
+    );
+    assert_eq!(report.kept_warm_count, 1);
+    assert_eq!(report.evicted_idle_count, 0);
+}
+
+#[test]
+fn evict_idle_does_not_clear_failed_slot() {
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "broken.json", "{not valid json");
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    assert!(store.get("broken").is_none()); // populates Failed
+    let entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "broken")
+        .unwrap()
+        .clone();
+    entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
+
+    let _ = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(60),
+        None,
+        &empty_keep_warm(),
+    );
+    // Failed slot survives — load_error still returns the original message.
+    assert!(
+        entry.load_error().is_some(),
+        "Failed slot must survive eviction (sticky failures)"
+    );
+}
+
+#[test]
+fn evict_idle_does_not_clear_empty_slot() {
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    // Never call get(); slot stays Empty.
+    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    assert!(!entry.is_parsed());
+
+    let report = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(0), // every entry "idle"
+        None,
+        &empty_keep_warm(),
+    );
+    assert_eq!(
+        report.evicted_idle_count, 0,
+        "Empty slot must not count as evicted"
+    );
+    assert!(!entry.is_parsed(), "Empty slot should remain Empty after sweep");
+}
+
+#[test]
+fn evict_idle_then_get_returns_fresh_arc_with_same_contents() {
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let arc1 = store.get("git").expect("first get must resolve");
+    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
+
+    let _ = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(60),
+        None,
+        &empty_keep_warm(),
+    );
+    let arc2 = store.get("git").expect("second get re-parses and resolves");
+    assert!(
+        !Arc::ptr_eq(&arc1, &arc2),
+        "post-eviction Arc must be a fresh allocation"
+    );
+    assert_eq!(arc1.name, arc2.name);
+}
+
+#[test]
+fn last_sweep_records_under_lock() {
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    assert!(store.last_sweep().is_none());
+
+    let now = SystemTime::now();
+    let _ = store.evict_idle_at(now, Duration::MAX, None, &empty_keep_warm());
+
+    let report = store.last_sweep().expect("last_sweep must record after a run");
+    assert_eq!(report.timestamp, now);
+    assert_eq!(report.evicted_idle_count, 0);
+}
+
+#[test]
+fn concurrent_evict_and_get_yields_single_parse() {
+    use std::sync::Barrier;
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = Arc::new(SpecStore::load_from_dir(dir.path()).unwrap().store);
+
+    // Force the slot to Evicted via a manual sweep-then-eligible.
+    let _ = store.get("git");
+    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
+    let _ = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(60),
+        None,
+        &empty_keep_warm(),
+    );
+    assert_eq!(store.parsed_count(), 0);
+
+    // Race 16 readers against the now-Evicted slot. They must all observe
+    // the same Arc identity (one parse, all share).
+    let barrier = Arc::new(Barrier::new(16));
+    let handles: Vec<_> = (0..16)
+        .map(|_| {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                store.get("git").expect("git must resolve")
+            })
+        })
+        .collect();
+
+    let arcs: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let first = &arcs[0];
+    for arc in &arcs[1..] {
+        assert!(
+            Arc::ptr_eq(first, arc),
+            "all concurrent readers must observe the same Arc — single-flight broken"
+        );
+    }
+}
+
+#[test]
+fn force_load_errors_re_parses_evicted_entries() {
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    write_spec(dir.path(), "broken.json", "{not valid json");
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+
+    // Prime: parse both. Broken stays Failed; git becomes Loaded.
+    let _ = store.get("git");
+    let _ = store.get("broken");
+    let git_entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    git_entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
+
+    // Evict git (broken slot is Failed and survives).
+    let _ = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(60),
+        None,
+        &empty_keep_warm(),
+    );
+    assert_eq!(store.parsed_count(), 0);
+
+    // force_load_errors should re-parse evicted entries (so git becomes
+    // Loaded again) and return the broken entry's still-stuck Failed
+    // error. Documented behaviour: status pays the re-parse cost.
+    let errors = store.force_load_errors();
+    assert_eq!(errors.len(), 1, "only the broken entry should report an error");
+    assert_eq!(errors[0].id, "broken");
+    assert_eq!(
+        store.parsed_count(),
+        1,
+        "git must have been re-parsed by force_load"
+    );
+}

--- a/crates/gc-suggest/tests/eviction.rs
+++ b/crates/gc-suggest/tests/eviction.rs
@@ -278,3 +278,129 @@ fn force_load_errors_re_parses_evicted_entries() {
         "git must have been re-parsed by force_load"
     );
 }
+
+fn write_n_specs(dir: &std::path::Path, n: usize) {
+    for i in 0..n {
+        write_spec(
+            dir,
+            &format!("cmd{i}.json"),
+            &minimal_spec(&format!("cmd{i}")),
+        );
+    }
+}
+
+#[test]
+fn backstop_evicts_oldest_first() {
+    let dir = TempDir::new().unwrap();
+    write_n_specs(dir.path(), 5);
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+
+    // Load all 5; set distinct last_accessed timestamps.
+    let now = SystemTime::now();
+    let loaded_arcs: Vec<_> = (0..5)
+        .map(|i| {
+            let id = format!("cmd{i}");
+            store.get(&id).expect("spec must load")
+        })
+        .collect();
+    for i in 0..5 {
+        let id = format!("cmd{i}");
+        let entry = store.entries().iter().find(|e| e.id == id).unwrap().clone();
+        // cmd0 oldest, cmd4 newest.
+        entry.set_last_accessed_for_test(now - Duration::from_secs((5 - i as u64) * 100));
+    }
+    assert_eq!(store.parsed_count(), 5);
+    let resident_before = store.estimated_resident_bytes();
+    assert!(resident_before > 1, "fixture specs should have non-zero heap estimate");
+
+    // Cap just below the current estimate forces exactly the oldest entry
+    // out: freeing cmd0 is enough to get back under the cap.
+    let report = store.evict_idle_at(
+        now,
+        Duration::MAX,            // TTL phase: no-op
+        Some(resident_before - 1), // backstop only
+        &empty_keep_warm(),
+    );
+    assert_eq!(report.evicted_backstop_count, 1);
+
+    // Specifically verify cmd0 (oldest) was evicted before cmd4 (newest).
+    // `is_parsed()` remains true for Evicted slots by design, so Arc identity
+    // is the public observable: cmd0 re-parses to a fresh Arc; cmd4 stays warm.
+    let cmd0_after = store.get("cmd0").expect("cmd0 must reparse");
+    let cmd4_after = store.get("cmd4").expect("cmd4 must remain available");
+    assert!(
+        !Arc::ptr_eq(&loaded_arcs[0], &cmd0_after),
+        "oldest entry must reparse after backstop eviction"
+    );
+    assert!(
+        Arc::ptr_eq(&loaded_arcs[4], &cmd4_after),
+        "newest entry should remain resident when one eviction satisfies cap"
+    );
+}
+
+#[test]
+fn backstop_respects_keep_warm_under_pressure() {
+    let dir = TempDir::new().unwrap();
+    write_n_specs(dir.path(), 3);
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let now = SystemTime::now();
+    for i in 0..3 {
+        let _ = store.get(&format!("cmd{i}"));
+    }
+    let cmd0_entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "cmd0")
+        .unwrap()
+        .clone();
+    cmd0_entry.set_last_accessed_for_test(now - Duration::from_secs(3600));
+
+    let mut keep_warm = HashSet::new();
+    keep_warm.insert("cmd0".to_string());
+    let _ = store.evict_idle_at(
+        now,
+        Duration::MAX,
+        Some(1), // pathological cap
+        &keep_warm,
+    );
+    // cmd0 must remain Loaded despite being the oldest.
+    let cmd0_after = store.entries().iter().find(|e| e.id == "cmd0").unwrap();
+    assert!(
+        cmd0_after.spec_arc().is_some(),
+        "keep_warm entry must be exempt from backstop eviction"
+    );
+}
+
+#[test]
+fn backstop_warns_when_keep_warm_pin_exceeds_cap() {
+    // When every Loaded entry is in keep_warm and total > cap, backstop
+    // cannot reach the target. The implementation logs a warn once per
+    // sweep. This test pins the behaviour without asserting on the log
+    // (log-capture machinery lives in lazy_loading.rs); it asserts that
+    // the entries remain Loaded and the report's evicted_backstop_count
+    // is zero.
+    let dir = TempDir::new().unwrap();
+    write_n_specs(dir.path(), 3);
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    for i in 0..3 {
+        let _ = store.get(&format!("cmd{i}"));
+    }
+    let mut keep_warm = HashSet::new();
+    for i in 0..3 {
+        keep_warm.insert(format!("cmd{i}"));
+    }
+    let report = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::MAX,
+        Some(1), // cap=1 byte forces backstop
+        &keep_warm,
+    );
+    assert_eq!(
+        report.evicted_backstop_count, 0,
+        "backstop must not evict keep_warm entries even when cap is unreachable"
+    );
+    assert_eq!(
+        report.parsed_count_after, 3,
+        "all three entries must remain Loaded"
+    );
+}

--- a/crates/gc-suggest/tests/eviction.rs
+++ b/crates/gc-suggest/tests/eviction.rs
@@ -6,12 +6,55 @@
 
 use std::collections::HashSet;
 use std::fs;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use gc_config::SpecCacheConfig;
 use gc_suggest::SpecStore;
 use tempfile::TempDir;
+use tracing_subscriber::fmt::MakeWriter;
+
+#[derive(Clone)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("capture buffer poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn install_log_capture() -> (Arc<Mutex<Vec<u8>>>, tracing::subscriber::DefaultGuard) {
+    let captured = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let writer = CaptureWriter(Arc::clone(&captured));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(writer)
+        .with_max_level(tracing::Level::WARN)
+        .with_ansi(false)
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing_core::callsite::rebuild_interest_cache();
+    (captured, guard)
+}
+
+fn captured_logs(captured: &Arc<Mutex<Vec<u8>>>) -> String {
+    String::from_utf8_lossy(&captured.lock().expect("capture buffer poisoned")).into_owned()
+}
 
 fn write_spec(dir: &std::path::Path, filename: &str, body: &str) {
     fs::write(dir.join(filename), body).unwrap();
@@ -547,4 +590,145 @@ async fn sweep_smoke_no_log_spam_when_nothing_eligible() {
     assert_eq!(report.evicted_idle_count, 0);
     assert_eq!(report.evicted_backstop_count, 0);
     assert_eq!(report.parsed_count_after, 1);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn sweep_smoke_does_not_panic_when_sweep_interval_zero() {
+    // `tokio::time::interval(Duration::from_secs(0))` panics. The
+    // `sweep_interval_secs.max(1)` clamp inside `spawn_spec_cache_sweep`
+    // is the only guard for callers that bypass `GhostConfig::normalize`.
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let store = Arc::new(store);
+
+    let cfg = SpecCacheConfig {
+        idle_ttl_secs: 1,
+        sweep_interval_secs: 0,
+        keep_warm: vec![],
+        max_resident_mb: 0,
+    };
+    let _sweep = gc_suggest::spawn_spec_cache_sweep_for_test(Arc::clone(&store), cfg);
+    tokio::task::yield_now().await; // let the task consume interval's initial tick
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        store.last_sweep().is_some(),
+        "the clamped 1-second interval must allow at least one sweep to complete"
+    );
+}
+
+#[test]
+fn repeated_get_bumps_last_accessed_each_call() {
+    // The read-lock fast path inside `parsed_result_arc` must call
+    // `bump_last_accessed` on every successful hit, otherwise an actively-
+    // used spec could be evicted as if it were idle.
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let _ = store.get("git"); // first parse, populates Loaded
+    let entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "git")
+        .unwrap()
+        .clone();
+
+    // Backdate the timestamp; a second get() must bump it back to ~now.
+    let now = SystemTime::now();
+    entry.set_last_accessed_for_test(now - Duration::from_secs(3600));
+    let _ = store.get("git").expect("warm get must resolve");
+    assert!(
+        entry.last_accessed() >= now - Duration::from_secs(60),
+        "warm read-lock fast path must bump last_accessed on every hit"
+    );
+
+    // The just-warmed entry must survive a TTL sweep.
+    let report = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(60),
+        None,
+        &empty_keep_warm(),
+    );
+    assert_eq!(report.evicted_idle_count, 0);
+    assert_eq!(store.parsed_count(), 1);
+}
+
+#[test]
+fn backstop_warn_emits_only_once_across_repeated_sweeps() {
+    // `backstop_cap_warned` is one-shot for the lifetime of the SpecStore.
+    // Three sweeps under unreachable-cap pressure must produce exactly one
+    // warn line, not three.
+    let dir = TempDir::new().unwrap();
+    write_n_specs(dir.path(), 3);
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    for i in 0..3 {
+        let _ = store.get(&format!("cmd{i}"));
+    }
+    let mut keep_warm = HashSet::new();
+    for i in 0..3 {
+        keep_warm.insert(format!("cmd{i}"));
+    }
+
+    let (captured, _guard) = install_log_capture();
+    for _ in 0..3 {
+        let _ = store.evict_idle_at(SystemTime::now(), Duration::MAX, Some(1), &keep_warm);
+    }
+
+    let logs = captured_logs(&captured);
+    assert_eq!(
+        logs.matches("backstop unable to reach cap").count(),
+        1,
+        "warn-once guard must collapse repeated unreachable-cap sweeps to a single log line:\n{logs}"
+    );
+}
+
+#[test]
+fn evict_idle_on_empty_store_reports_zero() {
+    // An empty spec dir produces a SpecStore with zero entries. evict_idle
+    // must walk it without panicking and report all-zero counters.
+    let dir = TempDir::new().unwrap();
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let report = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::from_secs(0),
+        Some(0), // also exercises the cap=0 path with no entries
+        &empty_keep_warm(),
+    );
+    assert_eq!(report.evicted_idle_count, 0);
+    assert_eq!(report.evicted_backstop_count, 0);
+    assert_eq!(report.parsed_count_after, 0);
+    assert_eq!(report.estimated_resident_bytes_after, 0);
+}
+
+#[test]
+fn backstop_with_single_entry_evicts_to_zero_under_pressure() {
+    // Cap = 0 forces the backstop to evict every Loaded entry. The
+    // saturating-sub of `current` against `freed` keeps the loop sound when
+    // freed bytes exceed remaining bytes. Post-sweep, the store must
+    // re-parse cleanly on the next get.
+    let dir = TempDir::new().unwrap();
+    write_spec(dir.path(), "git.json", &minimal_spec("git"));
+    let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
+    let _ = store.get("git").expect("first load must succeed");
+    assert_eq!(store.parsed_count(), 1);
+
+    let report = store.evict_idle_at(
+        SystemTime::now(),
+        Duration::MAX, // disable Phase 1
+        Some(0),       // cap=0 forces every Loaded entry out via Phase 2
+        &empty_keep_warm(),
+    );
+    assert_eq!(report.evicted_backstop_count, 1);
+    assert_eq!(store.parsed_count(), 0);
+
+    // Post-sweep, the entry must re-parse cleanly through the standard
+    // `get` path.
+    let arc = store
+        .get("git")
+        .expect("post-eviction re-parse must succeed");
+    assert_eq!(arc.name, "git");
+    assert_eq!(store.parsed_count(), 1);
 }

--- a/crates/gc-suggest/tests/eviction.rs
+++ b/crates/gc-suggest/tests/eviction.rs
@@ -48,7 +48,12 @@ fn evict_idle_evicts_loaded_past_threshold() {
     assert_eq!(store.parsed_count(), 1);
 
     // Force last_accessed to a known-old time.
-    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    let entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "git")
+        .unwrap()
+        .clone();
     let an_hour_ago = SystemTime::now() - Duration::from_secs(3600);
     entry.set_last_accessed_for_test(an_hour_ago);
 
@@ -68,17 +73,17 @@ fn evict_idle_skips_keep_warm_by_filename_stem() {
     write_spec(dir.path(), "git.json", &minimal_spec("git"));
     let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
     let _ = store.get("git");
-    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    let entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "git")
+        .unwrap()
+        .clone();
     entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
 
     let mut keep_warm = HashSet::new();
     keep_warm.insert("git".to_string());
-    let report = store.evict_idle_at(
-        SystemTime::now(),
-        Duration::from_secs(60),
-        None,
-        &keep_warm,
-    );
+    let report = store.evict_idle_at(SystemTime::now(), Duration::from_secs(60), None, &keep_warm);
     assert_eq!(report.evicted_idle_count, 0);
     assert_eq!(report.kept_warm_count, 1);
     assert_eq!(store.parsed_count(), 1);
@@ -105,12 +110,7 @@ fn evict_idle_skips_keep_warm_by_completion_name() {
 
     let mut keep_warm = HashSet::new();
     keep_warm.insert("mt".to_string()); // matches CompletionSpec.name, not stem
-    let report = store.evict_idle_at(
-        SystemTime::now(),
-        Duration::from_secs(60),
-        None,
-        &keep_warm,
-    );
+    let report = store.evict_idle_at(SystemTime::now(), Duration::from_secs(60), None, &keep_warm);
     assert_eq!(report.kept_warm_count, 1);
     assert_eq!(report.evicted_idle_count, 0);
 }
@@ -148,7 +148,12 @@ fn evict_idle_does_not_clear_empty_slot() {
     write_spec(dir.path(), "git.json", &minimal_spec("git"));
     let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
     // Never call get(); slot stays Empty.
-    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    let entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "git")
+        .unwrap()
+        .clone();
     assert!(!entry.is_parsed());
 
     let report = store.evict_idle_at(
@@ -161,7 +166,10 @@ fn evict_idle_does_not_clear_empty_slot() {
         report.evicted_idle_count, 0,
         "Empty slot must not count as evicted"
     );
-    assert!(!entry.is_parsed(), "Empty slot should remain Empty after sweep");
+    assert!(
+        !entry.is_parsed(),
+        "Empty slot should remain Empty after sweep"
+    );
 }
 
 #[test]
@@ -170,7 +178,12 @@ fn evict_idle_then_get_returns_fresh_arc_with_same_contents() {
     write_spec(dir.path(), "git.json", &minimal_spec("git"));
     let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
     let arc1 = store.get("git").expect("first get must resolve");
-    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    let entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "git")
+        .unwrap()
+        .clone();
     entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
 
     let _ = store.evict_idle_at(
@@ -197,7 +210,9 @@ fn last_sweep_records_under_lock() {
     let now = SystemTime::now();
     let _ = store.evict_idle_at(now, Duration::MAX, None, &empty_keep_warm());
 
-    let report = store.last_sweep().expect("last_sweep must record after a run");
+    let report = store
+        .last_sweep()
+        .expect("last_sweep must record after a run");
     assert_eq!(report.timestamp, now);
     assert_eq!(report.evicted_idle_count, 0);
 }
@@ -211,7 +226,12 @@ fn concurrent_evict_and_get_yields_single_parse() {
 
     // Force the slot to Evicted via a manual sweep-then-eligible.
     let _ = store.get("git");
-    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    let entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "git")
+        .unwrap()
+        .clone();
     entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
     let _ = store.evict_idle_at(
         SystemTime::now(),
@@ -255,7 +275,12 @@ fn force_load_errors_re_parses_evicted_entries() {
     // Prime: parse both. Broken stays Failed; git becomes Loaded.
     let _ = store.get("git");
     let _ = store.get("broken");
-    let git_entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    let git_entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "git")
+        .unwrap()
+        .clone();
     git_entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
 
     // Evict git (broken slot is Failed and survives).
@@ -271,7 +296,11 @@ fn force_load_errors_re_parses_evicted_entries() {
     // Loaded again) and return the broken entry's still-stuck Failed
     // error. Documented behaviour: status pays the re-parse cost.
     let errors = store.force_load_errors();
-    assert_eq!(errors.len(), 1, "only the broken entry should report an error");
+    assert_eq!(
+        errors.len(),
+        1,
+        "only the broken entry should report an error"
+    );
     assert_eq!(errors[0].id, "broken");
     assert_eq!(
         store.parsed_count(),
@@ -320,13 +349,16 @@ fn backstop_evicts_oldest_first() {
     }
     assert_eq!(store.parsed_count(), 5);
     let resident_before = store.estimated_resident_bytes();
-    assert!(resident_before > 1, "fixture specs should have non-zero heap estimate");
+    assert!(
+        resident_before > 1,
+        "fixture specs should have non-zero heap estimate"
+    );
 
     // Cap just below the current estimate forces exactly the oldest entry
     // out: freeing cmd3 is enough to get back under the cap.
     let report = store.evict_idle_at(
         now,
-        Duration::MAX,            // TTL phase: no-op
+        Duration::MAX,             // TTL phase: no-op
         Some(resident_before - 1), // backstop only
         &empty_keep_warm(),
     );
@@ -427,7 +459,12 @@ async fn sweep_smoke_evicts_idle_after_interval() {
     let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
     let store = Arc::new(store);
     let _ = store.get("git");
-    let entry = store.entries().iter().find(|e| e.id == "git").unwrap().clone();
+    let entry = store
+        .entries()
+        .iter()
+        .find(|e| e.id == "git")
+        .unwrap()
+        .clone();
     entry.set_last_accessed_for_test(SystemTime::now() - Duration::from_secs(3600));
 
     let cfg = SpecCacheConfig {
@@ -448,7 +485,11 @@ async fn sweep_smoke_evicts_idle_after_interval() {
     tokio::time::advance(Duration::from_secs(3)).await;
     tokio::task::yield_now().await; // give the sweep task a chance to run
 
-    assert_eq!(store.parsed_count(), 0, "sweep task must have evicted the idle entry");
+    assert_eq!(
+        store.parsed_count(),
+        0,
+        "sweep task must have evicted the idle entry"
+    );
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/gc-suggest/tests/eviction.rs
+++ b/crates/gc-suggest/tests/eviction.rs
@@ -69,7 +69,7 @@ fn empty_keep_warm() -> HashSet<String> {
 }
 
 #[test]
-fn eviction_disabled_preserves_v0_12_4_contract() {
+fn eviction_disabled_preserves_lazy_loading_contract() {
     // idle_threshold = MAX means no entry is ever idle long enough.
     let dir = TempDir::new().unwrap();
     write_spec(dir.path(), "git.json", &minimal_spec("git"));
@@ -464,11 +464,12 @@ fn backstop_respects_keep_warm_under_pressure() {
 #[test]
 fn backstop_warns_when_keep_warm_pin_exceeds_cap() {
     // When every Loaded entry is in keep_warm and total > cap, backstop
-    // cannot reach the target. The implementation logs a warn once per
-    // sweep. This test pins the behaviour without asserting on the log
-    // (log-capture machinery lives in lazy_loading.rs); it asserts that
-    // the entries remain Loaded and the report's evicted_backstop_count
-    // is zero.
+    // cannot reach the target. The implementation logs a warn once for
+    // the lifetime of the SpecStore (backstop_cap_warned is one-shot,
+    // not per-tick). This test pins the behaviour without asserting on
+    // the log (log-capture machinery lives in lazy_loading.rs); it
+    // asserts that the entries remain Loaded and the report's
+    // evicted_backstop_count is zero.
     let dir = TempDir::new().unwrap();
     write_n_specs(dir.path(), 3);
     let store = SpecStore::load_from_dir(dir.path()).unwrap().store;

--- a/crates/gc-suggest/tests/golden_specs.rs
+++ b/crates/gc-suggest/tests/golden_specs.rs
@@ -304,7 +304,7 @@ fn load_aws_spec() -> gc_suggest::specs::CompletionSpec {
         .unwrap()
         .store
         .get("aws")
-        .cloned()
+        .map(|spec| spec.as_ref().clone())
         .expect("aws spec must be present in specs/ — restored in ux-8")
 }
 

--- a/crates/gc-suggest/tests/lazy_loading.rs
+++ b/crates/gc-suggest/tests/lazy_loading.rs
@@ -153,9 +153,9 @@ fn lazy_load_failure_is_sticky() {
     let first_error = broken.load_error().unwrap().to_string();
     write_spec(dir.path(), "broken.json", &minimal_spec("broken"));
 
-    // Second lookup must not retry — the OnceLock pinned the failure.
+    // Second lookup must not retry — the parse slot pinned the failure.
     assert!(store.get("broken").is_none());
-    assert_eq!(broken.load_error(), Some(first_error.as_str()));
+    assert_eq!(broken.load_error(), Some(first_error));
 
     // Healthy spec still works alongside the broken one.
     assert!(store.get("ok").is_some());

--- a/crates/ghost-complete/src/doctor.rs
+++ b/crates/ghost-complete/src/doctor.rs
@@ -539,7 +539,7 @@ fn check_js_runtime(config: &gc_config::GhostConfig) -> CheckResult {
 }
 
 /// Warn when any `keep_warm` entry does not match a registered spec alias.
-/// Skipped when eviction is disabled because the field is then unused.
+/// Returns OK with an explanatory message when eviction is disabled.
 fn check_keep_warm_unmatched(
     store: &gc_suggest::SpecStore,
     cfg: &gc_config::SpecCacheConfig,

--- a/crates/ghost-complete/src/doctor.rs
+++ b/crates/ghost-complete/src/doctor.rs
@@ -371,7 +371,7 @@ fn check_corrections_for_store(store: &gc_suggest::SpecStore) -> CheckResult {
     let mut affected_specs: Vec<(&str, usize)> = store
         .iter()
         .filter_map(|(name, spec)| {
-            let n = count_corrected_generators_in_spec(spec);
+            let n = count_corrected_generators_in_spec(spec.as_ref());
             if n == 0 {
                 None
             } else {
@@ -659,7 +659,7 @@ fn check_embedded_runtime_metadata_for_store(store: &gc_suggest::SpecStore) -> C
     let mut affected: Vec<(&str, usize)> = store
         .iter()
         .filter_map(|(name, spec)| {
-            let n = count_missing_js_runtime_in_spec(spec);
+            let n = count_missing_js_runtime_in_spec(spec.as_ref());
             if n == 0 {
                 None
             } else {
@@ -670,7 +670,7 @@ fn check_embedded_runtime_metadata_for_store(store: &gc_suggest::SpecStore) -> C
     let mut unproven: Vec<(&str, usize)> = store
         .iter()
         .filter_map(|(name, spec)| {
-            let n = count_unproven_js_runtime_in_spec(spec);
+            let n = count_unproven_js_runtime_in_spec(spec.as_ref());
             if n == 0 {
                 None
             } else {

--- a/crates/ghost-complete/src/doctor.rs
+++ b/crates/ghost-complete/src/doctor.rs
@@ -1108,6 +1108,25 @@ mod tests {
     }
 
     #[test]
+    fn doctor_keep_warm_unmatched_ok_when_all_match() {
+        let store = gc_suggest::SpecStore::load_with_embedded(&[])
+            .unwrap()
+            .store;
+        let cfg = gc_config::SpecCacheConfig {
+            idle_ttl_secs: 300,
+            keep_warm: vec!["git".to_string()],
+            ..Default::default()
+        };
+
+        let result = check_keep_warm_unmatched(&store, &cfg);
+
+        assert!(matches!(result.severity, Severity::Ok));
+        assert!(result
+            .message
+            .contains("all entries match registered aliases"));
+    }
+
+    #[test]
     fn doctor_warns_at_90pct_resident_cap() {
         let dir = tempfile::TempDir::new().unwrap();
         let large_suggestion = "x".repeat(1_000_000);

--- a/crates/ghost-complete/src/doctor.rs
+++ b/crates/ghost-complete/src/doctor.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use gc_suggest::specs::{
@@ -537,6 +538,143 @@ fn check_js_runtime(config: &gc_config::GhostConfig) -> CheckResult {
     }
 }
 
+/// Warn when any `keep_warm` entry does not match a registered spec alias.
+/// Skipped when eviction is disabled because the field is then unused.
+fn check_keep_warm_unmatched(
+    store: &gc_suggest::SpecStore,
+    cfg: &gc_config::SpecCacheConfig,
+) -> CheckResult {
+    if !cfg.enabled() {
+        return CheckResult::ok("spec_cache.keep_warm: eviction disabled");
+    }
+
+    let registered: HashSet<&str> = store
+        .entries()
+        .iter()
+        .flat_map(|e| e.aliases.iter().map(String::as_str))
+        .collect();
+    let unmatched: Vec<&str> = cfg
+        .keep_warm
+        .iter()
+        .filter(|name| !registered.contains(name.as_str()))
+        .map(String::as_str)
+        .collect();
+
+    if unmatched.is_empty() {
+        return CheckResult::ok("spec_cache.keep_warm: all entries match registered aliases");
+    }
+
+    let suggestions = unmatched
+        .iter()
+        .map(|name| {
+            nearest_alias(name, &registered)
+                .map(|near| format!("'{name}' -> did you mean '{near}'?"))
+                .unwrap_or_else(|| format!("'{name}' (no near match)"))
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    CheckResult::warn(format!(
+        "spec_cache.keep_warm has {} unmatched alias(es): {suggestions}",
+        unmatched.len()
+    ))
+}
+
+fn nearest_alias(target: &str, registered: &HashSet<&str>) -> Option<String> {
+    registered
+        .iter()
+        .map(|alias| (*alias, levenshtein(target, alias)))
+        .filter(|(_, distance)| *distance <= 2)
+        .min_by(
+            |(left_alias, left_distance), (right_alias, right_distance)| {
+                left_distance
+                    .cmp(right_distance)
+                    .then_with(|| left_alias.cmp(right_alias))
+            },
+        )
+        .map(|(alias, _)| alias.to_string())
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let m = a.len();
+    let n = b.len();
+
+    if m == 0 {
+        return n;
+    }
+    if n == 0 {
+        return m;
+    }
+
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut curr = vec![0usize; n + 1];
+    for i in 1..=m {
+        curr[0] = i;
+        for j in 1..=n {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[n]
+}
+
+/// Warn when estimated resident heap exceeds 90% of `max_resident_mb`.
+fn check_resident_near_cap(
+    store: &gc_suggest::SpecStore,
+    cfg: &gc_config::SpecCacheConfig,
+) -> CheckResult {
+    if !cfg.enabled() {
+        return CheckResult::ok("spec_cache resident cap: eviction disabled");
+    }
+    let Some(cap) = cfg.max_resident_bytes() else {
+        return CheckResult::ok("spec_cache resident cap: no cap configured");
+    };
+    let resident = store.estimated_resident_bytes();
+    let threshold = cap.saturating_mul(9) / 10;
+    if resident > threshold {
+        CheckResult::warn(format!(
+            "spec_cache resident ~{} MB is >90% of cap ({} MB); consider raising \
+             max_resident_mb or shortening idle_ttl_secs",
+            resident / (1024 * 1024),
+            cfg.max_resident_mb,
+        ))
+    } else {
+        CheckResult::ok("spec_cache resident cap: below warning threshold")
+    }
+}
+
+fn check_spec_cache_for_store(
+    store: &gc_suggest::SpecStore,
+    cfg: &gc_config::SpecCacheConfig,
+) -> Vec<CheckResult> {
+    let mut results = vec![check_keep_warm_unmatched(store, cfg)];
+    if cfg.enabled() && cfg.max_resident_bytes().is_some() {
+        // Doctor is an explicit inspection command. Force-load resolved specs
+        // so resident-cap pressure reflects the parsed heap a warm runtime
+        // would actually hold.
+        let _ = store.iter().count();
+    }
+    results.push(check_resident_near_cap(store, cfg));
+    results
+}
+
+fn check_spec_cache(config: &gc_config::GhostConfig) -> Vec<CheckResult> {
+    match load_specs_for_config(config) {
+        Ok(result) => check_spec_cache_for_store(&result.store, &config.suggest.spec_cache),
+        Err(_) => vec![
+            CheckResult::skip(
+                "spec_cache.keep_warm — spec load failed (see Completion specs check)",
+            ),
+            CheckResult::skip(
+                "spec_cache.resident_cap — spec load failed (see Completion specs check)",
+            ),
+        ],
+    }
+}
+
 #[derive(Debug, Default)]
 struct RuntimeMetadataCounts {
     malformed: usize,
@@ -839,6 +977,7 @@ pub fn run_doctor(config_path: Option<&str>) -> Result<()> {
             results.push(check_alias_conflicts(cfg));
             results.push(check_js_runtime(cfg));
             results.push(check_embedded_runtime_metadata(cfg));
+            results.extend(check_spec_cache(cfg));
         }
         None => {
             results.push(CheckResult::skip(
@@ -847,6 +986,10 @@ pub fn run_doctor(config_path: Option<&str>) -> Result<()> {
             results.push(CheckResult::skip("JS runtime — config invalid"));
             results.push(CheckResult::skip(
                 "Embedded specs — config invalid, cannot resolve spec dirs",
+            ));
+            results.push(CheckResult::skip("spec_cache.keep_warm — config invalid"));
+            results.push(CheckResult::skip(
+                "spec_cache.resident_cap — config invalid",
             ));
         }
     }
@@ -927,6 +1070,110 @@ mod tests {
         let result = check_terminal_profile(&profile, true);
         assert!(matches!(result.severity, Severity::Ok));
         assert!(result.message.contains("multi_terminal"));
+    }
+
+    #[test]
+    fn doctor_warns_when_keep_warm_entry_unmatched() {
+        let store = gc_suggest::SpecStore::load_with_embedded(&[])
+            .unwrap()
+            .store;
+        let cfg = gc_config::SpecCacheConfig {
+            idle_ttl_secs: 300,
+            keep_warm: vec!["giit".to_string()],
+            ..Default::default()
+        };
+
+        let result = check_keep_warm_unmatched(&store, &cfg);
+
+        assert!(matches!(result.severity, Severity::Warn));
+        assert!(result.message.contains("spec_cache.keep_warm"));
+        assert!(result.message.contains("giit"));
+        assert!(result.message.contains("did you mean 'git'"));
+    }
+
+    #[test]
+    fn doctor_keep_warm_unmatched_skips_disabled_eviction() {
+        let store = gc_suggest::SpecStore::load_with_embedded(&[])
+            .unwrap()
+            .store;
+        let cfg = gc_config::SpecCacheConfig {
+            idle_ttl_secs: 0,
+            keep_warm: vec!["nonexistent-spec".to_string()],
+            ..Default::default()
+        };
+
+        let result = check_keep_warm_unmatched(&store, &cfg);
+
+        assert!(matches!(result.severity, Severity::Ok));
+    }
+
+    #[test]
+    fn doctor_warns_at_90pct_resident_cap() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let large_suggestion = "x".repeat(1_000_000);
+        let body = format!(
+            r#"{{
+                "name": "big",
+                "args": [{{
+                    "name": "target",
+                    "suggestions": ["{large_suggestion}"]
+                }}]
+            }}"#
+        );
+        std::fs::write(dir.path().join("big.json"), body).unwrap();
+        let store = gc_suggest::SpecStore::load_from_dir(dir.path())
+            .unwrap()
+            .store;
+        let _ = store.get("big");
+        let cfg = gc_config::SpecCacheConfig {
+            idle_ttl_secs: 300,
+            max_resident_mb: 1,
+            ..Default::default()
+        };
+
+        let result = check_resident_near_cap(&store, &cfg);
+
+        assert!(matches!(result.severity, Severity::Warn));
+        assert!(result.message.contains("spec_cache resident"));
+        assert!(result.message.contains(">90% of cap"));
+    }
+
+    #[test]
+    fn doctor_spec_cache_check_force_loads_for_resident_cap() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let large_suggestion = "x".repeat(1_000_000);
+        let body = format!(
+            r#"{{
+                "name": "big",
+                "args": [{{
+                    "name": "target",
+                    "suggestions": ["{large_suggestion}"]
+                }}]
+            }}"#
+        );
+        std::fs::write(dir.path().join("big.json"), body).unwrap();
+        let store = gc_suggest::SpecStore::load_from_dir(dir.path())
+            .unwrap()
+            .store;
+        assert_eq!(
+            store.parsed_count(),
+            0,
+            "fixture should start lazy so this test covers doctor's force-load path"
+        );
+        let cfg = gc_config::SpecCacheConfig {
+            idle_ttl_secs: 300,
+            max_resident_mb: 1,
+            ..Default::default()
+        };
+
+        let results = check_spec_cache_for_store(&store, &cfg);
+
+        assert!(
+            matches!(results[1].severity, Severity::Warn),
+            "resident cap check should warn after doctor force-loads parsed specs: {}",
+            results[1].message
+        );
+        assert_eq!(store.parsed_count(), 1);
     }
 
     /// Pin the user-facing spec health check to the embedded fallback path.

--- a/crates/ghost-complete/src/doctor.rs
+++ b/crates/ghost-complete/src/doctor.rs
@@ -1138,6 +1138,67 @@ mod tests {
         assert!(result.message.contains(">90% of cap"));
     }
 
+    /// OK branch: eviction is enabled and a cap is configured, but the
+    /// resident heap sits well below 90% of it. Pins the comparison so a
+    /// regression that flips `>` to `>=` or drops the threshold math would
+    /// fail loudly.
+    #[test]
+    fn doctor_resident_cap_ok_when_below_threshold() {
+        let store = gc_suggest::SpecStore::load_with_embedded(&[])
+            .unwrap()
+            .store;
+        // Force-load every entry so resident_bytes reflects the full
+        // parsed corpus (the same heap an uncapped daemon would hold).
+        let _ = store.iter().count();
+        let cfg = gc_config::SpecCacheConfig {
+            idle_ttl_secs: 300,
+            max_resident_mb: 1024,
+            ..Default::default()
+        };
+
+        let result = check_resident_near_cap(&store, &cfg);
+
+        assert!(
+            matches!(result.severity, Severity::Ok),
+            "resident heap below 90% of cap must be OK: {}",
+            result.message
+        );
+        assert!(
+            result.message.contains("below warning threshold"),
+            "OK message should name the threshold check: {}",
+            result.message
+        );
+    }
+
+    /// OK branch: eviction is enabled but no resident cap is configured
+    /// (`max_resident_mb = 0`). The check must short-circuit with an OK
+    /// result naming the missing cap, never compute a threshold against
+    /// an unset value.
+    #[test]
+    fn doctor_resident_cap_ok_when_no_cap_with_eviction_enabled() {
+        let store = gc_suggest::SpecStore::load_with_embedded(&[])
+            .unwrap()
+            .store;
+        let cfg = gc_config::SpecCacheConfig {
+            idle_ttl_secs: 300,
+            max_resident_mb: 0,
+            ..Default::default()
+        };
+
+        let result = check_resident_near_cap(&store, &cfg);
+
+        assert!(
+            matches!(result.severity, Severity::Ok),
+            "no-cap config must produce an OK result: {}",
+            result.message
+        );
+        assert!(
+            result.message.contains("no cap configured"),
+            "OK message should explain the unset cap: {}",
+            result.message
+        );
+    }
+
     #[test]
     fn doctor_spec_cache_check_force_loads_for_resident_cap() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/crates/ghost-complete/src/status.rs
+++ b/crates/ghost-complete/src/status.rs
@@ -1015,20 +1015,17 @@ fn run_status_inner_with_trend(
 ///       `command_alias_conflict_details` entries also include a
 ///       `disposition` field so consumers can distinguish rejected aliases
 ///       from fallback candidates.
-/// 1.4 — added a top-level `specs` block with resident spec-cache counters
-///       and policy/sweep visibility: `parsed_resident`,
-///       `estimated_resident_bytes`, `spec_cache`, and `last_sweep`.
-/// 1.5 — removes `parsed_resident`, `estimated_resident_bytes`, and
-///       `last_sweep` from the `specs` block. Those fields described the
-///       transient SpecStore that `ghost-complete status` builds in its own
-///       process, not the running proxy daemon — so they always reported
-///       the post-`force_load_all` corpus and `last_sweep: null`,
-///       misleading users into thinking eviction was broken even when the
-///       daemon had correctly evicted entries. The remaining `specs` fields
-///       (`registered`, `addressable_aliases`, `spec_cache`) are
-///       purely structural / policy-level and do not depend on daemon
-///       runtime state. This is a breaking removal — JSON consumers that
-///       relied on those keys must be updated.
+/// 1.5 — adds a top-level `specs` block with corpus-structural and
+///       policy-level fields: `registered`, `addressable_aliases`, and a
+///       `spec_cache` sub-block describing the user-declared eviction
+///       policy (`enabled`, `idle_ttl_secs`, `sweep_interval_secs`,
+///       `keep_warm`, `max_resident_mb`). Live runtime state (parse
+///       residency, byte estimates, last-sweep stats) is intentionally
+///       omitted: `ghost-complete status` runs in a one-shot process that
+///       builds its own transient `SpecStore`, so any per-process
+///       counters would describe the wrong store and mislead users into
+///       thinking eviction was broken even when the running proxy daemon
+///       had correctly evicted entries.
 const STATUS_SCHEMA_VERSION: &str = "1.5";
 
 /// The shape emitted by `ghost-complete status --json`. Defining this as a
@@ -1148,10 +1145,11 @@ struct SupportedByKind {
 /// spec-cache policy. None of them claim to reflect the running proxy
 /// daemon's live parse state: this struct is built inside the one-shot
 /// `ghost-complete status` process, which loads its own transient
-/// `SpecStore`. Schema 1.4 surfaced `parsed_resident`,
-/// `estimated_resident_bytes`, and `last_sweep` here too, but those values
-/// described the status process's own freshly-loaded store rather than the
-/// daemon's working set, so they were dropped in 1.5.
+/// `SpecStore`. Resident-state fields (parse residency, byte estimates,
+/// last-sweep stats) are intentionally absent — they would describe this
+/// short-lived process's own freshly-loaded store rather than the
+/// daemon's working set, and would mislead users about eviction
+/// behaviour.
 #[derive(Debug, Serialize)]
 struct SpecsStatus {
     registered: usize,

--- a/crates/ghost-complete/src/status.rs
+++ b/crates/ghost-complete/src/status.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use gc_suggest::spec_dirs::{partition_spec_dirs, resolve_spec_dirs};
@@ -484,9 +485,9 @@ fn scan_resolved_specs(
     }
 
     // resolved_entries() force-loads every registered candidate, so any
-    // per-entry lazy-parse failures are pinned in OnceLock by the time we
-    // call force_load_errors below.
-    let mut specs: Vec<(&str, &CompletionSpec, bool)> = Vec::new();
+    // per-entry lazy-parse failures are pinned in the parse slot by the time
+    // we call force_load_errors below.
+    let mut specs: Vec<(&str, Arc<CompletionSpec>, bool)> = Vec::new();
     for entry in store.resolved_entries() {
         let is_filesystem = matches!(&entry.source, SpecSource::Filesystem(_));
         if let Some(spec) = entry.spec() {
@@ -521,7 +522,7 @@ fn scan_resolved_specs(
         if is_filesystem {
             fs_specs += 1;
         }
-        let js_count = count_requires_js_generators(spec);
+        let js_count = count_requires_js_generators(spec.as_ref());
         if js_count > 0 {
             partially_functional += 1;
             js_commands.push(name.to_string());

--- a/crates/ghost-complete/src/status.rs
+++ b/crates/ghost-complete/src/status.rs
@@ -1038,8 +1038,9 @@ const STATUS_SCHEMA_VERSION: &str = "1.5";
 #[derive(Debug, Serialize)]
 struct StatusReport {
     schema_version: &'static str,
-    /// Runtime spec-store status. This complements the historical
-    /// `spec_counts` coverage block without changing that older schema.
+    /// Corpus-structural and policy-level spec-store status. This
+    /// complements the historical `spec_counts` coverage block without
+    /// changing that older schema.
     specs: SpecsStatus,
     spec_counts: SpecCounts,
     /// Raw-JSON scan over resolved runtime sources. Counts generator
@@ -1138,7 +1139,8 @@ struct SupportedByKind {
     custom: usize,
 }
 
-/// Runtime spec-store status surfaced under `status --json`'s `specs` key.
+/// Corpus-structural and policy-level spec-store status surfaced under
+/// `status --json`'s `specs` key.
 ///
 /// All fields here are corpus-structural or policy-level — the count of
 /// registered entries, the alias index size, and the user-declared

--- a/crates/ghost-complete/src/status.rs
+++ b/crates/ghost-complete/src/status.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use gc_suggest::spec_dirs::{partition_spec_dirs, resolve_spec_dirs};
@@ -340,10 +341,22 @@ pub struct StatusOutcome {
     /// Surfaced so users can see at a glance whether their requires_js
     /// generators will run.
     pub js_runtime_enabled: bool,
+    /// Registered runtime entries, including lower-precedence fallback
+    /// candidates that remain available for lazy parse failover.
+    pub registered_specs: usize,
     /// File-level scan results — sourced from the JSON behind each resolved
     /// runtime `SpecEntry` so the raw generator counters follow completion
     /// lookup fallback behavior.
     pub file_scan: FileScan,
+    /// Count of currently resident parsed specs. Evicted specs and sticky
+    /// parse failures are excluded.
+    pub parsed_resident: usize,
+    /// Estimated heap held by resident parsed specs, in bytes.
+    pub estimated_resident_bytes: u64,
+    /// Effective spec-cache policy from the active config.
+    pub spec_cache: gc_config::SpecCacheConfig,
+    /// Most recent eviction sweep, when the runtime has run one.
+    pub last_sweep: Option<gc_suggest::SweepReport>,
 }
 
 /// Serialised view of a single [`AliasConflict`]. Distinct from the
@@ -572,6 +585,11 @@ fn scan_resolved_specs(
 
     let js_runtime_enabled = config.suggest.providers.js_runtime;
 
+    let registered_specs = store.len();
+    let parsed_resident = store.parsed_count();
+    let estimated_resident_bytes = store.estimated_resident_bytes();
+    let last_sweep = store.last_sweep();
+
     Ok(StatusOutcome {
         fs_specs,
         embedded_count,
@@ -589,7 +607,12 @@ fn scan_resolved_specs(
         command_alias_conflicts,
         command_alias_conflict_details,
         js_runtime_enabled,
+        registered_specs,
         file_scan,
+        parsed_resident,
+        estimated_resident_bytes,
+        spec_cache: config.suggest.spec_cache.clone(),
+        last_sweep,
     })
 }
 
@@ -1005,7 +1028,10 @@ fn run_status_inner_with_trend(
 ///       `command_alias_conflict_details` entries also include a
 ///       `disposition` field so consumers can distinguish rejected aliases
 ///       from fallback candidates.
-const STATUS_SCHEMA_VERSION: &str = "1.3";
+/// 1.4 — adds a top-level `specs` block with resident spec-cache counters
+///       and policy/sweep visibility: `parsed_resident`,
+///       `estimated_resident_bytes`, `spec_cache`, and `last_sweep`.
+const STATUS_SCHEMA_VERSION: &str = "1.4";
 
 /// The shape emitted by `ghost-complete status --json`. Defining this as a
 /// `#[derive(Serialize)]` struct rather than inline `json!` macros fails
@@ -1017,6 +1043,9 @@ const STATUS_SCHEMA_VERSION: &str = "1.3";
 #[derive(Debug, Serialize)]
 struct StatusReport {
     schema_version: &'static str,
+    /// Runtime spec-store status. This complements the historical
+    /// `spec_counts` coverage block without changing that older schema.
+    specs: SpecsStatus,
     spec_counts: SpecCounts,
     /// Raw-JSON scan over resolved runtime sources. Counts generator
     /// occurrences while following lazy fallback and avoiding hidden
@@ -1114,6 +1143,110 @@ struct SupportedByKind {
     custom: usize,
 }
 
+/// Runtime spec-store status surfaced under `status --json`'s `specs` key.
+#[derive(Debug, Serialize)]
+struct SpecsStatus {
+    registered: usize,
+    addressable_aliases: usize,
+    parsed_resident: usize,
+    estimated_resident_bytes: u64,
+    spec_cache: SpecCacheStatus,
+    last_sweep: Option<LastSweepJson>,
+}
+
+impl SpecsStatus {
+    fn from_outcome(outcome: &StatusOutcome) -> Self {
+        Self {
+            registered: outcome.registered_specs,
+            addressable_aliases: outcome.commands_addressable,
+            parsed_resident: outcome.parsed_resident,
+            estimated_resident_bytes: outcome.estimated_resident_bytes,
+            spec_cache: SpecCacheStatus::from_config(&outcome.spec_cache),
+            last_sweep: outcome.last_sweep.clone().map(LastSweepJson::from_report),
+        }
+    }
+}
+
+/// JSON block for the active spec-cache eviction policy.
+#[derive(Debug, Serialize)]
+struct SpecCacheStatus {
+    enabled: bool,
+    idle_ttl_secs: u64,
+    sweep_interval_secs: u64,
+    keep_warm: Vec<String>,
+    max_resident_mb: u64,
+}
+
+impl SpecCacheStatus {
+    fn from_config(cfg: &gc_config::SpecCacheConfig) -> Self {
+        Self {
+            enabled: cfg.enabled(),
+            idle_ttl_secs: cfg.idle_ttl_secs,
+            sweep_interval_secs: cfg.sweep_interval_secs,
+            keep_warm: cfg.keep_warm.clone(),
+            max_resident_mb: cfg.max_resident_mb,
+        }
+    }
+}
+
+/// JSON block for the most recent spec-cache sweep.
+#[derive(Debug, Serialize)]
+struct LastSweepJson {
+    timestamp: String,
+    evicted_idle: usize,
+    evicted_backstop: usize,
+    kept_warm: usize,
+    parsed_after: usize,
+    estimated_resident_bytes_after: u64,
+}
+
+impl LastSweepJson {
+    fn from_report(report: gc_suggest::SweepReport) -> Self {
+        Self {
+            timestamp: format_system_time_rfc3339_utc(report.timestamp),
+            evicted_idle: report.evicted_idle_count,
+            evicted_backstop: report.evicted_backstop_count,
+            kept_warm: report.kept_warm_count,
+            parsed_after: report.parsed_count_after,
+            estimated_resident_bytes_after: report.estimated_resident_bytes_after,
+        }
+    }
+}
+
+/// Format a [`SystemTime`] as RFC3339 UTC (`YYYY-MM-DDTHH:MM:SSZ`).
+/// Zero-dep and second-precision, matching the build metadata formatter.
+fn format_system_time_rfc3339_utc(ts: SystemTime) -> String {
+    let secs = ts
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (y, mo, d, h, mi, s) = civil_from_unix_seconds(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+// Howard Hinnant's days_from_civil inverse; integer-only.
+fn civil_from_unix_seconds(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
+    let days = (secs / 86_400) as i64;
+    let sod = (secs % 86_400) as u32;
+    let h = sod / 3600;
+    let mi = (sod % 3600) / 60;
+    let s = sod % 60;
+
+    // Shift epoch from 1970-01-01 to 0000-03-01.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let mo = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    let y = (y + if mo <= 2 { 1 } else { 0 }) as i32;
+
+    (y, mo, d, h, mi, s)
+}
+
 #[derive(Debug, Serialize)]
 struct CoverageTrend {
     /// `null` on the bootstrap (single-row) case.
@@ -1187,6 +1320,7 @@ fn run_status_json(
     // text path emits so JSON consumers can surface them too.
     let payload = StatusReport {
         schema_version: STATUS_SCHEMA_VERSION,
+        specs: SpecsStatus::from_outcome(&outcome),
         spec_counts: SpecCounts {
             total: outcome.embedded_count,
             fully_functional: outcome.fully_functional,
@@ -1337,6 +1471,61 @@ mod tests {
         let p = tmp.path().join("coverage-baseline.json");
         std::fs::write(&p, body).unwrap();
         p
+    }
+
+    fn render_specs_status_for_test(
+        store: &gc_suggest::SpecStore,
+        cfg: &gc_config::SpecCacheConfig,
+    ) -> String {
+        let specs = SpecsStatus {
+            registered: store.len(),
+            addressable_aliases: store.aliases_count(),
+            parsed_resident: store.parsed_count(),
+            estimated_resident_bytes: store.estimated_resident_bytes(),
+            spec_cache: SpecCacheStatus::from_config(cfg),
+            last_sweep: store.last_sweep().map(LastSweepJson::from_report),
+        };
+
+        serde_json::to_string_pretty(&specs).unwrap()
+    }
+
+    #[test]
+    fn status_includes_spec_cache_block_with_defaults() {
+        let store = gc_suggest::SpecStore::load_with_embedded(&[])
+            .unwrap()
+            .store;
+        let cfg = gc_config::SpecCacheConfig::default();
+
+        let json = render_specs_status_for_test(&store, &cfg);
+
+        assert!(json.contains("\"spec_cache\""));
+        assert!(json.contains("\"enabled\": false"));
+        assert!(json.contains("\"idle_ttl_secs\": 0"));
+    }
+
+    #[test]
+    fn status_last_sweep_is_null_when_no_sweep_run() {
+        let store = gc_suggest::SpecStore::load_with_embedded(&[])
+            .unwrap()
+            .store;
+        let cfg = gc_config::SpecCacheConfig::default();
+
+        let json = render_specs_status_for_test(&store, &cfg);
+
+        assert!(json.contains("\"last_sweep\": null"));
+    }
+
+    #[test]
+    fn status_reports_parsed_resident_count() {
+        let store = gc_suggest::SpecStore::load_with_embedded(&[])
+            .unwrap()
+            .store;
+        let _ = store.get("git");
+        let cfg = gc_config::SpecCacheConfig::default();
+
+        let json = render_specs_status_for_test(&store, &cfg);
+
+        assert!(json.contains("\"parsed_resident\": 1"));
     }
 
     #[test]
@@ -2049,10 +2238,28 @@ mod tests {
         let txt = String::from_utf8_lossy(&out);
         let parsed: serde_json::Value = serde_json::from_str(&txt).unwrap();
 
-        assert_eq!(parsed["schema_version"], "1.3");
+        assert_eq!(parsed["schema_version"], "1.4");
         assert!(
             parsed["spec_counts"].is_object(),
             "spec_counts must be an object"
+        );
+        assert!(parsed["specs"].is_object(), "specs must be an object");
+        assert!(parsed["specs"]["registered"].is_number());
+        assert!(parsed["specs"]["addressable_aliases"].is_number());
+        assert!(parsed["specs"]["parsed_resident"].is_number());
+        assert!(parsed["specs"]["estimated_resident_bytes"].is_number());
+        assert!(
+            parsed["specs"]["spec_cache"].is_object(),
+            "spec_cache block must be present"
+        );
+        assert!(parsed["specs"]["spec_cache"]["enabled"].is_boolean());
+        assert!(parsed["specs"]["spec_cache"]["idle_ttl_secs"].is_number());
+        assert!(parsed["specs"]["spec_cache"]["sweep_interval_secs"].is_number());
+        assert!(parsed["specs"]["spec_cache"]["keep_warm"].is_array());
+        assert!(parsed["specs"]["spec_cache"]["max_resident_mb"].is_number());
+        assert!(
+            parsed["specs"]["last_sweep"].is_null(),
+            "fresh status scan should not have a sweep report"
         );
         assert!(parsed["spec_counts"]["total"].is_number());
         assert!(parsed["spec_counts"]["fully_functional"].is_number());
@@ -2206,7 +2413,7 @@ mod tests {
 
         // Current schema surfaces every command and generator counter as
         // a numeric value.
-        assert_eq!(parsed["schema_version"], "1.3");
+        assert_eq!(parsed["schema_version"], "1.4");
         let counts = &parsed["spec_counts"];
         assert_eq!(
             counts["commands_addressable"].as_u64().unwrap(),
@@ -2807,7 +3014,7 @@ mod tests {
         let txt = String::from_utf8_lossy(&out);
         let parsed: serde_json::Value = serde_json::from_str(&txt).unwrap();
 
-        assert_eq!(parsed["schema_version"], "1.3");
+        assert_eq!(parsed["schema_version"], "1.4");
         let details = parsed["spec_counts"]["command_alias_conflict_details"]
             .as_array()
             .expect("command_alias_conflict_details must be an array");

--- a/crates/ghost-complete/src/status.rs
+++ b/crates/ghost-complete/src/status.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use gc_suggest::spec_dirs::{partition_spec_dirs, resolve_spec_dirs};
@@ -348,15 +347,9 @@ pub struct StatusOutcome {
     /// runtime `SpecEntry` so the raw generator counters follow completion
     /// lookup fallback behavior.
     pub file_scan: FileScan,
-    /// Count of currently resident parsed specs. Evicted specs and sticky
-    /// parse failures are excluded.
-    pub parsed_resident: usize,
-    /// Estimated heap held by resident parsed specs, in bytes.
-    pub estimated_resident_bytes: u64,
-    /// Effective spec-cache policy from the active config.
+    /// Effective spec-cache policy from the active config. Reflects the
+    /// user's TOML-declared policy, not the running daemon's runtime state.
     pub spec_cache: gc_config::SpecCacheConfig,
-    /// Most recent eviction sweep, when the runtime has run one.
-    pub last_sweep: Option<gc_suggest::SweepReport>,
 }
 
 /// Serialised view of a single [`AliasConflict`]. Distinct from the
@@ -586,9 +579,6 @@ fn scan_resolved_specs(
     let js_runtime_enabled = config.suggest.providers.js_runtime;
 
     let registered_specs = store.len();
-    let parsed_resident = store.parsed_count();
-    let estimated_resident_bytes = store.estimated_resident_bytes();
-    let last_sweep = store.last_sweep();
 
     Ok(StatusOutcome {
         fs_specs,
@@ -609,10 +599,7 @@ fn scan_resolved_specs(
         js_runtime_enabled,
         registered_specs,
         file_scan,
-        parsed_resident,
-        estimated_resident_bytes,
         spec_cache: config.suggest.spec_cache.clone(),
-        last_sweep,
     })
 }
 
@@ -1028,10 +1015,21 @@ fn run_status_inner_with_trend(
 ///       `command_alias_conflict_details` entries also include a
 ///       `disposition` field so consumers can distinguish rejected aliases
 ///       from fallback candidates.
-/// 1.4 — adds a top-level `specs` block with resident spec-cache counters
+/// 1.4 — added a top-level `specs` block with resident spec-cache counters
 ///       and policy/sweep visibility: `parsed_resident`,
 ///       `estimated_resident_bytes`, `spec_cache`, and `last_sweep`.
-const STATUS_SCHEMA_VERSION: &str = "1.4";
+/// 1.5 — removes `parsed_resident`, `estimated_resident_bytes`, and
+///       `last_sweep` from the `specs` block. Those fields described the
+///       transient SpecStore that `ghost-complete status` builds in its own
+///       process, not the running proxy daemon — so they always reported
+///       the post-`force_load_all` corpus and `last_sweep: null`,
+///       misleading users into thinking eviction was broken even when the
+///       daemon had correctly evicted entries. The remaining `specs` fields
+///       (`registered`, `addressable_aliases`, `spec_cache`) are
+///       purely structural / policy-level and do not depend on daemon
+///       runtime state. This is a breaking removal — JSON consumers that
+///       relied on those keys must be updated.
+const STATUS_SCHEMA_VERSION: &str = "1.5";
 
 /// The shape emitted by `ghost-complete status --json`. Defining this as a
 /// `#[derive(Serialize)]` struct rather than inline `json!` macros fails
@@ -1144,14 +1142,21 @@ struct SupportedByKind {
 }
 
 /// Runtime spec-store status surfaced under `status --json`'s `specs` key.
+///
+/// All fields here are corpus-structural or policy-level — the count of
+/// registered entries, the alias index size, and the user-declared
+/// spec-cache policy. None of them claim to reflect the running proxy
+/// daemon's live parse state: this struct is built inside the one-shot
+/// `ghost-complete status` process, which loads its own transient
+/// `SpecStore`. Schema 1.4 surfaced `parsed_resident`,
+/// `estimated_resident_bytes`, and `last_sweep` here too, but those values
+/// described the status process's own freshly-loaded store rather than the
+/// daemon's working set, so they were dropped in 1.5.
 #[derive(Debug, Serialize)]
 struct SpecsStatus {
     registered: usize,
     addressable_aliases: usize,
-    parsed_resident: usize,
-    estimated_resident_bytes: u64,
     spec_cache: SpecCacheStatus,
-    last_sweep: Option<LastSweepJson>,
 }
 
 impl SpecsStatus {
@@ -1159,10 +1164,7 @@ impl SpecsStatus {
         Self {
             registered: outcome.registered_specs,
             addressable_aliases: outcome.commands_addressable,
-            parsed_resident: outcome.parsed_resident,
-            estimated_resident_bytes: outcome.estimated_resident_bytes,
             spec_cache: SpecCacheStatus::from_config(&outcome.spec_cache),
-            last_sweep: outcome.last_sweep.clone().map(LastSweepJson::from_report),
         }
     }
 }
@@ -1187,64 +1189,6 @@ impl SpecCacheStatus {
             max_resident_mb: cfg.max_resident_mb,
         }
     }
-}
-
-/// JSON block for the most recent spec-cache sweep.
-#[derive(Debug, Serialize)]
-struct LastSweepJson {
-    timestamp: String,
-    evicted_idle: usize,
-    evicted_backstop: usize,
-    kept_warm: usize,
-    parsed_after: usize,
-    estimated_resident_bytes_after: u64,
-}
-
-impl LastSweepJson {
-    fn from_report(report: gc_suggest::SweepReport) -> Self {
-        Self {
-            timestamp: format_system_time_rfc3339_utc(report.timestamp),
-            evicted_idle: report.evicted_idle_count,
-            evicted_backstop: report.evicted_backstop_count,
-            kept_warm: report.kept_warm_count,
-            parsed_after: report.parsed_count_after,
-            estimated_resident_bytes_after: report.estimated_resident_bytes_after,
-        }
-    }
-}
-
-/// Format a [`SystemTime`] as RFC3339 UTC (`YYYY-MM-DDTHH:MM:SSZ`).
-/// Zero-dep and second-precision, matching the build metadata formatter.
-fn format_system_time_rfc3339_utc(ts: SystemTime) -> String {
-    let secs = ts
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let (y, mo, d, h, mi, s) = civil_from_unix_seconds(secs);
-    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
-}
-
-// Howard Hinnant's days_from_civil inverse; integer-only.
-fn civil_from_unix_seconds(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
-    let days = (secs / 86_400) as i64;
-    let sod = (secs % 86_400) as u32;
-    let h = sod / 3600;
-    let mi = (sod % 3600) / 60;
-    let s = sod % 60;
-
-    // Shift epoch from 1970-01-01 to 0000-03-01.
-    let z = days + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = (z - era * 146_097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
-    let mo = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
-    let y = (y + if mo <= 2 { 1 } else { 0 }) as i32;
-
-    (y, mo, d, h, mi, s)
 }
 
 #[derive(Debug, Serialize)]
@@ -1480,10 +1424,7 @@ mod tests {
         let specs = SpecsStatus {
             registered: store.len(),
             addressable_aliases: store.aliases_count(),
-            parsed_resident: store.parsed_count(),
-            estimated_resident_bytes: store.estimated_resident_bytes(),
             spec_cache: SpecCacheStatus::from_config(cfg),
-            last_sweep: store.last_sweep().map(LastSweepJson::from_report),
         };
 
         serde_json::to_string_pretty(&specs).unwrap()
@@ -1503,29 +1444,41 @@ mod tests {
         assert!(json.contains("\"idle_ttl_secs\": 0"));
     }
 
+    /// `SpecCacheStatus::from_config` must surface every policy field as a
+    /// number / array / boolean when eviction is opted in. Pins the
+    /// `enabled = true` branch and the non-default values for
+    /// `idle_ttl_secs`, `sweep_interval_secs`, `keep_warm`, and
+    /// `max_resident_mb` so a regression that flips `enabled` for a
+    /// non-zero TTL or drops a policy field from the JSON would fail loudly.
     #[test]
-    fn status_last_sweep_is_null_when_no_sweep_run() {
+    fn status_spec_cache_block_when_eviction_enabled() {
         let store = gc_suggest::SpecStore::load_with_embedded(&[])
             .unwrap()
             .store;
-        let cfg = gc_config::SpecCacheConfig::default();
+        let cfg = gc_config::SpecCacheConfig {
+            idle_ttl_secs: 300,
+            sweep_interval_secs: 60,
+            keep_warm: vec!["git".to_string()],
+            max_resident_mb: 100,
+        };
 
         let json = render_specs_status_for_test(&store, &cfg);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let block = &parsed["spec_cache"];
 
-        assert!(json.contains("\"last_sweep\": null"));
-    }
-
-    #[test]
-    fn status_reports_parsed_resident_count() {
-        let store = gc_suggest::SpecStore::load_with_embedded(&[])
-            .unwrap()
-            .store;
-        let _ = store.get("git");
-        let cfg = gc_config::SpecCacheConfig::default();
-
-        let json = render_specs_status_for_test(&store, &cfg);
-
-        assert!(json.contains("\"parsed_resident\": 1"));
+        assert_eq!(block["enabled"], serde_json::Value::Bool(true));
+        assert_eq!(block["idle_ttl_secs"].as_u64().unwrap(), 300);
+        assert_eq!(block["sweep_interval_secs"].as_u64().unwrap(), 60);
+        assert_eq!(
+            block["keep_warm"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["git"]
+        );
+        assert_eq!(block["max_resident_mb"].as_u64().unwrap(), 100);
     }
 
     #[test]
@@ -2238,7 +2191,7 @@ mod tests {
         let txt = String::from_utf8_lossy(&out);
         let parsed: serde_json::Value = serde_json::from_str(&txt).unwrap();
 
-        assert_eq!(parsed["schema_version"], "1.4");
+        assert_eq!(parsed["schema_version"], "1.5");
         assert!(
             parsed["spec_counts"].is_object(),
             "spec_counts must be an object"
@@ -2246,8 +2199,23 @@ mod tests {
         assert!(parsed["specs"].is_object(), "specs must be an object");
         assert!(parsed["specs"]["registered"].is_number());
         assert!(parsed["specs"]["addressable_aliases"].is_number());
-        assert!(parsed["specs"]["parsed_resident"].is_number());
-        assert!(parsed["specs"]["estimated_resident_bytes"].is_number());
+        // 1.5 dropped `parsed_resident`, `estimated_resident_bytes`, and
+        // `last_sweep` from the `specs` block — those described the
+        // transient SpecStore the status command builds in its own
+        // process, not the running daemon. Guard the removal so a
+        // regression that re-adds them under `specs` would fail here.
+        assert!(
+            parsed["specs"].get("parsed_resident").is_none(),
+            "parsed_resident must not be present in 1.5"
+        );
+        assert!(
+            parsed["specs"].get("estimated_resident_bytes").is_none(),
+            "estimated_resident_bytes must not be present in 1.5"
+        );
+        assert!(
+            parsed["specs"].get("last_sweep").is_none(),
+            "last_sweep must not be present in 1.5"
+        );
         assert!(
             parsed["specs"]["spec_cache"].is_object(),
             "spec_cache block must be present"
@@ -2257,10 +2225,6 @@ mod tests {
         assert!(parsed["specs"]["spec_cache"]["sweep_interval_secs"].is_number());
         assert!(parsed["specs"]["spec_cache"]["keep_warm"].is_array());
         assert!(parsed["specs"]["spec_cache"]["max_resident_mb"].is_number());
-        assert!(
-            parsed["specs"]["last_sweep"].is_null(),
-            "fresh status scan should not have a sweep report"
-        );
         assert!(parsed["spec_counts"]["total"].is_number());
         assert!(parsed["spec_counts"]["fully_functional"].is_number());
         assert!(parsed["spec_counts"]["partially_functional"].is_number());
@@ -2413,7 +2377,7 @@ mod tests {
 
         // Current schema surfaces every command and generator counter as
         // a numeric value.
-        assert_eq!(parsed["schema_version"], "1.4");
+        assert_eq!(parsed["schema_version"], "1.5");
         let counts = &parsed["spec_counts"];
         assert_eq!(
             counts["commands_addressable"].as_u64().unwrap(),
@@ -3014,7 +2978,7 @@ mod tests {
         let txt = String::from_utf8_lossy(&out);
         let parsed: serde_json::Value = serde_json::from_str(&txt).unwrap();
 
-        assert_eq!(parsed["schema_version"], "1.4");
+        assert_eq!(parsed["schema_version"], "1.5");
         let details = parsed["spec_counts"]["command_alias_conflict_details"]
             .as_array()
             .expect("command_alias_conflict_details must be an array");

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -166,9 +166,9 @@ Script generator output passes through a transform pipeline (`split_lines`, `tri
 
 Generator results are cached in-memory with configurable TTL per-generator. `cache_by_directory` keys cache entries by CWD for commands whose output is directory-dependent. JS post-processed output uses a separate keyspace (`CacheKey::JsProcessed { source_hash }`) so two `js_runtime.source` bodies sharing the same script don't cross-contaminate.
 
-### Lazy Spec Loading (v0.12.4+)
+### Lazy Spec Loading
 
-Pre-v0.12.4, every embedded spec was parsed into `Arc<CompletionSpec>` at startup. The AWS spec alone (~36 MB minified, ~17 K subcommands, ~116 K descriptions) ballooned the daemon's physical footprint to ~333 MB on first load — most of which the user never touched. The fix decouples *registration* from *parsing*:
+Earlier revisions parsed every embedded spec into `Arc<CompletionSpec>` at startup. The AWS spec alone (~36 MB minified, ~17 K subcommands, ~116 K descriptions) ballooned the daemon's physical footprint to ~333 MB on first load — most of which the user never touched. The lazy-loading layer decouples *registration* from *parsing*:
 
 ```text
 SpecStore::load_with_embedded(&[]) ──► register every (filename, alias, &'static str)
@@ -195,14 +195,14 @@ Registration-time alias metadata is collected before a `SpecEntry` is stored. Fo
 
 `SpecStore::iter()` force-loads every registered candidate and yields one tuple per resolved runtime spec — used by `ghost-complete status` to avoid double-counting hidden fallbacks while still surfacing load errors via `SpecStore::force_load_errors()`. `validate-specs` uses its separate validator and parses configured spec directories directly. `SpecStore::get()` only loads the requested candidate chain. The embedded corpus is registered with the lowest precedence, so a valid filesystem spec with the same name (e.g. user-edited `~/.config/ghost-complete/specs/git.json`) wins.
 
-The runtime no longer materialises the embedded corpus to `~/.cache/ghost-complete/embedded-specs/`. `ghost-complete install` and `uninstall` purge that legacy path if a pre-v0.12.4 binary left it behind.
+The runtime no longer materialises the embedded corpus to `~/.cache/ghost-complete/embedded-specs/`. `ghost-complete install` and `uninstall` purge that legacy path if an earlier binary left it behind.
 
-### Spec Cache Eviction (v0.12.5+)
+### Spec Cache Eviction
 
-v0.12.4 made spec parsing lazy. Once a spec is parsed (for example, when
-the user types `aws ` once), it stays resident for the rest of the daemon
-lifetime. v0.12.5 adds an opt-in eviction policy that releases the heap of
-specs that have been idle past a configurable TTL.
+The lazy-loading layer above parses each spec on first access and keeps it
+resident for the rest of the daemon lifetime. The opt-in eviction layer
+adds a sweep that releases the heap of specs that have been idle past a
+configurable TTL.
 
 The `SpecEntry::parsed` field is now `RwLock<ParsedSlot>` with four states:
 
@@ -225,9 +225,9 @@ it, so the slot can mutate behind their back without invalidating the
 resolved spec.
 
 The sweep task is opt-in via `[suggest.spec_cache] idle_ttl_secs > 0`. With
-the default (`0`), no sweep is spawned and the engine keeps the v0.12.4
-"parse once, hold forever" behavior. See `docs/CONFIGURATION.md` for the
-full config schema and a suggested starting recipe.
+the default (`0`), no sweep is spawned and the engine keeps the lazy-loading
+layer's "parse once, hold forever" behavior. See `docs/CONFIGURATION.md` for
+the full config schema and a suggested starting recipe.
 
 Re-parse on a cold-cache hit blocks the popup for that one keystroke
 (~150 ms in the AWS worst case, <5 ms for most specs). Shell stdin

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -173,15 +173,14 @@ Pre-v0.12.4, every embedded spec was parsed into `Arc<CompletionSpec>` at startu
 ```text
 SpecStore::load_with_embedded(&[]) ──► register every (filename, alias, &'static str)
                                        as SpecEntry { source: Embedded(json),
-                                                      parsed: OnceLock::new() }
+                                                      parsed: lazy slot }
                                        and add it to the alias index
                                        ─► ~183 µs, ~5 MB heap
 
 store.get("git") ──► first touch: try each registered candidate in
                      precedence order; serde_json::from_str(json) into
-                     Arc<CompletionSpec>, store in OnceLock
-                     ─► subsequent get("git") hits the OnceLock fast path
-                        (~11 ns: HashMap lookup + OnceLock read + borrow)
+                     Arc<CompletionSpec>, store in the parsed slot
+                     ─► subsequent get("git") hits the cached fast path
 ```
 
 Each `SpecEntry` holds:
@@ -189,7 +188,7 @@ Each `SpecEntry` holds:
 | Field | Purpose |
 |-------|---------|
 | `source: SpecSource` | `Filesystem(PathBuf)` for user specs, `Embedded(&'static str)` for the binary corpus. The lazy parse path reads from this without re-touching disk for embedded specs. |
-| `parsed: OnceLock<Result<Arc<CompletionSpec>, String>>` | First-touch parse result. The `Result` makes parse failures **sticky** — a malformed spec doesn't get re-parsed on every lookup. Surfaces via `SpecEntry::load_error()`. |
+| `parsed: RwLock<ParsedSlot>` | First-touch parse result. `Failed(String)` makes parse failures **sticky** — a malformed spec doesn't get re-parsed on every lookup. Surfaces via `SpecEntry::load_error()`. |
 | `aliases: Vec<String>` | Every command name that resolves to this entry: filename stem first, then a non-conflicting `CompletionSpec.name` alias when it differs from the stem. |
 
 Registration-time alias metadata is collected before a `SpecEntry` is stored. For the embedded corpus the build script emits an `EMBEDDED_SPEC_ALIASES` table; for filesystem specs the loader runs a shallow `serde_json::from_str::<SpecHeader>` (just `name`) at load time. That transient `name_alias` is folded into `SpecEntry.aliases`. Duplicate filenames remain registered as lower-precedence fallback candidates, so a malformed higher-precedence filesystem spec can fall through to the next filesystem copy and then to the embedded corpus.
@@ -197,6 +196,42 @@ Registration-time alias metadata is collected before a `SpecEntry` is stored. Fo
 `SpecStore::iter()` force-loads every registered candidate and yields one tuple per resolved runtime spec — used by `ghost-complete status` to avoid double-counting hidden fallbacks while still surfacing load errors via `SpecStore::force_load_errors()`. `validate-specs` uses its separate validator and parses configured spec directories directly. `SpecStore::get()` only loads the requested candidate chain. The embedded corpus is registered with the lowest precedence, so a valid filesystem spec with the same name (e.g. user-edited `~/.config/ghost-complete/specs/git.json`) wins.
 
 The runtime no longer materialises the embedded corpus to `~/.cache/ghost-complete/embedded-specs/`. `ghost-complete install` and `uninstall` purge that legacy path if a pre-v0.12.4 binary left it behind.
+
+### Spec Cache Eviction (v0.12.5+)
+
+v0.12.4 made spec parsing lazy. Once a spec is parsed (for example, when
+the user types `aws ` once), it stays resident for the rest of the daemon
+lifetime. v0.12.5 adds an opt-in eviction policy that releases the heap of
+specs that have been idle past a configurable TTL.
+
+The `SpecEntry::parsed` field is now `RwLock<ParsedSlot>` with four states:
+
+| State | Meaning |
+|-------|---------|
+| `Empty` | Registered, never accessed. Zero parsed heap. |
+| `Loaded(Arc<CompletionSpec>)` | Parsed and resident. Eligible for eviction. |
+| `Evicted` | Was `Loaded`, then a sweep released the cached `Arc`. Re-parses on next access. |
+| `Failed(String)` | Parse failed. Sticky: never evicted, never retried. |
+
+Each entry also carries an `AtomicU64 last_accessed_nanos`. Every
+successful `get()` bumps the timestamp; the sweep task takes write locks on
+entries whose timestamp is older than the TTL and replaces `Loaded(_)` with
+`Evicted`. Dropping the cache's `Arc` releases the heap; any caller still
+holding a clone keeps its copy alive.
+
+`SpecStore::get` returns `Option<Arc<CompletionSpec>>` (changed from
+`Option<&CompletionSpec>`). Callers own an `Arc` for as long as they need
+it, so the slot can mutate behind their back without invalidating the
+resolved spec.
+
+The sweep task is opt-in via `[suggest.spec_cache] idle_ttl_secs > 0`. With
+the default (`0`), no sweep is spawned and the engine keeps the v0.12.4
+"parse once, hold forever" behavior. See `docs/CONFIGURATION.md` for the
+full config schema and a suggested starting recipe.
+
+Re-parse on a cold-cache hit blocks the popup for that one keystroke
+(~150 ms in the AWS worst case, <5 ms for most specs). Shell stdin
+forwarding is unaffected; it runs on a separate `spawn_blocking` thread.
 
 ## Popup Rendering
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -68,8 +68,8 @@ Shell history loads up to 10,000 entries.
 ### `[suggest.spec_cache]`
 
 Cache eviction policy for parsed completion specs. Eviction is opt-in; the
-default (`idle_ttl_secs = 0`) preserves the v0.12.4 "parse once, hold
-forever" contract.
+default (`idle_ttl_secs = 0`) preserves the lazy-loading layer's "parse
+once, hold forever" behavior.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -93,7 +93,7 @@ forwarding is unaffected; only the popup for that one keystroke is delayed.
 
 Enable this when daemon idle resident memory matters: long-running shells,
 modest-RAM machines, or multiple terminals. The default disables eviction
-because v0.12.4 lazy loading already keeps idle daemon memory low until a
+because the lazy-loading layer already keeps idle daemon memory low until a
 heavy spec has been parsed.
 
 Hot reload is not supported. Restart the daemon after changing this

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -65,6 +65,40 @@ generator_timeout_ms = 5000
 
 Shell history loads up to 10,000 entries.
 
+### `[suggest.spec_cache]`
+
+Cache eviction policy for parsed completion specs. Eviction is opt-in; the
+default (`idle_ttl_secs = 0`) preserves the v0.12.4 "parse once, hold
+forever" contract.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `idle_ttl_secs` | integer | `0` | Seconds after last access before a successfully parsed spec is evicted. `0` disables eviction entirely. |
+| `sweep_interval_secs` | integer | `60` | How often the background sweep wakes to scan for idle entries. Ignored when `idle_ttl_secs = 0`. |
+| `keep_warm` | string[] | `[]` | Spec aliases that must never be evicted. Aliases match filename stems and `CompletionSpec.name` values, not shell aliases. |
+| `max_resident_mb` | integer | `0` | LRU backstop: after TTL eviction, if total estimated resident heap exceeds this cap, evict more entries oldest-access-first until under cap. `0` disables the backstop. |
+
+Recommended recipe:
+
+```toml
+[suggest.spec_cache]
+idle_ttl_secs = 300
+keep_warm = ["git", "cd", "ls", "cargo", "npm", "docker"]
+max_resident_mb = 100
+```
+
+Trade-off: enabling eviction means a re-parse cost on the next access of an
+evicted spec (~150 ms in the AWS worst case, <5 ms for most specs). Shell
+forwarding is unaffected; only the popup for that one keystroke is delayed.
+
+Enable this when daemon idle resident memory matters: long-running shells,
+modest-RAM machines, or multiple terminals. The default disables eviction
+because v0.12.4 lazy loading already keeps idle daemon memory low until a
+heavy spec has been parsed.
+
+Hot reload is not supported. Restart the daemon after changing this
+section.
+
 ### `[suggest.providers]`
 
 Enable or disable individual suggestion providers.


### PR DESCRIPTION
## What changed

Adds opt-in TTL/LRU eviction for lazily parsed completion specs behind `[suggest.spec_cache] idle_ttl_secs > 0`.

- Adds `SpecCacheConfig` with TTL, sweep interval, `keep_warm`, and resident cap settings.
- Changes parsed specs to Arc-backed slots with `Empty`, `Loaded`, `Evicted`, and sticky `Failed` states.
- Adds TTL eviction, LRU backstop, sweep reports, and a cancellable background sweep task wired into the proxy.
- Exposes spec cache policy and sweep metadata in `ghost-complete status --json`.
- Adds doctor checks for unmatched `keep_warm` entries and resident-cap pressure.
- Documents the v0.12.5 spec cache behavior and configuration.

## Why

v0.12.4 made spec parsing lazy but retained parsed specs forever after first touch. This keeps default behavior unchanged while letting memory-sensitive users opt into reclaiming idle parsed spec heap.

## Validation

- `cargo build --release`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo bench -p gc-suggest -- lazy_load`
  - `warm_get_git_under_eviction_path`: `[31.622 ns 31.994 ns 32.439 ns]`
- Manual proxied zsh smoke with opt-in TTL showed `spec_cache sweep evicted_idle=1 evicted_backstop=0 kept_warm=0 parsed=0 bytes=0`.

Note: the benchmark is under the hard 50 ns hot-path budget, but above the plan's aspirational 30 ns target.
