### PR TITLE
fix(linux): gate macOS-only OnceLock import to silence unused-import warning

### DIFF
--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, RwLock};
+#[cfg(target_os = "macos")]
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};


### PR DESCRIPTION
## Summary

On Linux builds, `crates/gc-suggest/src/specs.rs` emits an unused-import warning because `OnceLock` is only used inside `#[cfg(target_os = "macos")]` blocks (the `mach_absolute_time`-based clock helpers). The Linux clock path uses `clock_gettime` and doesn't need `OnceLock`.

This patch mirrors the existing `cfg(target_os = "macos")` gate on the import itself, eliminating the warning without changing behavior on either platform.

```rust
use std::sync::{Arc, RwLock};
#[cfg(target_os = "macos")]
use std::sync::OnceLock;
```

## Context

I'm exploring a Linux fork of ghost-complete and noticed this is the only warning the codebase emits on `cargo build --release` on Linux. The PTY proxy, terminal detection, and rest of the workspace already build and test cleanly cross-platform — this is the smallest possible cleanup. I understand Linux support isn't on the roadmap; happy to close this if you'd rather keep the codebase strictly macOS-shaped.

## Test plan

- [x] `cargo build --release` clean (no warnings) on Linux
- [x] `cargo build --release` still clean on macOS (cfg gate matches the existing pattern at `specs.rs:847,856,865,883`)
- [x] `cargo test --workspace` passes on Linux (1700+ tests, 0 failures)