### PR TITLE
feat(tui): add spec_cache section to config editor

### DIFF
--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -2780,7 +2780,11 @@ mod tests {
         )
         .unwrap();
         let store = SpecStore::load_from_dir(dir.path()).unwrap().store;
-        let before = std::time::SystemTime::now();
+        // Capture `before` from the same clock source as `bump_last_accessed`.
+        // Mixing `SystemTime::now()` against a `now_unix_nanos()`-derived
+        // timestamp races on Linux release builds where the two CLOCK_REALTIME
+        // reads can be ordered inconsistently.
+        let before = UNIX_EPOCH + Duration::from_nanos(now_unix_nanos());
         let _ = store.get("foo");
         let entry = store.entries().iter().find(|e| e.id == "foo").unwrap();
         assert!(entry.is_parsed());

--- a/crates/ghost-complete/src/tui/fields.rs
+++ b/crates/ghost-complete/src/tui/fields.rs
@@ -37,6 +37,7 @@ pub const SECTIONS: &[&str] = &[
     "popup",
     "suggest",
     "suggest.providers",
+    "suggest.spec_cache",
     "keybindings",
     "theme",
     "paths",
@@ -53,6 +54,7 @@ pub fn section_label(section: &str) -> &'static str {
         "popup" => "Popup",
         "suggest" => "Suggest",
         "suggest.providers" => "Providers",
+        "suggest.spec_cache" => "Spec Cache",
         "keybindings" => "Keybindings",
         "theme" => "Theme",
         "paths" => "Paths",
@@ -186,6 +188,39 @@ pub fn all_fields() -> Vec<FieldMeta> {
             default: "true",
             reload: ReloadBehavior::RequiresRestart,
             help: "Enable git branch/tag/remote completions",
+        },
+        // suggest.spec_cache
+        FieldMeta {
+            section: "suggest.spec_cache",
+            key: "idle_ttl_secs",
+            field_type: FieldType::U64,
+            default: "0",
+            reload: ReloadBehavior::RequiresRestart,
+            help: "Seconds idle before evicting parsed specs (0 disables eviction)",
+        },
+        FieldMeta {
+            section: "suggest.spec_cache",
+            key: "sweep_interval_secs",
+            field_type: FieldType::U64,
+            default: "60",
+            reload: ReloadBehavior::RequiresRestart,
+            help: "How often the eviction sweep runs (seconds, ignored when eviction disabled)",
+        },
+        FieldMeta {
+            section: "suggest.spec_cache",
+            key: "keep_warm",
+            field_type: FieldType::StringArray,
+            default: "[]",
+            reload: ReloadBehavior::RequiresRestart,
+            help: "Spec aliases (filename stems) that must never be evicted",
+        },
+        FieldMeta {
+            section: "suggest.spec_cache",
+            key: "max_resident_mb",
+            field_type: FieldType::U64,
+            default: "0",
+            reload: ReloadBehavior::RequiresRestart,
+            help: "LRU backstop cap in MiB after TTL eviction (0 disables)",
         },
         // keybindings
         FieldMeta {
@@ -336,4 +371,52 @@ pub fn all_fields() -> Vec<FieldMeta> {
             help: "Enable proxy in unsupported terminals",
         },
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_section_has_at_least_one_field() {
+        let fields = all_fields();
+        for section in SECTIONS {
+            assert!(
+                fields.iter().any(|f| f.section == *section),
+                "section {section:?} declared in SECTIONS has no fields"
+            );
+        }
+    }
+
+    #[test]
+    fn every_section_has_a_label() {
+        for section in SECTIONS {
+            assert_ne!(
+                section_label(section),
+                "Unknown",
+                "section {section:?} is missing a label"
+            );
+        }
+    }
+
+    #[test]
+    fn spec_cache_section_exposes_all_config_fields() {
+        let fields = all_fields();
+        let keys: Vec<&str> = fields
+            .iter()
+            .filter(|f| f.section == "suggest.spec_cache")
+            .map(|f| f.key)
+            .collect();
+        for expected in [
+            "idle_ttl_secs",
+            "sweep_interval_secs",
+            "keep_warm",
+            "max_resident_mb",
+        ] {
+            assert!(
+                keys.contains(&expected),
+                "suggest.spec_cache.{expected} missing from config editor"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `[suggest.spec_cache]` section to `ghost-complete config edit` — missing after PR #110 added the underlying config struct
- Surface all four fields (`idle_ttl_secs`, `sweep_interval_secs`, `keep_warm`, `max_resident_mb`) marked `RequiresRestart` since the values bake in at proxy startup (`gc-pty/src/proxy.rs:291`)
- Add three regression tests so a future `SECTIONS` addition without matching fields or label fails CI loudly

## Test plan
- [x] `cargo test -p ghost-complete` — 197 tests pass, including 3 new in `tui::fields::tests`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Open `ghost-complete config edit` and verify the new **Spec Cache** section appears between Providers and Keybindings, with all four keys editable and round-tripping through save → reload