### PR TITLE
feat(cli): use real clap subcommands

### DIFF
--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -3,7 +3,7 @@
 //! Reads from `~/.config/ghost-complete/config.toml` with serde deserialization
 //! and sensible defaults for all fields.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use serde::{de, Deserialize, Deserializer, Serialize};
@@ -760,9 +760,9 @@ impl GhostConfig {
         }
     }
 
-    pub fn load(path: Option<&str>) -> Result<Self> {
+    pub fn load(path: Option<&Path>) -> Result<Self> {
         let config_path = match path {
-            Some(p) => PathBuf::from(p),
+            Some(p) => p.to_path_buf(),
             None => {
                 let Some(dir) = config_dir() else {
                     // HOME unset — refuse to load from CWD (could be attacker-controlled).
@@ -1003,7 +1003,7 @@ max_resident_mb = 100
 
     #[test]
     fn test_missing_file_returns_default() {
-        let config = GhostConfig::load(Some("/nonexistent/path/config.toml")).unwrap();
+        let config = GhostConfig::load(Some(Path::new("/nonexistent/path/config.toml"))).unwrap();
         assert_eq!(config.popup.max_visible, 10);
     }
 
@@ -1011,7 +1011,7 @@ max_resident_mb = 100
     fn test_malformed_toml_returns_error() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "this is not [valid toml = {{}}").unwrap();
-        let result = GhostConfig::load(Some(tmp.path().to_str().unwrap()));
+        let result = GhostConfig::load(Some(tmp.path()));
         assert!(result.is_err());
     }
 
@@ -1348,7 +1348,7 @@ max_width = 80
     fn test_popup_max_width_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nmax_width = 1000").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.max_width, 500);
     }
 
@@ -1356,7 +1356,7 @@ max_width = 80
     fn test_popup_max_width_above_u16_still_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nmax_width = 100000").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.max_width, 500);
     }
 
@@ -1364,7 +1364,7 @@ max_width = 80
     fn test_popup_min_width_clamps_floor() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nmin_width = 1").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.min_width, 10);
     }
 
@@ -1372,7 +1372,7 @@ max_width = 80
     fn test_popup_min_width_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nmin_width = 600").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.min_width, 500);
         assert_eq!(config.popup.max_width, 500);
     }
@@ -1381,7 +1381,7 @@ max_width = 80
     fn test_popup_min_width_above_u16_still_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nmin_width = 100000").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.min_width, 500);
         assert_eq!(config.popup.max_width, 500);
     }
@@ -1390,7 +1390,7 @@ max_width = 80
     fn test_popup_max_below_min_raised_to_min() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nmin_width = 50\nmax_width = 30").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.min_width, 50);
         assert_eq!(config.popup.max_width, 50);
     }
@@ -1418,7 +1418,7 @@ description_box = "side"
     fn test_description_box_lines_zero_clamps_to_default() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_lines = 0").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.description_box_lines, 5);
     }
 
@@ -1426,7 +1426,7 @@ description_box = "side"
     fn test_description_box_lines_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_lines = 999").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.description_box_lines, 20);
     }
 
@@ -1434,7 +1434,7 @@ description_box = "side"
     fn test_description_box_lines_above_u16_still_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_lines = 100000").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.description_box_lines, 20);
     }
 
@@ -1442,7 +1442,7 @@ description_box = "side"
     fn test_description_box_max_width_clamps_floor() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_max_width = 5").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.description_box_max_width, 20);
     }
 
@@ -1453,7 +1453,7 @@ description_box = "side"
         // `> 0 && <`, which would let zero leak through and render a degenerate box.
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_max_width = 0").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.description_box_max_width, 20);
     }
 
@@ -1461,7 +1461,7 @@ description_box = "side"
     fn test_description_box_max_width_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_max_width = 9999").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.description_box_max_width, 200);
     }
 
@@ -1469,7 +1469,7 @@ description_box = "side"
     fn test_description_box_max_width_above_u16_still_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_max_width = 100000").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.description_box_max_width, 200);
     }
 
@@ -1477,7 +1477,7 @@ description_box = "side"
     fn test_description_box_debounce_ms_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_debounce_ms = 9999").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.description_box_debounce_ms, 500);
     }
 
@@ -1485,7 +1485,7 @@ description_box = "side"
     fn test_description_box_debounce_ms_above_u16_still_clamps_ceiling() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_debounce_ms = 100000").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.description_box_debounce_ms, 500);
     }
 
@@ -1493,7 +1493,7 @@ description_box = "side"
     fn test_popup_negative_min_width_rejected() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nmin_width = -10").unwrap();
-        let result = GhostConfig::load(Some(tmp.path().to_str().unwrap()));
+        let result = GhostConfig::load(Some(tmp.path()));
         let err = result.expect_err("negative min_width must be rejected");
         let msg = format!("{err:#}");
         assert!(
@@ -1506,7 +1506,7 @@ description_box = "side"
     fn test_popup_negative_description_box_lines_rejected() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\ndescription_box_lines = -1").unwrap();
-        let result = GhostConfig::load(Some(tmp.path().to_str().unwrap()));
+        let result = GhostConfig::load(Some(tmp.path()));
         let err = result.expect_err("negative description_box_lines must be rejected");
         let msg = format!("{err:#}");
         assert!(
@@ -1619,7 +1619,7 @@ max_visible = 5
     fn test_clamp_max_visible_over_limit() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nmax_visible = 100000").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.max_visible, MAX_VISIBLE_UPPER);
     }
 
@@ -1627,7 +1627,7 @@ max_visible = 5
     fn test_clamp_max_results_over_limit() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[suggest]\nmax_results = 999999").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.suggest.max_results, MAX_RESULTS_UPPER);
     }
 
@@ -1639,7 +1639,7 @@ max_visible = 5
             "[popup]\nmax_visible = 25\n[suggest]\nmax_results = 500"
         )
         .unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.max_visible, 25);
         assert_eq!(config.suggest.max_results, 500);
     }
@@ -1652,7 +1652,7 @@ max_visible = 5
             "[popup]\nmax_visible = 50\n[suggest]\nmax_results = 10000"
         )
         .unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.max_visible, 50);
         assert_eq!(config.suggest.max_results, 10000);
     }
@@ -1664,7 +1664,7 @@ max_visible = 5
         // permanently blank popup.
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[suggest]\nmax_results = 0").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.suggest.max_results, MAX_RESULTS_DEFAULT);
     }
 
@@ -1672,7 +1672,7 @@ max_visible = 5
     fn test_clamp_max_visible_zero_to_default() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nmax_visible = 0").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.max_visible, 10);
     }
 
@@ -1684,7 +1684,7 @@ max_visible = 5
             "[popup]\nfeedback_dismiss_ms = 20000\nspinner = false\nshow_provider_errors = true"
         )
         .unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.feedback_dismiss_ms, 10000);
         assert!(!config.popup.spinner);
         assert!(config.popup.show_provider_errors);
@@ -1696,7 +1696,7 @@ max_visible = 5
         // choice, so it must pass through untouched.
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[trigger]\ndelay_ms = 0").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.trigger.delay_ms, 0);
     }
 
@@ -1704,7 +1704,7 @@ max_visible = 5
     fn test_feedback_dismiss_ms_zero_is_allowed() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[popup]\nfeedback_dismiss_ms = 0").unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.popup.feedback_dismiss_ms, 0);
     }
 
@@ -1871,7 +1871,7 @@ max_history_results = 10
     fn test_load_rejects_invalid_theme_style() {
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(tmp, "[theme]\nselected = \"blod\"").unwrap();
-        let result = GhostConfig::load(Some(tmp.path().to_str().unwrap()));
+        let result = GhostConfig::load(Some(tmp.path()));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("invalid theme"));
@@ -1885,7 +1885,7 @@ max_history_results = 10
             "[theme]\nselected = \"bold fg:196\"\nborder = \"fg:#00FF00\""
         )
         .unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         assert_eq!(config.theme.selected.as_deref(), Some("bold fg:196"));
         assert_eq!(config.theme.border.as_deref(), Some("fg:#00FF00"));
     }
@@ -1900,7 +1900,7 @@ max_history_results = 10
             "[trigger]\ndelay_ms = 200\ndelay_ms_typo = 999\n\n[suggest]\nmax_results = 75"
         )
         .unwrap();
-        let config = GhostConfig::load(Some(tmp.path().to_str().unwrap())).unwrap();
+        let config = GhostConfig::load(Some(tmp.path())).unwrap();
         // Known fields still applied correctly.
         assert_eq!(config.trigger.delay_ms, 200);
         assert_eq!(config.suggest.max_results, 75);
@@ -1909,7 +1909,9 @@ max_history_results = 10
     #[test]
     fn test_missing_file_returns_default_via_notfound() {
         // Verifies the TOCTOU-safe path: read_to_string NotFound → default
-        let config = GhostConfig::load(Some("/tmp/definitely_not_a_real_config_42.toml")).unwrap();
+        let config =
+            GhostConfig::load(Some(Path::new("/tmp/definitely_not_a_real_config_42.toml")))
+                .unwrap();
         assert_eq!(config.popup.max_visible, 10);
         assert_eq!(config.suggest.max_results, 50);
     }

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -120,19 +120,7 @@ pub fn spawn_config_watcher(
 
             tracing::info!("config.toml changed, reloading...");
 
-            // If the config path contains non-UTF-8 bytes, we can't pass
-            // it through the str-based GhostConfig::load API. Skipping the
-            // reload is strictly better than silently substituting an
-            // empty string (which would dispatch load() to its "no path"
-            // fallback and reload the wrong file).
-            let Some(config_path_str) = config_path.to_str() else {
-                tracing::warn!(
-                    "config reload skipped: path is not valid UTF-8: {}",
-                    config_path.display()
-                );
-                continue;
-            };
-            let config = match GhostConfig::load(Some(config_path_str)) {
+            let config = match GhostConfig::load(Some(config_path.as_path())) {
                 Ok(c) => c,
                 Err(e) => {
                     tracing::warn!("config reload failed (parse): {e}");

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -1,3 +1,4 @@
+use std::ffi::{OsStr, OsString};
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -71,7 +72,7 @@ fn input_handler_for_resolution(
 /// through the InputHandler for suggestion popup interception.
 ///
 /// Returns the shell's exit code.
-pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Result<i32> {
+pub async fn run_proxy(shell: &OsStr, args: &[OsString], config: &GhostConfig) -> Result<i32> {
     // Detect terminal capabilities
     let terminal_profile = gc_terminal::TerminalProfile::detect();
     if matches!(

--- a/crates/gc-pty/src/spawn.rs
+++ b/crates/gc-pty/src/spawn.rs
@@ -1,3 +1,5 @@
+use std::ffi::{OsStr, OsString};
+
 use anyhow::{Context, Result};
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtyPair};
 
@@ -8,7 +10,7 @@ pub struct SpawnedShell {
     pub child: Box<dyn Child + Send + Sync>,
 }
 
-pub fn spawn_shell(shell: &str, args: &[String]) -> Result<SpawnedShell> {
+pub fn spawn_shell(shell: &OsStr, args: &[OsString]) -> Result<SpawnedShell> {
     let size = get_terminal_size().context("failed to query terminal size")?;
 
     let pty_system = native_pty_system();

--- a/crates/ghost-complete/src/config_cmd.rs
+++ b/crates/ghost-complete/src/config_cmd.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use toml_edit::DocumentMut;
@@ -14,9 +14,9 @@ use crate::sanitize::sanitize_preserving_whitespace;
 /// `gc_config::config_dir()` couldn't resolve (e.g. `$HOME` unset). In that
 /// case there's nothing on disk to read, so we fall through to the
 /// defaults-with-banner branch.
-fn resolve_config_file_path(config_path: Option<&str>) -> Option<PathBuf> {
+fn resolve_config_file_path(config_path: Option<&Path>) -> Option<PathBuf> {
     match config_path {
-        Some(p) => Some(PathBuf::from(p)),
+        Some(p) => Some(p.to_path_buf()),
         None => gc_config::config_dir().map(|d| d.join("config.toml")),
     }
 }
@@ -33,13 +33,13 @@ fn resolve_config_file_path(config_path: Option<&str>) -> Option<PathBuf> {
 /// `GhostConfig` (which is already what `load()` returned, so this reflects
 /// the defaults the proxy would actually use) and prepend a banner comment
 /// explaining that this is synthesized output rather than the user's file.
-pub fn run_config(config_path: Option<&str>) -> Result<()> {
+pub fn run_config(config_path: Option<&Path>) -> Result<()> {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     run_config_inner(config_path, &mut handle)
 }
 
-pub(crate) fn run_config_inner<W: Write>(config_path: Option<&str>, out: &mut W) -> Result<()> {
+pub(crate) fn run_config_inner<W: Write>(config_path: Option<&Path>, out: &mut W) -> Result<()> {
     // Load so that bad configs (invalid theme, malformed TOML) still
     // surface an anyhow error consistent with the rest of the CLI —
     // even though the "happy path" output below bypasses the typed
@@ -104,7 +104,7 @@ mod tests {
         std::fs::write(&cfg_path, body).unwrap();
 
         let mut out = Vec::new();
-        run_config_inner(Some(cfg_path.to_str().unwrap()), &mut out).unwrap();
+        run_config_inner(Some(&cfg_path), &mut out).unwrap();
         let emitted = String::from_utf8(out).expect("output must be valid UTF-8");
 
         assert!(
@@ -130,7 +130,7 @@ mod tests {
         let missing = tmp.path().join("does-not-exist.toml");
 
         let mut out = Vec::new();
-        run_config_inner(Some(missing.to_str().unwrap()), &mut out).unwrap();
+        run_config_inner(Some(&missing), &mut out).unwrap();
         let emitted = String::from_utf8(out).expect("output must be valid UTF-8");
 
         assert!(

--- a/crates/ghost-complete/src/doctor.rs
+++ b/crates/ghost-complete/src/doctor.rs
@@ -95,9 +95,9 @@ fn print_results(results: &[CheckResult]) {
 }
 
 /// Check 1: Config file valid
-fn check_config(config_path: Option<&str>) -> (CheckResult, Option<gc_config::GhostConfig>) {
+fn check_config(config_path: Option<&Path>) -> (CheckResult, Option<gc_config::GhostConfig>) {
     let path = match config_path {
-        Some(p) => PathBuf::from(p),
+        Some(p) => p.to_path_buf(),
         None => {
             let Some(dir) = gc_config::config_dir() else {
                 // HOME unset — refuse to probe CWD for config.
@@ -1202,7 +1202,7 @@ fn check_terminal_profile(
     CheckResult::ok(msg)
 }
 
-pub fn run_doctor(config_path: Option<&str>) -> Result<()> {
+pub fn run_doctor(config_path: Option<&Path>) -> Result<()> {
     let mut results = Vec::new();
 
     // Check 1: Config file

--- a/crates/ghost-complete/src/main.rs
+++ b/crates/ghost-complete/src/main.rs
@@ -103,7 +103,7 @@ enum Command {
         json: bool,
         /// Override the embedded coverage baseline
         #[arg(long, value_name = "PATH")]
-        baseline: Option<std::path::PathBuf>,
+        baseline: Option<PathBuf>,
     },
     /// Show or edit resolved configuration
     Config {
@@ -180,10 +180,11 @@ fn init_tracing(level: LogLevel, log_file: Option<&Path>) -> Result<()> {
     // the `--log-level` flag value otherwise. This matches how every other
     // tracing/log-based Rust binary behaves and keeps `--log-level` as a
     // convenient default for users who don't want to export an env var.
-    // `level.as_filter_str()` returns one of the static strings clap's
-    // ValueEnum accepts, so `EnvFilter::try_new` cannot fail here — `expect`
-    // documents the invariant and makes any future regression in
-    // `as_filter_str` loud rather than silent.
+    // `level.as_filter_str()` returns one of the five fixed level directives
+    // (`trace`/`debug`/`info`/`warn`/`error`), all of which are valid
+    // `EnvFilter` syntax, so `try_new` cannot fail here — `expect` documents
+    // the invariant and makes any future regression in `as_filter_str` loud
+    // rather than silent.
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::try_new(level.as_filter_str())
             .expect("LogLevel ValueEnum variant maps to a valid EnvFilter directive")
@@ -353,10 +354,11 @@ fn run_proxy(
     tracing::info!(shell = %Path::new(&shell).display(), "starting ghost-complete proxy");
 
     // SAFETY: must run while the process is still single-threaded.
-    // We're in `fn main` before any `std::thread::spawn` or tokio
-    // runtime construction; the AWS SDK reads this env var later from
-    // many threads but never writes it, and nothing else in our
-    // process mutates the environment after this point. See the
+    // We're in `fn run_proxy`, called synchronously from `fn main`
+    // before any `std::thread::spawn` or tokio runtime construction;
+    // the AWS SDK reads this env var later from many threads but never
+    // writes it, and nothing else in our process mutates the
+    // environment after this point. See the
     // `gc_suggest::aws::set_imds_disabled_env` SAFETY doc.
     unsafe {
         gc_suggest::aws::set_imds_disabled_env();

--- a/crates/ghost-complete/src/main.rs
+++ b/crates/ghost-complete/src/main.rs
@@ -138,40 +138,6 @@ where
         .unwrap_or_else(|| DEFAULT_FALLBACK_SHELL.to_string())
 }
 
-/// Parse `--baseline <path>` (or `--baseline=PATH`) out of the trailing
-/// arg list `shell_args`. Accepts the GNU-style `--baseline=` form as a
-/// convenience alias.
-///
-/// A bare `--baseline` with no following value — or a `--baseline` whose
-/// next token starts with `-` (another flag) — is a user error, not a
-/// silent fallback to the embedded baseline. The latter behaviour would
-/// mask typos like `ghost-complete status --baseline --json`.
-fn parse_baseline_flag(shell_args: &[String]) -> Result<Option<std::path::PathBuf>> {
-    let mut out: Option<std::path::PathBuf> = None;
-    let mut i = 0;
-    while i < shell_args.len() {
-        let a = &shell_args[i];
-        if a == "--baseline" {
-            let next = shell_args.get(i + 1);
-            match next {
-                Some(v) if !v.starts_with('-') => {
-                    out = Some(std::path::PathBuf::from(v));
-                    i += 2;
-                    continue;
-                }
-                _ => anyhow::bail!("--baseline requires a path argument"),
-            }
-        } else if let Some(rest) = a.strip_prefix("--baseline=") {
-            if rest.is_empty() {
-                anyhow::bail!("--baseline requires a path argument");
-            }
-            out = Some(std::path::PathBuf::from(rest));
-        }
-        i += 1;
-    }
-    Ok(out)
-}
-
 fn init_tracing(level: &str, log_file: Option<&str>) -> Result<()> {
     // Prefer `RUST_LOG` (standard ecosystem env var) when set; fall back to
     // the `--log-level` flag value otherwise. This matches how every other
@@ -358,11 +324,7 @@ fn run_proxy(
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_baseline_flag, resolve_default_shell_from, DEFAULT_FALLBACK_SHELL};
-
-    fn argv(parts: &[&str]) -> Vec<String> {
-        parts.iter().map(|s| s.to_string()).collect()
-    }
+    use super::{resolve_default_shell_from, DEFAULT_FALLBACK_SHELL};
 
     #[test]
     fn resolve_default_shell_uses_env_when_set() {
@@ -386,50 +348,5 @@ mod tests {
         // cryptic ENOENT instead of using the fallback.
         let shell = resolve_default_shell_from(|_| Some(String::new()));
         assert_eq!(shell, DEFAULT_FALLBACK_SHELL);
-    }
-
-    #[test]
-    fn status_baseline_flag_with_value_parses() {
-        let args = argv(&["status", "--baseline", "/tmp/b.json"]);
-        let parsed = parse_baseline_flag(&args).unwrap();
-        assert_eq!(parsed, Some(std::path::PathBuf::from("/tmp/b.json")));
-    }
-
-    #[test]
-    fn status_baseline_equals_form_parses() {
-        let args = argv(&["status", "--baseline=/tmp/b.json"]);
-        let parsed = parse_baseline_flag(&args).unwrap();
-        assert_eq!(parsed, Some(std::path::PathBuf::from("/tmp/b.json")));
-    }
-
-    #[test]
-    fn status_baseline_flag_without_value_errors() {
-        // Bare `--baseline` (no trailing value) — must produce a clear
-        // error rather than silently falling back to the embedded
-        // baseline, so typos like `ghost-complete status --baseline
-        // --json` are caught at the flag boundary.
-        let args = argv(&["status", "--baseline"]);
-        let err = parse_baseline_flag(&args).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("--baseline requires a path argument"),
-            "expected clear error message, got: {err}"
-        );
-
-        // `--baseline` followed by another flag is equivalently bad:
-        // the next token is consumed as a value today, which eats the
-        // real flag. Forbid it.
-        let args = argv(&["status", "--baseline", "--json"]);
-        let err = parse_baseline_flag(&args).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("--baseline requires a path argument"));
-
-        // Empty `--baseline=` form — same contract.
-        let args = argv(&["status", "--baseline="]);
-        let err = parse_baseline_flag(&args).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("--baseline requires a path argument"));
     }
 }

--- a/crates/ghost-complete/src/main.rs
+++ b/crates/ghost-complete/src/main.rs
@@ -7,8 +7,37 @@ mod tui;
 mod validate;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use tracing_subscriber::EnvFilter;
+
+/// Closed set of `--log-level` values, validated by clap at parse time.
+///
+/// The fallback in `init_tracing` silently rewrites invalid free-form
+/// strings to `warn`; modeling the flag as a `ValueEnum` lets clap reject
+/// typos at the parse boundary so `--log-level deubg` errors out instead
+/// of silently logging at `warn`. The `RUST_LOG` env-var path stays
+/// free-form because `EnvFilter` syntax is richer than a single level.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[value(rename_all = "lower")]
+enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogLevel {
+    fn as_filter_str(self) -> &'static str {
+        match self {
+            LogLevel::Trace => "trace",
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(
@@ -30,8 +59,8 @@ struct Cli {
     config: Option<String>,
 
     /// Log level (trace, debug, info, warn, error)
-    #[arg(long, global = true, default_value = "warn")]
-    log_level: String,
+    #[arg(long, global = true, value_enum, default_value_t = LogLevel::Warn)]
+    log_level: LogLevel,
 
     /// Log to file instead of stderr
     #[arg(long, global = true)]
@@ -63,7 +92,7 @@ enum Command {
     },
     /// Show loaded specs and JS compatibility
     Status {
-        /// Exit nonzero if coverage regressed against the baseline
+        /// Exit nonzero if any spec failed to parse or no runtime specs are available
         #[arg(long)]
         strict: bool,
         /// Emit JSON output
@@ -75,12 +104,17 @@ enum Command {
     },
     /// Show or edit resolved configuration
     Config {
+        /// `None` means "print resolved config to stdout"; `Some(Edit)` launches the interactive editor.
         #[command(subcommand)]
         subcommand: Option<ConfigCommand>,
     },
     /// Run health checks
     Doctor,
-    /// Proxy fallback for shell commands such as `ghost-complete /bin/zsh -l`
+    // Catch-all for argv that doesn't match a named subcommand — clap routes
+    // it here so we can dispatch to proxy mode without emitting an "unknown
+    // subcommand" error. clap suppresses `///` docs on `external_subcommand`
+    // variants from `--help`, so the user-facing description lives in the
+    // top-level `after_help` block.
     #[command(external_subcommand)]
     External(Vec<String>),
 }
@@ -138,13 +172,17 @@ where
         .unwrap_or_else(|| DEFAULT_FALLBACK_SHELL.to_string())
 }
 
-fn init_tracing(level: &str, log_file: Option<&str>) -> Result<()> {
+fn init_tracing(level: LogLevel, log_file: Option<&str>) -> Result<()> {
     // Prefer `RUST_LOG` (standard ecosystem env var) when set; fall back to
     // the `--log-level` flag value otherwise. This matches how every other
     // tracing/log-based Rust binary behaves and keeps `--log-level` as a
     // convenient default for users who don't want to export an env var.
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::try_new(level).unwrap_or_else(|_| EnvFilter::new("warn")));
+    // `level.as_filter_str()` is one of the static strings clap's ValueEnum
+    // accepts, so `EnvFilter::try_new` cannot fail here — the
+    // `unwrap_or_else` is defensive.
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::try_new(level.as_filter_str()).unwrap_or_else(|_| EnvFilter::new("warn"))
+    });
 
     if let Some(path) = log_file {
         let file = std::fs::OpenOptions::new()
@@ -232,15 +270,15 @@ fn main() -> Result<()> {
 
     match cli.command {
         Some(Command::Install { dry_run }) => {
-            init_tracing(&log_level, log_file.as_deref())?;
+            init_tracing(log_level, log_file.as_deref())?;
             install::run_install(dry_run)
         }
         Some(Command::Uninstall) => {
-            init_tracing(&log_level, log_file.as_deref())?;
+            init_tracing(log_level, log_file.as_deref())?;
             install::run_uninstall()
         }
         Some(Command::ValidateSpecs { strict, json }) => {
-            init_tracing(&log_level, log_file.as_deref())?;
+            init_tracing(log_level, log_file.as_deref())?;
             validate::run_validate_specs_with_opts(config_path.as_deref(), strict, json)
         }
         Some(Command::Status {
@@ -248,33 +286,35 @@ fn main() -> Result<()> {
             json,
             baseline,
         }) => {
-            init_tracing(&log_level, log_file.as_deref())?;
+            init_tracing(log_level, log_file.as_deref())?;
             status::run_status_with_opts(config_path.as_deref(), strict, json, baseline.as_deref())
         }
         Some(Command::Config {
             subcommand: Some(ConfigCommand::Edit),
         }) => {
-            init_tracing(&log_level, log_file.as_deref())?;
+            init_tracing(log_level, log_file.as_deref())?;
             tui::run_config_editor(config_path.as_deref())?;
             Ok(())
         }
         Some(Command::Config { subcommand: None }) => {
-            init_tracing(&log_level, log_file.as_deref())?;
+            init_tracing(log_level, log_file.as_deref())?;
             config_cmd::run_config(config_path.as_deref())
         }
         Some(Command::Doctor) => {
-            init_tracing(&log_level, log_file.as_deref())?;
+            init_tracing(log_level, log_file.as_deref())?;
             doctor::run_doctor(config_path.as_deref())
         }
-        Some(Command::External(argv)) => run_proxy(&log_level, log_file, &config_path, argv),
-        None => run_proxy(&log_level, log_file, &config_path, Vec::new()),
+        Some(Command::External(argv)) => {
+            run_proxy(log_level, log_file, config_path.as_deref(), argv)
+        }
+        None => run_proxy(log_level, log_file, config_path.as_deref(), Vec::new()),
     }
 }
 
 fn run_proxy(
-    log_level: &str,
+    log_level: LogLevel,
     cli_log_file: Option<String>,
-    config_path: &Option<String>,
+    config_path: Option<&str>,
     argv: Vec<String>,
 ) -> Result<()> {
     // Proxy mode — default to log file, never stderr
@@ -290,8 +330,7 @@ fn run_proxy(
         (shell, args)
     };
 
-    let config =
-        gc_config::GhostConfig::load(config_path.as_deref()).context("failed to load config")?;
+    let config = gc_config::GhostConfig::load(config_path).context("failed to load config")?;
 
     // Auto-refresh the install mirror (`~/.config/ghost-complete/specs/`)
     // if a previous binary version installed it. The mirror takes

--- a/crates/ghost-complete/src/main.rs
+++ b/crates/ghost-complete/src/main.rs
@@ -273,9 +273,9 @@ fn main() -> Result<()> {
             init_tracing(&log_level, log_file.as_deref())?;
             install::run_uninstall()
         }
-        Some(Command::ValidateSpecs { .. }) => {
+        Some(Command::ValidateSpecs { strict, json }) => {
             init_tracing(&log_level, log_file.as_deref())?;
-            validate::run_validate_specs(config_path.as_deref())
+            validate::run_validate_specs_with_opts(config_path.as_deref(), strict, json)
         }
         Some(Command::Status {
             strict,

--- a/crates/ghost-complete/src/main.rs
+++ b/crates/ghost-complete/src/main.rs
@@ -7,7 +7,7 @@ mod tui;
 mod validate;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
@@ -22,24 +22,73 @@ use tracing_subscriber::EnvFilter;
         ")"
     ),
     about = "Terminal-native autocomplete engine",
-    after_help = "COMMANDS:\n  install          Install shell integration (zsh)\n  uninstall        Remove shell integration\n  validate-specs   Validate completion spec files\n  status           Show loaded specs and JS compatibility\n  config           Show resolved configuration\n  config edit      Open interactive config editor\n  doctor           Run health checks\n\nSHELL SUPPORT:\n  zsh   Full support (auto-installed into ~/.zshrc)"
+    after_help = "SHELL SUPPORT:\n  zsh   Full support (auto-installed into ~/.zshrc)\n\nWith no subcommand, ghost-complete starts in proxy mode wrapping $SHELL.\nTo wrap a specific shell, run e.g. `ghost-complete /bin/zsh -l`.\nIf your shell binary is named like a subcommand, prefix with `--`:\n  ghost-complete -- install --some-flag"
 )]
 struct Cli {
     /// Path to config file
-    #[arg(long)]
+    #[arg(long, global = true)]
     config: Option<String>,
 
     /// Log level (trace, debug, info, warn, error)
-    #[arg(long, default_value = "warn")]
+    #[arg(long, global = true, default_value = "warn")]
     log_level: String,
 
     /// Log to file instead of stderr
-    #[arg(long)]
+    #[arg(long, global = true)]
     log_file: Option<String>,
 
-    /// Shell command and arguments (default: $SHELL or /bin/zsh)
-    #[arg(trailing_var_arg = true)]
-    shell_args: Vec<String>,
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Install shell integration (zsh)
+    Install {
+        /// Print what would be installed without writing files
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Remove shell integration
+    Uninstall,
+    /// Validate completion spec files
+    #[command(name = "validate-specs")]
+    ValidateSpecs {
+        /// Treat warnings as failures
+        #[arg(long)]
+        strict: bool,
+        /// Emit JSON output
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show loaded specs and JS compatibility
+    Status {
+        /// Exit nonzero if coverage regressed against the baseline
+        #[arg(long)]
+        strict: bool,
+        /// Emit JSON output
+        #[arg(long)]
+        json: bool,
+        /// Override the embedded coverage baseline
+        #[arg(long, value_name = "PATH")]
+        baseline: Option<std::path::PathBuf>,
+    },
+    /// Show or edit resolved configuration
+    Config {
+        #[command(subcommand)]
+        subcommand: Option<ConfigCommand>,
+    },
+    /// Run health checks
+    Doctor,
+    /// Proxy fallback for shell commands such as `ghost-complete /bin/zsh -l`
+    #[command(external_subcommand)]
+    External(Vec<String>),
+}
+
+#[derive(Subcommand)]
+enum ConfigCommand {
+    /// Open the interactive config editor
+    Edit,
 }
 
 fn default_log_file() -> Option<String> {
@@ -211,67 +260,72 @@ fn auto_refresh_install_mirror_if_stale(config: &gc_config::GhostConfig) {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    let config_path = cli.config;
+    let log_level = cli.log_level;
+    let log_file = cli.log_file;
 
-    match cli.shell_args.first().map(|s| s.as_str()) {
-        Some("install") => {
-            init_tracing(&cli.log_level, cli.log_file.as_deref())?;
-            let dry_run = cli.shell_args.iter().any(|s| s == "--dry-run");
-            return install::run_install(dry_run);
+    match cli.command {
+        Some(Command::Install { dry_run }) => {
+            init_tracing(&log_level, log_file.as_deref())?;
+            install::run_install(dry_run)
         }
-        Some("uninstall") => {
-            init_tracing(&cli.log_level, cli.log_file.as_deref())?;
-            return install::run_uninstall();
+        Some(Command::Uninstall) => {
+            init_tracing(&log_level, log_file.as_deref())?;
+            install::run_uninstall()
         }
-        Some("validate-specs") => {
-            init_tracing(&cli.log_level, cli.log_file.as_deref())?;
-            return validate::run_validate_specs(cli.config.as_deref());
+        Some(Command::ValidateSpecs { .. }) => {
+            init_tracing(&log_level, log_file.as_deref())?;
+            validate::run_validate_specs(config_path.as_deref())
         }
-        Some("status") => {
-            init_tracing(&cli.log_level, cli.log_file.as_deref())?;
-            // Mirror `validate-specs --strict` / `install --dry-run`: the
-            // top-level clap parser just collects a trailing arg list, so we
-            // scan it ourselves for the status-specific flags.
-            let strict = cli.shell_args.iter().any(|s| s == "--strict");
-            let json = cli.shell_args.iter().any(|s| s == "--json");
-            let baseline_path = parse_baseline_flag(&cli.shell_args)?;
-            return status::run_status_with_opts(
-                cli.config.as_deref(),
-                strict,
-                json,
-                baseline_path.as_deref(),
-            );
+        Some(Command::Status {
+            strict,
+            json,
+            baseline,
+        }) => {
+            init_tracing(&log_level, log_file.as_deref())?;
+            status::run_status_with_opts(config_path.as_deref(), strict, json, baseline.as_deref())
         }
-        Some("config") => {
-            if cli.shell_args.get(1).map(|s| s.as_str()) == Some("edit") {
-                init_tracing(&cli.log_level, cli.log_file.as_deref())?;
-                tui::run_config_editor(cli.config.as_deref())?;
-                std::process::exit(0);
-            }
-            init_tracing(&cli.log_level, cli.log_file.as_deref())?;
-            return config_cmd::run_config(cli.config.as_deref());
+        Some(Command::Config {
+            subcommand: Some(ConfigCommand::Edit),
+        }) => {
+            init_tracing(&log_level, log_file.as_deref())?;
+            tui::run_config_editor(config_path.as_deref())?;
+            Ok(())
         }
-        Some("doctor") => {
-            init_tracing(&cli.log_level, cli.log_file.as_deref())?;
-            return doctor::run_doctor(cli.config.as_deref());
+        Some(Command::Config { subcommand: None }) => {
+            init_tracing(&log_level, log_file.as_deref())?;
+            config_cmd::run_config(config_path.as_deref())
         }
-        _ => {}
+        Some(Command::Doctor) => {
+            init_tracing(&log_level, log_file.as_deref())?;
+            doctor::run_doctor(config_path.as_deref())
+        }
+        Some(Command::External(argv)) => run_proxy(&log_level, log_file, &config_path, argv),
+        None => run_proxy(&log_level, log_file, &config_path, Vec::new()),
     }
+}
 
+fn run_proxy(
+    log_level: &str,
+    cli_log_file: Option<String>,
+    config_path: &Option<String>,
+    argv: Vec<String>,
+) -> Result<()> {
     // Proxy mode — default to log file, never stderr
-    let log_file = cli.log_file.or_else(default_log_file);
-    init_tracing(&cli.log_level, log_file.as_deref())?;
+    let log_file = cli_log_file.or_else(default_log_file);
+    init_tracing(log_level, log_file.as_deref())?;
 
-    let (shell, args) = if cli.shell_args.is_empty() {
+    let (shell, args) = if argv.is_empty() {
         (resolve_default_shell(), vec![])
     } else {
-        let mut iter = cli.shell_args.into_iter();
-        let shell = iter.next().unwrap();
+        let mut iter = argv.into_iter();
+        let shell = iter.next().expect("argv non-empty branch already checked");
         let args: Vec<String> = iter.collect();
         (shell, args)
     };
 
     let config =
-        gc_config::GhostConfig::load(cli.config.as_deref()).context("failed to load config")?;
+        gc_config::GhostConfig::load(config_path.as_deref()).context("failed to load config")?;
 
     // Auto-refresh the install mirror (`~/.config/ghost-complete/specs/`)
     // if a previous binary version installed it. The mirror takes

--- a/crates/ghost-complete/src/main.rs
+++ b/crates/ghost-complete/src/main.rs
@@ -6,16 +6,19 @@ mod status;
 mod tui;
 mod validate;
 
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use tracing_subscriber::EnvFilter;
 
 /// Closed set of `--log-level` values, validated by clap at parse time.
 ///
-/// The fallback in `init_tracing` silently rewrites invalid free-form
-/// strings to `warn`; modeling the flag as a `ValueEnum` lets clap reject
-/// typos at the parse boundary so `--log-level deubg` errors out instead
-/// of silently logging at `warn`. The `RUST_LOG` env-var path stays
+/// Before this enum existed, `--log-level deubg` would silently fall back
+/// to `warn` inside `init_tracing`. Modeling the flag as a `ValueEnum`
+/// lets clap reject typos at the parse boundary so the fallback path is
+/// unreachable for `--log-level`; the `RUST_LOG` env-var path stays
 /// free-form because `EnvFilter` syntax is richer than a single level.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 #[value(rename_all = "lower")]
@@ -56,7 +59,7 @@ impl LogLevel {
 struct Cli {
     /// Path to config file
     #[arg(long, global = true)]
-    config: Option<String>,
+    config: Option<PathBuf>,
 
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, global = true, value_enum, default_value_t = LogLevel::Warn)]
@@ -64,7 +67,7 @@ struct Cli {
 
     /// Log to file instead of stderr
     #[arg(long, global = true)]
-    log_file: Option<String>,
+    log_file: Option<PathBuf>,
 
     #[command(subcommand)]
     command: Option<Command>,
@@ -114,9 +117,11 @@ enum Command {
     // it here so we can dispatch to proxy mode without emitting an "unknown
     // subcommand" error. clap suppresses `///` docs on `external_subcommand`
     // variants from `--help`, so the user-facing description lives in the
-    // top-level `after_help` block.
+    // top-level `after_help` block. `Vec<OsString>` preserves non-UTF-8 argv
+    // (e.g. file-system names) the shell-wrapper invocations may carry; clap
+    // derives the right parser automatically under `external_subcommand`.
     #[command(external_subcommand)]
-    External(Vec<String>),
+    External(Vec<OsString>),
 }
 
 #[derive(Subcommand)]
@@ -125,7 +130,7 @@ enum ConfigCommand {
     Edit,
 }
 
-fn default_log_file() -> Option<String> {
+fn default_log_file() -> Option<PathBuf> {
     let state_dir = dirs::state_dir()
         .or_else(|| dirs::home_dir().map(|h| h.join(".local/state")))
         .map(|d| d.join("ghost-complete"));
@@ -142,11 +147,7 @@ fn default_log_file() -> Option<String> {
         );
         return None;
     }
-    Some(
-        dir.join("ghost-complete.log")
-            .to_string_lossy()
-            .into_owned(),
-    )
+    Some(dir.join("ghost-complete.log"))
 }
 
 /// Default fallback shell when `$SHELL` is unset, empty, or unreadable.
@@ -154,34 +155,38 @@ const DEFAULT_FALLBACK_SHELL: &str = "/bin/zsh";
 
 /// Resolve the default shell from `$SHELL`, falling back to [`DEFAULT_FALLBACK_SHELL`].
 ///
-/// `env::var("SHELL")` returns `Ok("")` when the variable is set but empty —
-/// passing that straight to the PTY spawn produces an opaque `ENOENT` and a
-/// confused user. Treat empty as missing so the fallback applies.
-fn resolve_default_shell() -> String {
-    resolve_default_shell_from(|name| std::env::var(name).ok())
+/// `env::var_os("SHELL")` returns `Some("")` when the variable is set but
+/// empty — passing that straight to the PTY spawn produces an opaque
+/// `ENOENT` and a confused user. Treat empty as missing so the fallback
+/// applies. Returns `OsString` so a hypothetically non-UTF-8 `$SHELL`
+/// survives end-to-end into the spawn.
+fn resolve_default_shell() -> OsString {
+    resolve_default_shell_from(|name| std::env::var_os(name))
 }
 
 /// Pure helper used by [`resolve_default_shell`]; takes an env-lookup closure
 /// so the resolution rules can be unit-tested without touching process state.
-fn resolve_default_shell_from<F>(lookup: F) -> String
+fn resolve_default_shell_from<F>(lookup: F) -> OsString
 where
-    F: Fn(&str) -> Option<String>,
+    F: Fn(&str) -> Option<OsString>,
 {
     lookup("SHELL")
         .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_FALLBACK_SHELL.to_string())
+        .unwrap_or_else(|| OsString::from(DEFAULT_FALLBACK_SHELL))
 }
 
-fn init_tracing(level: LogLevel, log_file: Option<&str>) -> Result<()> {
+fn init_tracing(level: LogLevel, log_file: Option<&Path>) -> Result<()> {
     // Prefer `RUST_LOG` (standard ecosystem env var) when set; fall back to
     // the `--log-level` flag value otherwise. This matches how every other
     // tracing/log-based Rust binary behaves and keeps `--log-level` as a
     // convenient default for users who don't want to export an env var.
-    // `level.as_filter_str()` is one of the static strings clap's ValueEnum
-    // accepts, so `EnvFilter::try_new` cannot fail here — the
-    // `unwrap_or_else` is defensive.
+    // `level.as_filter_str()` returns one of the static strings clap's
+    // ValueEnum accepts, so `EnvFilter::try_new` cannot fail here — `expect`
+    // documents the invariant and makes any future regression in
+    // `as_filter_str` loud rather than silent.
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        EnvFilter::try_new(level.as_filter_str()).unwrap_or_else(|_| EnvFilter::new("warn"))
+        EnvFilter::try_new(level.as_filter_str())
+            .expect("LogLevel ValueEnum variant maps to a valid EnvFilter directive")
     });
 
     if let Some(path) = log_file {
@@ -189,7 +194,7 @@ fn init_tracing(level: LogLevel, log_file: Option<&str>) -> Result<()> {
             .create(true)
             .append(true)
             .open(path)
-            .with_context(|| format!("failed to open log file: {}", path))?;
+            .with_context(|| format!("failed to open log file: {}", path.display()))?;
 
         tracing_subscriber::fmt()
             .with_env_filter(filter)
@@ -293,8 +298,7 @@ fn main() -> Result<()> {
             subcommand: Some(ConfigCommand::Edit),
         }) => {
             init_tracing(log_level, log_file.as_deref())?;
-            tui::run_config_editor(config_path.as_deref())?;
-            Ok(())
+            tui::run_config_editor(config_path.as_deref())
         }
         Some(Command::Config { subcommand: None }) => {
             init_tracing(log_level, log_file.as_deref())?;
@@ -311,11 +315,14 @@ fn main() -> Result<()> {
     }
 }
 
+// `cli_log_file` is taken by value because the body consumes it for the
+// `.or_else(default_log_file)` chain below; `config_path` is borrowed
+// because no caller hands ownership down beyond this stack frame.
 fn run_proxy(
     log_level: LogLevel,
-    cli_log_file: Option<String>,
-    config_path: Option<&str>,
-    argv: Vec<String>,
+    cli_log_file: Option<PathBuf>,
+    config_path: Option<&Path>,
+    argv: Vec<OsString>,
 ) -> Result<()> {
     // Proxy mode — default to log file, never stderr
     let log_file = cli_log_file.or_else(default_log_file);
@@ -326,7 +333,7 @@ fn run_proxy(
     } else {
         let mut iter = argv.into_iter();
         let shell = iter.next().expect("argv non-empty branch already checked");
-        let args: Vec<String> = iter.collect();
+        let args: Vec<OsString> = iter.collect();
         (shell, args)
     };
 
@@ -343,7 +350,7 @@ fn run_proxy(
     // for the full rationale.
     auto_refresh_install_mirror_if_stale(&config);
 
-    tracing::info!(shell = %shell, "starting ghost-complete proxy");
+    tracing::info!(shell = %Path::new(&shell).display(), "starting ghost-complete proxy");
 
     // SAFETY: must run while the process is still single-threaded.
     // We're in `fn main` before any `std::thread::spawn` or tokio
@@ -364,28 +371,29 @@ fn run_proxy(
 #[cfg(test)]
 mod tests {
     use super::{resolve_default_shell_from, DEFAULT_FALLBACK_SHELL};
+    use std::ffi::OsString;
 
     #[test]
     fn resolve_default_shell_uses_env_when_set() {
         let shell = resolve_default_shell_from(|name| {
             assert_eq!(name, "SHELL");
-            Some("/usr/local/bin/fish".to_string())
+            Some(OsString::from("/usr/local/bin/fish"))
         });
-        assert_eq!(shell, "/usr/local/bin/fish");
+        assert_eq!(shell, OsString::from("/usr/local/bin/fish"));
     }
 
     #[test]
     fn resolve_default_shell_falls_back_when_unset() {
         let shell = resolve_default_shell_from(|_| None);
-        assert_eq!(shell, DEFAULT_FALLBACK_SHELL);
+        assert_eq!(shell, OsString::from(DEFAULT_FALLBACK_SHELL));
     }
 
     #[test]
     fn resolve_default_shell_falls_back_when_empty() {
-        // Regression: `env::var("SHELL")` returns `Ok("")` when SHELL is set
-        // but empty. Without the empty filter, the PTY spawn fails with a
+        // Regression: `env::var_os("SHELL")` returns `Some("")` when SHELL is
+        // set but empty. Without the empty filter, the PTY spawn fails with a
         // cryptic ENOENT instead of using the fallback.
-        let shell = resolve_default_shell_from(|_| Some(String::new()));
-        assert_eq!(shell, DEFAULT_FALLBACK_SHELL);
+        let shell = resolve_default_shell_from(|_| Some(OsString::new()));
+        assert_eq!(shell, OsString::from(DEFAULT_FALLBACK_SHELL));
     }
 }

--- a/crates/ghost-complete/src/status.rs
+++ b/crates/ghost-complete/src/status.rs
@@ -467,7 +467,7 @@ fn include_embedded_for_configured_dirs(configured: &[String]) -> bool {
 
 /// Scan resolved runtime specs and collect the numbers the status report
 /// needs. Does NOT produce any output.
-fn scan_specs(config_path: Option<&str>) -> Result<StatusOutcome> {
+fn scan_specs(config_path: Option<&Path>) -> Result<StatusOutcome> {
     let config = gc_config::GhostConfig::load(config_path).context("failed to load config")?;
     let dirs = resolve_spec_dirs(&config.paths.spec_dirs);
     let include_embedded = include_embedded_for_configured_dirs(&config.paths.spec_dirs);
@@ -865,7 +865,7 @@ fn has_non_empty_raw_script_or_template(map: &serde_json::Map<String, serde_json
 /// Inner implementation that writes its report to `out` instead of stdout,
 /// so the sanitisation path can be tested without a real terminal.
 fn run_status_inner(
-    config_path: Option<&str>,
+    config_path: Option<&Path>,
     out: &mut dyn std::io::Write,
 ) -> Result<StatusOutcome> {
     let outcome = scan_specs(config_path)?;
@@ -1026,7 +1026,7 @@ fn run_status_inner(
 /// Callers that want a minimal report (e.g. tests that don't care about
 /// the trend block) can still call the inner form directly.
 fn run_status_inner_with_trend(
-    config_path: Option<&str>,
+    config_path: Option<&Path>,
     baseline_path: Option<&Path>,
     out: &mut dyn Write,
 ) -> Result<StatusOutcome> {
@@ -1304,7 +1304,7 @@ struct CoverageDelta {
 
 /// Emit the JSON status report to `out`.
 fn run_status_json(
-    config_path: Option<&str>,
+    config_path: Option<&Path>,
     baseline_path: Option<&Path>,
     out: &mut dyn Write,
 ) -> Result<StatusOutcome> {
@@ -1421,7 +1421,7 @@ fn run_status_json(
 /// Non-strict, non-JSON mode preserves the prior behaviour: always returns
 /// `Ok(())` regardless of spec health.
 pub fn run_status_with_opts(
-    config_path: Option<&str>,
+    config_path: Option<&Path>,
     strict: bool,
     json: bool,
     baseline_path: Option<&Path>,
@@ -1445,7 +1445,7 @@ enum StatusExit {
 }
 
 fn run_status_with_opts_to_writer(
-    config_path: Option<&str>,
+    config_path: Option<&Path>,
     strict: bool,
     json: bool,
     baseline_path: Option<&Path>,
@@ -1546,7 +1546,7 @@ mod tests {
         unsupported: u64,
     ) {
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), None, &mut out).unwrap();
+        run_status_json(Some(cfg), None, &mut out).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         let spec_counts = &parsed["spec_counts"];
         assert_eq!(
@@ -1604,7 +1604,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), None, &mut out).unwrap();
+        run_status_json(Some(&cfg), None, &mut out).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
 
         assert_eq!(parsed["schema_version"], "1.10");
@@ -1717,7 +1717,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_inner(Some(cfg.to_str().unwrap()), &mut out).unwrap();
+        run_status_inner(Some(&cfg), &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
 
         // The "failed to load" line is the only place user-supplied bytes
@@ -1783,7 +1783,7 @@ mod tests {
         .unwrap();
 
         let cfg = write_config_for_dirs(&[&primary_dir, &fallback_dir], &tmp);
-        let outcome = scan_specs(Some(cfg.to_str().unwrap())).unwrap();
+        let outcome = scan_specs(Some(&cfg)).unwrap();
 
         assert_eq!(outcome.fs_specs, 2);
         assert_eq!(outcome.fully_functional, 1);
@@ -1814,7 +1814,7 @@ mod tests {
         std::fs::write(fallback_dir.join("git.json"), fallback_git).unwrap();
 
         let cfg = write_config_for_dirs(&[&primary_dir, &fallback_dir], &tmp);
-        let outcome = scan_specs(Some(cfg.to_str().unwrap())).unwrap();
+        let outcome = scan_specs(Some(&cfg)).unwrap();
 
         // SpecStore keeps fallback candidates, but only the primary entry
         // resolves while it parses successfully.
@@ -1857,7 +1857,7 @@ mod tests {
         .unwrap();
 
         let cfg = write_config_for_dirs(&[&primary_dir, &fallback_dir], &tmp);
-        let outcome = scan_specs(Some(cfg.to_str().unwrap())).unwrap();
+        let outcome = scan_specs(Some(&cfg)).unwrap();
 
         assert_eq!(
             outcome.total_parse_errors, 1,
@@ -2011,14 +2011,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let exit = run_status_with_opts_to_writer(
-            Some(cfg.to_str().unwrap()),
-            true,
-            false,
-            None,
-            &mut out,
-        )
-        .unwrap();
+        let exit = run_status_with_opts_to_writer(Some(&cfg), true, false, None, &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
 
         assert_eq!(exit, StatusExit::Failure);
@@ -2041,7 +2034,7 @@ mod tests {
         std::fs::write(&broken_path, "{not valid json").unwrap();
         let cfg = write_config_for(&spec_dir, &tmp);
 
-        let outcome = scan_specs(Some(cfg.to_str().unwrap())).unwrap();
+        let outcome = scan_specs(Some(&cfg)).unwrap();
 
         assert_eq!(outcome.total_parse_errors, 1);
         let detail = outcome.parse_error_lines.first().unwrap();
@@ -2060,14 +2053,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let exit = run_status_with_opts_to_writer(
-            Some(cfg.to_str().unwrap()),
-            true,
-            false,
-            None,
-            &mut out,
-        )
-        .unwrap();
+        let exit = run_status_with_opts_to_writer(Some(&cfg), true, false, None, &mut out).unwrap();
 
         assert_eq!(exit, StatusExit::Success);
     }
@@ -2084,7 +2070,7 @@ mod tests {
 
         let cfg = write_config_for_dirs(&[&primary_dir, &fallback_dir], &tmp);
         let mut out = Vec::new();
-        run_status_inner(Some(cfg.to_str().unwrap()), &mut out).unwrap();
+        run_status_inner(Some(&cfg), &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
 
         assert!(
@@ -2409,7 +2395,7 @@ mod tests {
         let baseline_path = write_baseline(&tmp, body);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), Some(&baseline_path), &mut out).unwrap();
+        run_status_json(Some(&cfg), Some(&baseline_path), &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
 
         assert!(
@@ -2460,7 +2446,7 @@ mod tests {
         let baseline_path = write_baseline(&tmp, body);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), Some(&baseline_path), &mut out).unwrap();
+        run_status_json(Some(&cfg), Some(&baseline_path), &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
         let parsed: serde_json::Value = serde_json::from_str(&txt).unwrap();
 
@@ -2596,7 +2582,7 @@ mod tests {
         let baseline_path = write_baseline(&tmp, body);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), Some(&baseline_path), &mut out).unwrap();
+        run_status_json(Some(&cfg), Some(&baseline_path), &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
         let parsed: serde_json::Value = serde_json::from_str(&txt).unwrap();
         assert!(
@@ -2653,7 +2639,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), None, &mut out).unwrap();
+        run_status_json(Some(&cfg), None, &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
         let parsed: serde_json::Value = serde_json::from_str(&txt).unwrap();
 
@@ -2770,7 +2756,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), None, &mut out).unwrap();
+        run_status_json(Some(&cfg), None, &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
         let parsed: serde_json::Value = serde_json::from_str(&txt).unwrap();
 
@@ -2858,7 +2844,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), None, &mut out).unwrap();
+        run_status_json(Some(&cfg), None, &mut out).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_str(&String::from_utf8_lossy(&out)).unwrap();
 
@@ -2915,7 +2901,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), None, &mut out).unwrap();
+        run_status_json(Some(&cfg), None, &mut out).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_str(&String::from_utf8_lossy(&out)).unwrap();
 
@@ -2976,7 +2962,7 @@ mod tests {
         );
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), Some(&baseline), &mut out).unwrap();
+        run_status_json(Some(&cfg), Some(&baseline), &mut out).unwrap();
         let status_path = tmp.path().join("status.json");
         std::fs::write(&status_path, &out).unwrap();
 
@@ -3047,7 +3033,7 @@ mod tests {
         .unwrap();
         let cfg = write_config_for(&spec_dir, &tmp);
 
-        let outcome = scan_specs(Some(cfg.to_str().unwrap())).unwrap();
+        let outcome = scan_specs(Some(&cfg)).unwrap();
         assert_eq!(outcome.fs_specs, 2);
         assert_eq!(outcome.fully_functional, 1);
         assert_eq!(outcome.partially_functional, 1);
@@ -3089,7 +3075,7 @@ mod tests {
         }
 
         let cfg = write_config_for(&spec_dir, &tmp);
-        let outcome = scan_specs(Some(cfg.to_str().unwrap())).unwrap();
+        let outcome = scan_specs(Some(&cfg)).unwrap();
 
         // The active fixture set:
         //   static_only.json                    → stem `static_only`, name `static-only`,
@@ -3398,7 +3384,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_inner(Some(cfg.to_str().unwrap()), &mut out).unwrap();
+        run_status_inner(Some(&cfg), &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
 
         // Coverage section
@@ -3473,7 +3459,7 @@ mod tests {
         std::fs::write(&cfg_path, body).unwrap();
 
         let mut out = Vec::new();
-        run_status_inner(Some(cfg_path.to_str().unwrap()), &mut out).unwrap();
+        run_status_inner(Some(&cfg_path), &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
 
         assert!(
@@ -3501,7 +3487,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), None, &mut out).unwrap();
+        run_status_json(Some(&cfg), None, &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
         let parsed: serde_json::Value = serde_json::from_str(&txt).unwrap();
 
@@ -3590,7 +3576,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), None, &mut out).unwrap();
+        run_status_json(Some(&cfg), None, &mut out).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_str(&String::from_utf8_lossy(&out)).unwrap();
 
@@ -3646,7 +3632,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_status_json(Some(cfg.to_str().unwrap()), None, &mut out).unwrap();
+        run_status_json(Some(&cfg), None, &mut out).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_str(&String::from_utf8_lossy(&out)).unwrap();
 

--- a/crates/ghost-complete/src/tui/mod.rs
+++ b/crates/ghost-complete/src/tui/mod.rs
@@ -14,7 +14,7 @@ use crossterm::{
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Once;
 
 /// RAII guard that restores terminal state on Drop — including during a panic
@@ -65,9 +65,9 @@ impl Drop for TerminalSession {
     }
 }
 
-pub fn run_config_editor(config_path: Option<&str>) -> Result<()> {
+pub fn run_config_editor(config_path: Option<&Path>) -> Result<()> {
     let path = match config_path {
-        Some(p) => PathBuf::from(p),
+        Some(p) => p.to_path_buf(),
         None => {
             let dir = gc_config::config_dir().context("cannot determine config directory")?;
             dir.join("config.toml")

--- a/crates/ghost-complete/src/validate.rs
+++ b/crates/ghost-complete/src/validate.rs
@@ -663,12 +663,6 @@ mod tests {
         assert!(!outcome.strict_failed);
     }
 
-    #[test]
-    fn run_validate_specs_with_opts_accepts_typed_flags_without_env_scan() {
-        let _entry: fn(Option<&str>, bool, bool) -> anyhow::Result<()> =
-            run_validate_specs_with_opts;
-    }
-
     /// Sanity check that `validate_dir` writes to its sink rather than
     /// stdout — keeps the rest of the test surface clean.
     #[test]

--- a/crates/ghost-complete/src/validate.rs
+++ b/crates/ghost-complete/src/validate.rs
@@ -663,6 +663,17 @@ mod tests {
         assert!(!outcome.strict_failed);
     }
 
+    #[test]
+    fn run_validate_specs_with_opts_accepts_typed_flags_without_env_scan() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let spec_dir = tmp.path().join("specs");
+        std::fs::create_dir_all(&spec_dir).unwrap();
+        write_spec(&spec_dir, "good.json", r#"{"name":"good"}"#);
+        let cfg = write_config_for(&spec_dir, &tmp);
+
+        run_validate_specs_with_opts(Some(cfg.to_str().unwrap()), false, true).unwrap();
+    }
+
     /// Sanity check that `validate_dir` writes to its sink rather than
     /// stdout — keeps the rest of the test surface clean.
     #[test]

--- a/crates/ghost-complete/src/validate.rs
+++ b/crates/ghost-complete/src/validate.rs
@@ -421,7 +421,7 @@ pub struct ValidateOutcome {
 ///   `... | jq 'select(.spec_name)'`  → per-spec rows
 ///   `... | jq 'select(.summary)'`    → summary row
 pub fn run_validate_specs_inner(
-    config_path: Option<&str>,
+    config_path: Option<&Path>,
     strict: bool,
     json: bool,
     out: &mut dyn std::io::Write,
@@ -522,7 +522,7 @@ fn emit_json_summary(
 /// Entry point invoked by `main.rs` after clap has parsed command-specific
 /// flags.
 pub fn run_validate_specs_with_opts(
-    config_path: Option<&str>,
+    config_path: Option<&Path>,
     strict: bool,
     json: bool,
 ) -> Result<()> {
@@ -580,8 +580,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), false, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), false, false, &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
         assert!(
             outcome.counts.warnings > 0,
@@ -620,8 +619,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert!(outcome.counts.warnings > 0);
         assert!(
             outcome.strict_failed,
@@ -656,8 +654,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert_eq!(outcome.counts.warnings, 0);
         assert_eq!(outcome.counts.failed, 0);
         assert!(!outcome.strict_failed);
@@ -700,7 +697,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_validate_specs_inner(Some(cfg.to_str().unwrap()), false, true, &mut out).unwrap();
+        run_validate_specs_inner(Some(&cfg), false, true, &mut out).unwrap();
         let rows = parse_ndjson(&out);
 
         assert_eq!(
@@ -736,7 +733,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_validate_specs_inner(Some(cfg.to_str().unwrap()), false, true, &mut out).unwrap();
+        run_validate_specs_inner(Some(&cfg), false, true, &mut out).unwrap();
         let rows = parse_ndjson(&out);
 
         let spec_row = rows
@@ -773,7 +770,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_validate_specs_inner(Some(cfg.to_str().unwrap()), false, true, &mut out).unwrap();
+        run_validate_specs_inner(Some(&cfg), false, true, &mut out).unwrap();
         let rows = parse_ndjson(&out);
 
         let spec_row = rows
@@ -814,7 +811,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_validate_specs_inner(Some(cfg.to_str().unwrap()), false, true, &mut out).unwrap();
+        run_validate_specs_inner(Some(&cfg), false, true, &mut out).unwrap();
         let rows = parse_ndjson(&out);
 
         let summary = rows
@@ -876,7 +873,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_validate_specs_inner(Some(cfg.to_str().unwrap()), false, true, &mut out).unwrap();
+        run_validate_specs_inner(Some(&cfg), false, true, &mut out).unwrap();
         let rows = parse_ndjson(&out);
 
         let summary = rows
@@ -904,7 +901,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        run_validate_specs_inner(Some(cfg.to_str().unwrap()), false, true, &mut out).unwrap();
+        run_validate_specs_inner(Some(&cfg), false, true, &mut out).unwrap();
         let txt = String::from_utf8_lossy(&out);
 
         assert!(
@@ -941,8 +938,7 @@ mod tests {
 
         // Non-strict mode: no warning, no strict_failed.
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), false, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), false, false, &mut out).unwrap();
         assert_eq!(
             outcome.counts.warnings, 0,
             "non-strict mode must not warn on missing js_runtime"
@@ -951,8 +947,7 @@ mod tests {
 
         // Strict mode: at least one warning + strict_failed=true.
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert!(
             outcome.counts.warnings > 0,
             "strict mode must surface a warning for missing js_runtime"
@@ -996,8 +991,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert!(
             outcome.counts.warnings > 0,
             "strict mode must warn on missing js_runtime in option args array"
@@ -1037,8 +1031,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert_eq!(outcome.counts.warnings, 0);
         assert!(!outcome.strict_failed);
     }
@@ -1068,8 +1061,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert!(outcome.counts.warnings > 0);
         assert!(outcome.strict_failed);
     }
@@ -1132,8 +1124,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert!(
             outcome.counts.warnings > 0,
             "strict mode must warn on missing js_runtime at deep nesting"
@@ -1185,8 +1176,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert!(
             outcome.counts.warnings > 0,
             "strict mode must warn on script_function without self_contained"
@@ -1228,8 +1218,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert!(outcome.counts.warnings > 0);
         assert!(outcome.strict_failed);
         let txt = String::from_utf8_lossy(&out);
@@ -1271,8 +1260,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert!(
             outcome.counts.warnings > 0,
             "strict mode must warn on post_process without script/script_template"
@@ -1314,8 +1302,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert_eq!(outcome.counts.warnings, 0);
         assert!(!outcome.strict_failed);
     }
@@ -1348,8 +1335,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert_eq!(outcome.counts.warnings, 0);
         assert!(!outcome.strict_failed);
     }
@@ -1382,8 +1368,7 @@ mod tests {
         let cfg = write_config_for(&spec_dir, &tmp);
 
         let mut out = Vec::new();
-        let outcome =
-            run_validate_specs_inner(Some(cfg.to_str().unwrap()), true, false, &mut out).unwrap();
+        let outcome = run_validate_specs_inner(Some(&cfg), true, false, &mut out).unwrap();
         assert!(outcome.counts.warnings > 0);
         let txt = String::from_utf8_lossy(&out);
         assert!(

--- a/crates/ghost-complete/src/validate.rs
+++ b/crates/ghost-complete/src/validate.rs
@@ -519,13 +519,13 @@ fn emit_json_summary(
     Ok(())
 }
 
-/// Entry point invoked by `main.rs`. Reads `--strict` and `--json` directly
-/// out of the process args (the top-level CLI parser only forwards a
-/// positional arg list to subcommands, mirroring the existing `--dry-run`
-/// handling for `install`).
-pub fn run_validate_specs(config_path: Option<&str>) -> Result<()> {
-    let strict = std::env::args().any(|a| a == "--strict");
-    let json = std::env::args().any(|a| a == "--json");
+/// Entry point invoked by `main.rs` after clap has parsed command-specific
+/// flags.
+pub fn run_validate_specs_with_opts(
+    config_path: Option<&str>,
+    strict: bool,
+    json: bool,
+) -> Result<()> {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
     let outcome = run_validate_specs_inner(config_path, strict, json, &mut handle)?;
@@ -665,13 +665,8 @@ mod tests {
 
     #[test]
     fn run_validate_specs_with_opts_accepts_typed_flags_without_env_scan() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let spec_dir = tmp.path().join("specs");
-        std::fs::create_dir_all(&spec_dir).unwrap();
-        write_spec(&spec_dir, "good.json", r#"{"name":"good"}"#);
-        let cfg = write_config_for(&spec_dir, &tmp);
-
-        run_validate_specs_with_opts(Some(cfg.to_str().unwrap()), false, true).unwrap();
+        let _entry: fn(Option<&str>, bool, bool) -> anyhow::Result<()> =
+            run_validate_specs_with_opts;
     }
 
     /// Sanity check that `validate_dir` writes to its sink rather than

--- a/crates/ghost-complete/tests/cli_help_routing.rs
+++ b/crates/ghost-complete/tests/cli_help_routing.rs
@@ -677,7 +677,15 @@ fn config_edit_attempts_tui_not_dump() {
 #[test]
 fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
     let tmp = isolated_home();
+    // Pin a supported terminal. CI runners leave `TERM_PROGRAM` unset, so
+    // `TerminalProfile::detect()` yields `Terminal::Unknown`, which routes
+    // `run_proxy` into the `multi_terminal`-gated exec-fallback (`execvp`,
+    // surfacing a bare `failed to exec shell: ... (os error 2)`) instead of
+    // the PTY proxy spawn path whose `failed to spawn shell process` signature
+    // this test fingerprints. Mirrors the `TERM_PROGRAM` pin in
+    // `tests/harness/mod.rs`.
     let output = cmd_with_isolated_home(tmp.path())
+        .env("TERM_PROGRAM", "ghostty")
         .arg("--")
         .arg("/tmp/ghost-complete-bogus-shell-does-not-exist/install")
         .arg("--some-flag")

--- a/crates/ghost-complete/tests/cli_help_routing.rs
+++ b/crates/ghost-complete/tests/cli_help_routing.rs
@@ -4,7 +4,7 @@
 mod harness;
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use harness::GhostProcess;
 use tempfile::TempDir;
@@ -189,4 +189,327 @@ fn external_subcommand_falls_back_to_proxy_mode() {
     proc.expect_output("proxy-works");
     let code = proc.exit_with_code(0);
     assert_eq!(code, 0, "expected proxy fallback shell to exit 0");
+}
+
+/// Write `config.toml` pointing at a single spec dir; return the cfg path.
+fn write_config_with_spec_dir(tmp: &TempDir, spec_dir: &Path) -> PathBuf {
+    let cfg = tmp.path().join("config.toml");
+    let body = format!(
+        "[paths]\nspec_dirs = [\"{}\"]\n",
+        spec_dir.display().to_string().replace('\\', "\\\\")
+    );
+    std::fs::write(&cfg, body).expect("write config.toml");
+    cfg
+}
+
+/// End-to-end regression guard: `validate-specs --strict` must flip the
+/// process exit code to non-zero when a generator warning is surfaced. The
+/// `run_validate_specs_inner` unit tests assert the inner logic in isolation;
+/// this test instead drives clap → `main.rs` routing → `run_validate_specs_with_opts`
+/// so that a future refactor which transposed `strict`/`json`, hard-coded
+/// `strict=false`, or dropped the flag during dispatch could not land
+/// silently.
+#[test]
+fn validate_specs_strict_flag_propagates_from_cli() {
+    let tmp = isolated_home();
+    let spec_dir = tmp.path().join("specs");
+    std::fs::create_dir_all(&spec_dir).unwrap();
+    // A spec with a doubled split transform — `validate_spec_generators`
+    // surfaces this as a warning but parsing succeeds, so non-strict exits
+    // 0 and strict exits 1.
+    std::fs::write(
+        spec_dir.join("bad.json"),
+        r#"{
+            "name": "bad",
+            "args": [{
+                "name": "x",
+                "generators": [
+                    {"script": ["cmd"], "transforms": ["split_lines", "split_lines"]}
+                ]
+            }]
+        }"#,
+    )
+    .unwrap();
+    let cfg = write_config_with_spec_dir(&tmp, &spec_dir);
+
+    // Non-strict: warnings present but exit code is 0.
+    let nonstrict = cmd_with_isolated_home(tmp.path())
+        .arg("--config")
+        .arg(&cfg)
+        .arg("validate-specs")
+        .output()
+        .unwrap();
+    assert!(
+        nonstrict.status.success(),
+        "non-strict validate-specs must exit 0 even when warnings present.\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&nonstrict.stdout),
+        String::from_utf8_lossy(&nonstrict.stderr),
+    );
+
+    // Strict: warnings must promote to non-zero exit.
+    let strict = cmd_with_isolated_home(tmp.path())
+        .arg("--config")
+        .arg(&cfg)
+        .arg("validate-specs")
+        .arg("--strict")
+        .output()
+        .unwrap();
+    assert!(
+        !strict.status.success(),
+        "validate-specs --strict must exit non-zero when warnings present, \
+         but got success exit. If this regressed, the clap-to-handler routing \
+         likely dropped or transposed the `strict` flag.\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&strict.stdout),
+        String::from_utf8_lossy(&strict.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&strict.stdout);
+    assert!(
+        stdout.contains("strict mode"),
+        "expected strict-mode banner in stdout to confirm strict path executed:\n{stdout}"
+    );
+}
+
+/// End-to-end regression guard: `status --strict` must flip the process
+/// exit code to non-zero when a spec file in the configured dir fails to
+/// parse. Mirrors `validate_specs_strict_flag_propagates_from_cli` for the
+/// sibling subcommand so a transposition of strict/json or a refactor that
+/// drops the flag during dispatch in `main.rs` cannot land silently.
+#[test]
+fn status_strict_flag_propagates_from_cli() {
+    let tmp = isolated_home();
+    let spec_dir = tmp.path().join("specs");
+    std::fs::create_dir_all(&spec_dir).unwrap();
+    // An obviously broken JSON file — status's lazy parse surfaces it as a
+    // parse error, which strict promotes to a non-zero exit.
+    std::fs::write(spec_dir.join("broken.json"), "{not valid json").unwrap();
+    let cfg = write_config_with_spec_dir(&tmp, &spec_dir);
+
+    // Non-strict: parse errors logged but exit code is 0.
+    let nonstrict = cmd_with_isolated_home(tmp.path())
+        .arg("--config")
+        .arg(&cfg)
+        .arg("status")
+        .output()
+        .unwrap();
+    assert!(
+        nonstrict.status.success(),
+        "non-strict status must exit 0 even when parse errors present.\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&nonstrict.stdout),
+        String::from_utf8_lossy(&nonstrict.stderr),
+    );
+
+    // Strict: parse error must promote to non-zero exit.
+    let strict = cmd_with_isolated_home(tmp.path())
+        .arg("--config")
+        .arg(&cfg)
+        .arg("status")
+        .arg("--strict")
+        .output()
+        .unwrap();
+    assert!(
+        !strict.status.success(),
+        "status --strict must exit non-zero on parse errors, but got success. \
+         If this regressed, the clap-to-handler routing likely dropped or \
+         transposed the `strict` flag.\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&strict.stdout),
+        String::from_utf8_lossy(&strict.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&strict.stdout);
+    assert!(
+        stdout.contains("strict mode"),
+        "expected strict-mode banner in stdout to confirm strict path executed:\n{stdout}"
+    );
+}
+
+/// `config edit` must route to the interactive TUI path, not to the
+/// read-only `config` dump path. With stdin forced to `Stdio::null()`,
+/// `enable_raw_mode()` (in the TUI entry) fails fast in a non-TTY
+/// environment and the process exits non-zero — meanwhile, stdout must NOT
+/// contain the TOML-section markers (`[trigger]`, `[popup]`) that the
+/// `config` dump emits. If a future refactor accidentally re-routes
+/// `config edit` to `config_cmd::run_config` (the dump arm), this test
+/// catches it.
+#[test]
+fn config_edit_attempts_tui_not_dump() {
+    let tmp = isolated_home();
+    // Use a non-existent config path so that `config` dump would deliberately
+    // fall through to the "showing defaults" branch and print recognisable
+    // TOML section markers. If `config edit` ever silently fell back to the
+    // dump path, those markers would appear on stdout — the assertion
+    // below pins that they must not.
+    let missing_cfg = tmp.path().join("nonexistent-config.toml");
+
+    let output = cmd_with_isolated_home(tmp.path())
+        .arg("--config")
+        .arg(&missing_cfg)
+        .arg("config")
+        .arg("edit")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "`config edit` with stdin=null must fail TUI init (not silently dump). \
+         If this exited 0, the routing likely fell through to `run_config`.\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The `config` dump fallback emits `# No config file found; showing
+    // defaults.` followed by `[trigger]` and `[popup]` section headers.
+    // Their presence in stdout means the wrong arm ran.
+    assert!(
+        !stdout.contains("[trigger]"),
+        "`config edit` stdout must NOT contain `[trigger]` (a `config` dump marker). \
+         Routing regressed: `Config edit` fell through to the dump path.\n\
+         stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("[popup]"),
+        "`config edit` stdout must NOT contain `[popup]` (a `config` dump marker). \
+         Routing regressed: `Config edit` fell through to the dump path.\n\
+         stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("showing defaults"),
+        "`config edit` stdout must NOT contain the `config` dump's fallback banner. \
+         Routing regressed: `Config edit` fell through to the dump path.\n\
+         stdout:\n{stdout}"
+    );
+}
+
+/// Verifies the documented `--` escape hatch in `after_help` (a user whose
+/// shell binary is named like a subcommand can prefix with `--`). The
+/// invocation must route through the `External(Vec<String>)` arm and try to
+/// spawn the binary — failing with a spawn-error message — rather than
+/// produce a clap-level "unrecognized subcommand" / "unknown argument"
+/// error. If clap stopped honouring `--` for `external_subcommand` (or the
+/// arm was deleted), this test fails and signals that the after_help advice
+/// is misleading.
+#[test]
+fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
+    let tmp = isolated_home();
+    let output = cmd_with_isolated_home(tmp.path())
+        .arg("--")
+        .arg("/tmp/ghost-complete-bogus-shell-does-not-exist/install")
+        .arg("--some-flag")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "spawning a non-existent shell must fail with non-zero exit.\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // clap's "unrecognized subcommand" / "unknown argument" / "for more
+    // information, try '--help'" wording must NOT appear — those signal
+    // the `External` arm did not catch the routing and clap rejected the
+    // input at parse time.
+    let clap_signatures = [
+        "unrecognized subcommand",
+        "error: unrecognized",
+        "for more information, try",
+    ];
+    for sig in &clap_signatures {
+        assert!(
+            !stderr.to_lowercase().contains(&sig.to_lowercase()),
+            "stderr must not contain clap-level `{sig}` — the `--` escape \
+             hatch should route past clap into the External arm.\n\
+             stderr:\n{stderr}"
+        );
+    }
+    // Positive signal: the spawn-failure path (the External arm running
+    // run_proxy) mentions the bogus path somewhere in the error chain.
+    // We accept either stderr or stdout because the proxy may surface the
+    // error on either depending on logging config.
+    let combined = format!("{}\n{}", String::from_utf8_lossy(&output.stdout), stderr);
+    assert!(
+        combined.contains("ghost-complete-bogus-shell-does-not-exist")
+            || combined.to_lowercase().contains("spawn")
+            || combined.to_lowercase().contains("doesn't exist"),
+        "expected spawn-failure signature mentioning the bogus binary path; \
+         instead got:\n{combined}"
+    );
+}
+
+/// Pins the `None => run_proxy(..., Vec::new())` routing arm in `main.rs`.
+/// Invokes ghost-complete with NO positional argv and no subcommand. The
+/// proxy reads `$SHELL` via `resolve_default_shell()`, logs `"starting
+/// ghost-complete proxy"` with that shell, then bails when `enable_raw_mode`
+/// fails (stdin/stdout are not a TTY because we route them through
+/// `Stdio::piped`). The log file is the deterministic signal: if the `None`
+/// arm regressed (e.g. swapped with `External`, hard-coded a different
+/// shell, or panicked), the recorded `shell=` line would not match the
+/// $SHELL value we set — or the log would be empty because tracing never
+/// initialised.
+///
+/// Avoids the PTY harness intentionally — the PTY-backed harness always
+/// passes a positional `/bin/sh`, which exercises only the `External(...)`
+/// arm. This test fills the gap for the None arm without touching the
+/// harness module.
+#[test]
+fn proxy_with_no_args_uses_default_shell_from_env() {
+    let tmp = isolated_home();
+    let log_file = tmp.path().join("ghost.log");
+    // Pick a recognisable shell path that differs from the host's $SHELL —
+    // the assertion below checks this exact string appears in the log so
+    // we know the None arm consulted $SHELL rather than a hard-coded
+    // fallback.
+    let marker_shell = "/tmp/ghost-complete-none-arm-marker-shell";
+
+    let output = cmd_with_isolated_home(tmp.path())
+        .env("SHELL", marker_shell)
+        .arg("--log-level")
+        .arg("info")
+        .arg("--log-file")
+        .arg(&log_file)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    // Process exits non-zero because raw mode fails outside a TTY; this is
+    // expected and indicates the None arm reached `run_proxy`. (A 0 exit
+    // here would suggest a different code path ran — for example, a
+    // refactor that turned the None arm into a no-op.)
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit from proxy when stdin is not a TTY (raw-mode \
+         init fails), got success. The None routing arm likely regressed.\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // The log file must record the proxy starting with our marker shell —
+    // proving the None arm ran `resolve_default_shell` and called
+    // `run_proxy` with the result.
+    let log_contents = std::fs::read_to_string(&log_file)
+        .unwrap_or_else(|e| panic!("log file at {} unreadable: {e}", log_file.display()));
+    assert!(
+        log_contents.contains("starting ghost-complete proxy"),
+        "log must record the proxy startup line — proves the None arm \
+         reached run_proxy.\nlog contents:\n{log_contents}"
+    );
+    assert!(
+        log_contents.contains(marker_shell),
+        "log must mention `shell={marker_shell}` — proves the None arm \
+         resolved $SHELL via resolve_default_shell rather than using \
+         a hard-coded fallback or routing to the wrong arm.\n\
+         log contents:\n{log_contents}"
+    );
 }

--- a/crates/ghost-complete/tests/cli_help_routing.rs
+++ b/crates/ghost-complete/tests/cli_help_routing.rs
@@ -666,28 +666,38 @@ fn config_edit_attempts_tui_not_dump() {
     );
 }
 
-/// Verifies the documented `--` escape hatch in `after_help` (a user whose
-/// shell binary is named like a subcommand can prefix with `--`). The
-/// invocation must route through the `External(Vec<String>)` arm and try to
-/// spawn the binary — failing with a spawn-error message — rather than
-/// produce a clap-level "unrecognized subcommand" / "unknown argument"
-/// error. If clap stopped honouring `--` for `external_subcommand` (or the
-/// arm was deleted), this test fails and signals that the after_help advice
-/// is misleading.
+/// Verifies the documented `--` escape hatch from `after_help`: argv after
+/// `--` must route through the `External(Vec<OsString>)` arm into proxy
+/// mode rather than trip a clap-level "unrecognized subcommand" / "unknown
+/// argument" error. If clap stopped honouring `--` for `external_subcommand`
+/// (or the arm was deleted), this test fails and signals that the
+/// `after_help` advice is misleading.
+///
+/// The positive signal is the `--log-file` log, not the process's
+/// stdout/stderr: `run_proxy` records `starting ghost-complete proxy` with
+/// `shell=<argv[0]>` before handing off to `gc_pty::run_proxy`, so it is
+/// captured no matter where the proxy later bails. Asserting on the
+/// spawn-failure *message* instead would be environment dependent —
+/// `gc_pty`'s `spawn_shell` queries the terminal size before spawning, and
+/// `crossterm`'s size query fails on a headless CI runner (`ioctl` has no
+/// tty, `tput` has no `$TERM`), so the proxy bails with `failed to query
+/// terminal size` long before it reaches the spawn. Mirrors the log-based
+/// signal in `proxy_with_no_args_uses_default_shell_from_env`.
 #[test]
 fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
     let tmp = isolated_home();
-    // Pin a supported terminal. CI runners leave `TERM_PROGRAM` unset, so
-    // `TerminalProfile::detect()` yields `Terminal::Unknown`, which routes
-    // `run_proxy` into the `multi_terminal`-gated exec-fallback (`execvp`,
-    // surfacing a bare `failed to exec shell: ... (os error 2)`) instead of
-    // the PTY proxy spawn path whose `failed to spawn shell process` signature
-    // this test fingerprints. Mirrors the `TERM_PROGRAM` pin in
-    // `tests/harness/mod.rs`.
+    let log_file = tmp.path().join("escape.log");
+    // A path that cannot exist on the filesystem; its final component
+    // (`install`) echoes the `after_help` example `ghost-complete -- install`.
+    let bogus_shell = "/tmp/ghost-complete-bogus-shell-does-not-exist/install";
+
     let output = cmd_with_isolated_home(tmp.path())
-        .env("TERM_PROGRAM", "ghostty")
+        .arg("--log-level")
+        .arg("info")
+        .arg("--log-file")
+        .arg(&log_file)
         .arg("--")
-        .arg("/tmp/ghost-complete-bogus-shell-does-not-exist/install")
+        .arg(bogus_shell)
         .arg("--some-flag")
         .output()
         .unwrap();
@@ -700,11 +710,11 @@ fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
         String::from_utf8_lossy(&output.stderr),
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
     // clap's "unrecognized subcommand" / "unknown argument" / "for more
-    // information, try '--help'" wording must NOT appear — those signal
-    // the `External` arm did not catch the routing and clap rejected the
-    // input at parse time.
+    // information, try '--help'" wording must NOT appear — those signal the
+    // `External` arm did not catch the routing and clap rejected the input
+    // at parse time.
+    let stderr = String::from_utf8_lossy(&output.stderr);
     let clap_signatures = [
         "unrecognized subcommand",
         "error: unrecognized",
@@ -718,17 +728,24 @@ fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
              stderr:\n{stderr}"
         );
     }
-    // Positive signal: the spawn-failure path (the External arm running
-    // run_proxy) mentions the bogus path somewhere in the error chain.
-    // We accept either stderr or stdout because the proxy may surface the
-    // error on either depending on logging config.
-    let combined = format!("{}\n{}", String::from_utf8_lossy(&output.stdout), stderr);
+
+    // Positive signal: the `External` arm reached `run_proxy`, which logs
+    // `starting ghost-complete proxy` with `shell=<argv[0]>`. Both strings
+    // present proves the `--`-escaped argv was forwarded into proxy mode as
+    // the shell rather than being rejected by clap at parse time. Reading
+    // the log keeps the assertion independent of the headless-CI
+    // terminal-size failure described above.
+    let log = std::fs::read_to_string(&log_file)
+        .unwrap_or_else(|e| panic!("log file at {} unreadable: {e}", log_file.display()));
     assert!(
-        combined.contains("ghost-complete-bogus-shell-does-not-exist")
-            || combined.to_lowercase().contains("spawn")
-            || combined.to_lowercase().contains("doesn't exist"),
-        "expected spawn-failure signature mentioning the bogus binary path; \
-         instead got:\n{combined}"
+        log.contains("starting ghost-complete proxy"),
+        "log must record the proxy startup line — proves the `--` escape \
+         routed into the External arm and reached run_proxy.\nlog:\n{log}"
+    );
+    assert!(
+        log.contains(bogus_shell),
+        "log must record `shell={bogus_shell}` — proves the `--`-escaped \
+         argv[0] became the proxy's shell.\nlog:\n{log}"
     );
 }
 

--- a/crates/ghost-complete/tests/cli_help_routing.rs
+++ b/crates/ghost-complete/tests/cli_help_routing.rs
@@ -674,9 +674,11 @@ fn config_edit_attempts_tui_not_dump() {
 /// if clap ever stops honouring `--` for `external_subcommand` (the case
 /// that would make the `after_help` advice misleading).
 ///
-/// The escape token is `validate-specs`: a registered subcommand name, so
-/// `--` is load-bearing rather than decorative, and one no real `$PATH`
-/// binary can shadow, so the proxy's spawn fails fast.
+/// The escape token is `validate-specs`, a registered subcommand name, so
+/// `--` is load-bearing rather than decorative. The positive case pins
+/// `$PATH` to an empty directory and drops `RUST_LOG`, so neither the
+/// proxy's shell lookup nor the log filter depends on the test runner's
+/// environment.
 ///
 /// The positive signal is the `--log-file` log, not the process's
 /// stdout/stderr. `run_proxy` records `starting ghost-complete proxy` with
@@ -690,15 +692,23 @@ fn config_edit_attempts_tui_not_dump() {
 /// log-based signal in `proxy_with_no_args_uses_default_shell_from_env`.
 #[test]
 fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
-    // A registered subcommand name (`Command::ValidateSpecs`) that no real
-    // `$PATH` binary can shadow.
+    // A registered subcommand name (`Command::ValidateSpecs`).
     let escape_token = "validate-specs";
 
     // With `--`: clap must route `validate-specs` through the External arm
     // so it becomes the proxy's shell.
     let tmp = isolated_home();
     let log_file = tmp.path().join("escape.log");
+    // Pin the environment so this case is deterministic regardless of the
+    // test runner: `$PATH` is an empty dir, so the proxy's lookup of
+    // `validate-specs` always fails (no binary by that name can be found on
+    // it); and `RUST_LOG` is dropped, so `--log-level info` — not an
+    // inherited filter — governs whether the startup line is recorded.
+    let empty_path = tmp.path().join("no-bin");
+    std::fs::create_dir_all(&empty_path).expect("create empty PATH dir");
     let escaped = cmd_with_isolated_home(tmp.path())
+        .env("PATH", &empty_path)
+        .env_remove("RUST_LOG")
         .arg("--log-level")
         .arg("info")
         .arg("--log-file")

--- a/crates/ghost-complete/tests/cli_help_routing.rs
+++ b/crates/ghost-complete/tests/cli_help_routing.rs
@@ -38,7 +38,10 @@ fn assert_success(output: &std::process::Output, context: &str) {
 #[test]
 fn top_level_help_lists_real_subcommands() {
     let tmp = isolated_home();
-    let output = cmd_with_isolated_home(tmp.path()).arg("--help").output().unwrap();
+    let output = cmd_with_isolated_home(tmp.path())
+        .arg("--help")
+        .output()
+        .unwrap();
 
     assert_success(&output, "top-level --help");
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/crates/ghost-complete/tests/cli_help_routing.rs
+++ b/crates/ghost-complete/tests/cli_help_routing.rs
@@ -1,0 +1,189 @@
+//! CLI parsing and routing coverage for real clap subcommands.
+
+#[allow(dead_code)]
+mod harness;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use harness::GhostProcess;
+use tempfile::TempDir;
+
+fn ghost_bin() -> PathBuf {
+    env!("CARGO_BIN_EXE_ghost-complete").into()
+}
+
+fn isolated_home() -> TempDir {
+    TempDir::new().expect("tempdir")
+}
+
+fn cmd_with_isolated_home(home: &Path) -> Command {
+    let mut cmd = Command::new(ghost_bin());
+    cmd.env("HOME", home)
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("XDG_STATE_HOME");
+    cmd
+}
+
+fn assert_success(output: &std::process::Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context} failed with {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn top_level_help_lists_real_subcommands() {
+    let tmp = isolated_home();
+    let output = cmd_with_isolated_home(tmp.path()).arg("--help").output().unwrap();
+
+    assert_success(&output, "top-level --help");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for subcommand in [
+        "install",
+        "uninstall",
+        "status",
+        "validate-specs",
+        "config",
+        "doctor",
+    ] {
+        assert!(
+            stdout.contains(subcommand),
+            "top-level --help missing {subcommand}; got:\n{stdout}",
+        );
+    }
+}
+
+#[test]
+fn real_subcommand_help_exits_zero_and_lists_flags() {
+    let cases: &[(&[&str], &[&str])] = &[
+        (&["install"], &["--dry-run"]),
+        (&["uninstall"], &[]),
+        (&["status"], &["--strict", "--json", "--baseline"]),
+        (&["validate-specs"], &["--strict", "--json"]),
+        (&["config"], &["edit"]),
+        (&["config", "edit"], &[]),
+        (&["doctor"], &[]),
+    ];
+
+    for (argv, expected) in cases {
+        let tmp = isolated_home();
+        let output = cmd_with_isolated_home(tmp.path())
+            .args(*argv)
+            .arg("--help")
+            .output()
+            .unwrap();
+
+        assert_success(&output, &format!("{argv:?} --help"));
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for needle in *expected {
+            assert!(
+                stdout.contains(needle),
+                "{argv:?} --help missing {needle}; got:\n{stdout}",
+            );
+        }
+    }
+}
+
+#[test]
+fn status_baseline_without_value_fails_at_parse_time() {
+    let tmp = isolated_home();
+    let output = cmd_with_isolated_home(tmp.path())
+        .arg("status")
+        .arg("--baseline")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "bare --baseline must error");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--baseline") && (stderr.contains("value") || stderr.contains("required")),
+        "expected clap missing-value error; got:\n{stderr}",
+    );
+}
+
+#[test]
+fn unknown_flag_on_real_subcommand_fails() {
+    let tmp = isolated_home();
+    let output = cmd_with_isolated_home(tmp.path())
+        .arg("status")
+        .arg("--this-flag-does-not-exist")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "unknown flag must error");
+}
+
+#[test]
+fn globals_parse_before_each_real_subcommand() {
+    let cases: &[&[&str]] = &[
+        &["install"],
+        &["uninstall"],
+        &["status"],
+        &["validate-specs"],
+        &["config"],
+        &["config", "edit"],
+        &["doctor"],
+    ];
+
+    for argv in cases {
+        let tmp = isolated_home();
+        let log_file = tmp.path().join("gc.log");
+        let output = cmd_with_isolated_home(tmp.path())
+            .arg("--config")
+            .arg("/nonexistent/ghost-complete.toml")
+            .arg("--log-level")
+            .arg("debug")
+            .arg("--log-file")
+            .arg(&log_file)
+            .args(*argv)
+            .arg("--help")
+            .output()
+            .unwrap();
+
+        assert_success(&output, &format!("globals before {argv:?}"));
+    }
+}
+
+#[test]
+fn globals_parse_after_each_real_subcommand() {
+    let cases: &[&[&str]] = &[
+        &["install"],
+        &["uninstall"],
+        &["status"],
+        &["validate-specs"],
+        &["config"],
+        &["config", "edit"],
+        &["doctor"],
+    ];
+
+    for argv in cases {
+        let tmp = isolated_home();
+        let log_file = tmp.path().join("gc.log");
+        let output = cmd_with_isolated_home(tmp.path())
+            .args(*argv)
+            .arg("--config")
+            .arg("/nonexistent/ghost-complete.toml")
+            .arg("--log-level")
+            .arg("debug")
+            .arg("--log-file")
+            .arg(&log_file)
+            .arg("--help")
+            .output()
+            .unwrap();
+
+        assert_success(&output, &format!("globals after {argv:?}"));
+    }
+}
+
+#[test]
+fn external_subcommand_falls_back_to_proxy_mode() {
+    let mut proc = GhostProcess::spawn();
+    proc.send_line("echo proxy-works");
+    proc.expect_output("proxy-works");
+    let code = proc.exit_with_code(0);
+    assert_eq!(code, 0, "expected proxy fallback shell to exit 0");
+}

--- a/crates/ghost-complete/tests/cli_help_routing.rs
+++ b/crates/ghost-complete/tests/cli_help_routing.rs
@@ -369,6 +369,166 @@ fn status_strict_flag_propagates_from_cli() {
     );
 }
 
+/// End-to-end regression guard: `status --json` must route through the JSON
+/// formatter (`run_status_json`) rather than the text formatter. The sibling
+/// `strict` flag is already covered by `status_strict_flag_propagates_from_cli`;
+/// this is the symmetric `json` flag test. A refactor that transposed
+/// `(strict, json)` or hard-coded `json=false` during dispatch in `main.rs`
+/// would silently regress users to the text formatter — but both existing
+/// strict tests would still pass. Parsing stdout as a JSON object and pinning
+/// the `schema_version` key catches that regression.
+#[test]
+fn status_json_flag_propagates_from_cli() {
+    let tmp = isolated_home();
+    let spec_dir = tmp.path().join("specs");
+    std::fs::create_dir_all(&spec_dir).unwrap();
+    let cfg = write_config_with_spec_dir(&tmp, &spec_dir);
+
+    let output = cmd_with_isolated_home(tmp.path())
+        .arg("--config")
+        .arg(&cfg)
+        .arg("status")
+        .arg("--json")
+        .output()
+        .unwrap();
+
+    assert_success(&output, "status --json");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The JSON formatter emits a single pretty-printed JSON object followed
+    // by a trailing newline. If `--json` did not reach the handler, the text
+    // formatter would have run and stdout would not parse as JSON.
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "`status --json` stdout must parse as a JSON object — the `json` \
+             flag was dropped during routing if this fails. parse error: {e}\n\
+             stdout:\n{stdout}"
+        )
+    });
+    assert!(
+        parsed.is_object(),
+        "expected a JSON object at the top level, got: {parsed}"
+    );
+    assert!(
+        parsed.get("schema_version").is_some(),
+        "expected `schema_version` key from run_status_json — its absence \
+         means the text formatter ran instead of the JSON formatter.\n\
+         parsed:\n{parsed}"
+    );
+    // Pin a second well-known key for defense-in-depth: a malformed
+    // alternative formatter producing `{}` would otherwise satisfy the
+    // `schema_version` check above only after a deliberate sabotage.
+    assert!(
+        parsed.get("spec_counts").is_some(),
+        "expected `spec_counts` key from run_status_json — its absence \
+         suggests the JSON shape regressed or a different formatter ran.\n\
+         parsed:\n{parsed}"
+    );
+}
+
+/// End-to-end regression guard: `validate-specs --json` must route through
+/// the NDJSON formatter rather than the text formatter. Mirrors
+/// `status_json_flag_propagates_from_cli` for the sibling subcommand. A
+/// refactor that hard-coded `json=false` or transposed `(strict, json)` in
+/// `main.rs` dispatch would silently regress users to the text formatter —
+/// the existing strict tests would still pass.
+///
+/// The validate output is NDJSON (one JSON object per line) — one row per
+/// spec plus a trailing `{"summary":{...}}` row.
+#[test]
+fn validate_specs_json_flag_propagates_from_cli() {
+    let tmp = isolated_home();
+    let spec_dir = tmp.path().join("specs");
+    std::fs::create_dir_all(&spec_dir).unwrap();
+    // A trivially well-formed spec produces one `{"spec_name":..., "ok":true}`
+    // row in NDJSON mode, plus the trailing summary row.
+    std::fs::write(spec_dir.join("ok.json"), r#"{"name":"ok"}"#).unwrap();
+    let cfg = write_config_with_spec_dir(&tmp, &spec_dir);
+
+    let output = cmd_with_isolated_home(tmp.path())
+        .arg("--config")
+        .arg(&cfg)
+        .arg("validate-specs")
+        .arg("--json")
+        .output()
+        .unwrap();
+
+    assert_success(&output, "validate-specs --json");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // NDJSON: split on lines, skip empties, parse each as a JSON object.
+    let rows: Vec<serde_json::Value> = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(|l| {
+            serde_json::from_str(l).unwrap_or_else(|e| {
+                panic!(
+                    "`validate-specs --json` line must parse as JSON — the \
+                     `json` flag was dropped during routing if this fails. \
+                     line: {l:?}\nparse error: {e}\nstdout:\n{stdout}"
+                )
+            })
+        })
+        .collect();
+
+    assert!(
+        !rows.is_empty(),
+        "expected at least one NDJSON row from validate-specs --json; got \
+         empty stdout. The `json` flag likely did not reach the handler.\n\
+         stdout:\n{stdout}"
+    );
+
+    // A per-spec row carries `spec_name`; the trailing row carries `summary`.
+    let per_spec_rows: Vec<&serde_json::Value> = rows
+        .iter()
+        .filter(|r| r.get("spec_name").is_some())
+        .collect();
+    let summary_rows: Vec<&serde_json::Value> =
+        rows.iter().filter(|r| r.get("summary").is_some()).collect();
+
+    assert_eq!(
+        per_spec_rows.len(),
+        1,
+        "expected exactly one per-spec NDJSON row for our `ok.json` spec; \
+         got {}. rows:\n{rows:#?}",
+        per_spec_rows.len()
+    );
+    assert_eq!(
+        summary_rows.len(),
+        1,
+        "expected exactly one trailing summary NDJSON row; got {}. If this \
+         is 0, the text formatter ran instead of the JSON formatter.\n\
+         rows:\n{rows:#?}",
+        summary_rows.len()
+    );
+
+    // Pin the per-spec row shape — proves `emit_json_spec` ran with the
+    // expected fields rather than e.g. an arbitrary alternative formatter
+    // emitting JSON-shaped but mislabeled output.
+    let spec_row = per_spec_rows[0];
+    assert_eq!(
+        spec_row["ok"],
+        serde_json::Value::Bool(true),
+        "expected ok=true for a well-formed spec; got row:\n{spec_row}"
+    );
+    assert!(
+        spec_row.get("divergences").is_some() && spec_row.get("warnings").is_some(),
+        "expected `divergences` and `warnings` keys on the per-spec row — \
+         their absence means the wrong formatter ran.\nrow:\n{spec_row}"
+    );
+
+    // Defense-in-depth: the text formatter emits a `Validating specs in ...`
+    // banner before any per-spec output. Its absence is an independent
+    // signal that the JSON path ran.
+    assert!(
+        !stdout.contains("Validating specs in"),
+        "`validate-specs --json` stdout must NOT contain the text formatter's \
+         `Validating specs in` banner. Routing regressed: --json fell through \
+         to the text formatter.\nstdout:\n{stdout}"
+    );
+}
+
 /// End-to-end regression guard for the `--baseline <path>` positive path:
 /// the parsed `Option<PathBuf>` must reach `status::run_status_with_opts`
 /// as `baseline.as_deref()`. The existing

--- a/crates/ghost-complete/tests/cli_help_routing.rs
+++ b/crates/ghost-complete/tests/cli_help_routing.rs
@@ -108,6 +108,50 @@ fn status_baseline_without_value_fails_at_parse_time() {
     );
 }
 
+/// Pins clap's `ValueEnum` rejection of typo'd `--log-level` values at the
+/// parse boundary. The `LogLevel` enum was introduced specifically so a
+/// typo like `--log-level deubg` errors out instead of silently being
+/// rewritten to `warn` inside `init_tracing`. If a future refactor reverted
+/// the field to `log_level: String` (or dropped `value_enum` /
+/// `default_value_t`), the rejection would silently disappear and the
+/// silent-rewrite-to-warn behavior would return — this test fails loudly
+/// in that scenario.
+#[test]
+fn invalid_log_level_rejected_at_parse_time() {
+    let tmp = isolated_home();
+    let output = cmd_with_isolated_home(tmp.path())
+        .arg("--log-level")
+        .arg("deubg")
+        .arg("status")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "typo'd --log-level must error at parse time; got success.\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--log-level") && stderr.contains("invalid value"),
+        "expected clap ValueEnum rejection mentioning `--log-level` and \
+         `invalid value`. If this regressed, the `LogLevel` enum was likely \
+         reverted to a free-form `String`, restoring the silent-rewrite-to-warn \
+         fallback in init_tracing.\nstderr:\n{stderr}"
+    );
+    // Sanity check that clap is suggesting one of the legal values — pins
+    // the `[possible values: ...]` rendering that ValueEnum produces.
+    assert!(
+        stderr.contains("possible values") || stderr.contains("debug"),
+        "expected clap to surface `possible values` or a typo suggestion. \
+         Its absence suggests the ValueEnum derive was dropped.\n\
+         stderr:\n{stderr}"
+    );
+}
+
 #[test]
 fn unknown_flag_on_real_subcommand_fails() {
     let tmp = isolated_home();
@@ -325,6 +369,66 @@ fn status_strict_flag_propagates_from_cli() {
     );
 }
 
+/// End-to-end regression guard for the `--baseline <path>` positive path:
+/// the parsed `Option<PathBuf>` must reach `status::run_status_with_opts`
+/// as `baseline.as_deref()`. The existing
+/// `status_baseline_without_value_fails_at_parse_time` covers the bare
+/// `--baseline` negative case at parse time, but no test confirms a value
+/// is actually forwarded through clap → `main.rs` dispatch → the status
+/// handler. If a regression hard-coded `baseline.as_deref()` to `None`
+/// (e.g. a refactor accidentally dropping the destructure binding),
+/// `--baseline /missing.json` would silently fall through to the embedded
+/// baseline lookup instead of erroring with the authoritative
+/// `baseline file does not exist` message at status.rs:166. This test
+/// pins that contract end-to-end.
+#[test]
+fn status_baseline_path_propagates_from_cli() {
+    let tmp = isolated_home();
+    let missing_baseline = tmp.path().join("nonexistent-baseline.json");
+    assert!(
+        !missing_baseline.exists(),
+        "preconditions: baseline path must not exist for this test to be meaningful"
+    );
+
+    let output = cmd_with_isolated_home(tmp.path())
+        .arg("status")
+        .arg("--baseline")
+        .arg(&missing_baseline)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "`status --baseline <missing>` must exit non-zero — load_baseline \
+         must surface the missing path as an error. If this exited 0, the \
+         parsed PathBuf likely never reached run_status_with_opts \
+         (`baseline.as_deref()` was dropped or hard-coded to None).\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+    assert!(
+        combined.contains("baseline file does not exist"),
+        "expected the authoritative `baseline file does not exist` bail \
+         message (status.rs:166) — its absence means the explicit-baseline \
+         arm of load_baseline was not reached and the CLI value was \
+         silently dropped during routing.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    // Also pin that the error references the path we supplied, ruling out
+    // a routing arm that pointed load_baseline at a different (stale) value.
+    assert!(
+        combined.contains("nonexistent-baseline.json"),
+        "expected the error to mention our supplied baseline path. Its \
+         absence means the parsed value was dropped or replaced by a \
+         different path before reaching load_baseline.\n\
+         stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
 /// `config edit` must route to the interactive TUI path, not to the
 /// read-only `config` dump path. With stdin forced to `Stdio::null()`,
 /// `enable_raw_mode()` (in the TUI entry) fails fast in a non-TTY
@@ -384,6 +488,21 @@ fn config_edit_attempts_tui_not_dump() {
         "`config edit` stdout must NOT contain the `config` dump's fallback banner. \
          Routing regressed: `Config edit` fell through to the dump path.\n\
          stdout:\n{stdout}"
+    );
+
+    // Positive TUI-arm signal: with stdin=null and stdout=piped, the TUI's
+    // `enable_raw_mode()` fails with a recognisable error chain
+    // (`failed to enable raw mode\n\nCaused by:\n    Device not
+    // configured`). Pinning this stderr fingerprint closes the gap where a
+    // refactor could re-route `Config { subcommand: Some(Edit) }` to an
+    // arbitrary wrong arm (e.g. `doctor::run_doctor`) whose non-zero exit
+    // and absence of dump markers would otherwise pass silently.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("raw mode") || stderr.contains("raw_mode"),
+        "expected TUI-init failure signature (`raw mode`) in stderr — its \
+         absence suggests `config edit` did not route to the TUI arm.\n\
+         stderr:\n{stderr}"
     );
 }
 
@@ -449,11 +568,12 @@ fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
 /// Invokes ghost-complete with NO positional argv and no subcommand. The
 /// proxy reads `$SHELL` via `resolve_default_shell()`, logs `"starting
 /// ghost-complete proxy"` with that shell, then bails when `enable_raw_mode`
-/// fails (stdin/stdout are not a TTY because we route them through
-/// `Stdio::piped`). The log file is the deterministic signal: if the `None`
-/// arm regressed (e.g. swapped with `External`, hard-coded a different
-/// shell, or panicked), the recorded `shell=` line would not match the
-/// $SHELL value we set — or the log would be empty because tracing never
+/// fails (stdin is routed through `Stdio::null()` and stdout/stderr through
+/// `Stdio::piped()` — none of them is a TTY, so `enable_raw_mode` fails
+/// fast). The log file is the deterministic signal: if the `None` arm
+/// regressed (e.g. swapped with `External`, hard-coded a different shell,
+/// or panicked), the recorded `shell=` line would not match the $SHELL
+/// value we set — or the log would be empty because tracing never
 /// initialised.
 ///
 /// Avoids the PTY harness intentionally — the PTY-backed harness always

--- a/crates/ghost-complete/tests/cli_help_routing.rs
+++ b/crates/ghost-complete/tests/cli_help_routing.rs
@@ -666,55 +666,62 @@ fn config_edit_attempts_tui_not_dump() {
     );
 }
 
-/// Verifies the documented `--` escape hatch from `after_help`: argv after
-/// `--` must route through the `External(Vec<OsString>)` arm into proxy
-/// mode rather than trip a clap-level "unrecognized subcommand" / "unknown
-/// argument" error. If clap stopped honouring `--` for `external_subcommand`
-/// (or the arm was deleted), this test fails and signals that the
-/// `after_help` advice is misleading.
+/// Verifies the documented `--` escape hatch from `after_help`: a shell
+/// binary whose name collides with a real subcommand can still be launched
+/// by prefixing `--`. The test drives both halves — with `--`, clap must
+/// route the name through the `External(Vec<OsString>)` arm into proxy
+/// mode; without `--`, clap must claim it as that subcommand — so it fails
+/// if clap ever stops honouring `--` for `external_subcommand` (the case
+/// that would make the `after_help` advice misleading).
+///
+/// The escape token is `validate-specs`: a registered subcommand name, so
+/// `--` is load-bearing rather than decorative, and one no real `$PATH`
+/// binary can shadow, so the proxy's spawn fails fast.
 ///
 /// The positive signal is the `--log-file` log, not the process's
-/// stdout/stderr: `run_proxy` records `starting ghost-complete proxy` with
-/// `shell=<argv[0]>` before handing off to `gc_pty::run_proxy`, so it is
-/// captured no matter where the proxy later bails. Asserting on the
-/// spawn-failure *message* instead would be environment dependent —
-/// `gc_pty`'s `spawn_shell` queries the terminal size before spawning, and
-/// `crossterm`'s size query fails on a headless CI runner (`ioctl` has no
-/// tty, `tput` has no `$TERM`), so the proxy bails with `failed to query
-/// terminal size` long before it reaches the spawn. Mirrors the log-based
-/// signal in `proxy_with_no_args_uses_default_shell_from_env`.
+/// stdout/stderr. `run_proxy` records `starting ghost-complete proxy` with
+/// `shell=<argv[0]>` before handing off to `gc_pty::run_proxy` — before any
+/// terminal detection or terminal I/O — so it is captured wherever the
+/// proxy later bails. The proxy's failure *message* is environment
+/// dependent (`failed to spawn shell process` / `failed to exec shell` /
+/// `failed to query terminal size`, depending on terminal detection and
+/// whether `crossterm` can size a headless runner), so asserting on it
+/// would re-couple this routing test to terminal state. Mirrors the
+/// log-based signal in `proxy_with_no_args_uses_default_shell_from_env`.
 #[test]
 fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
+    // A registered subcommand name (`Command::ValidateSpecs`) that no real
+    // `$PATH` binary can shadow.
+    let escape_token = "validate-specs";
+
+    // With `--`: clap must route `validate-specs` through the External arm
+    // so it becomes the proxy's shell.
     let tmp = isolated_home();
     let log_file = tmp.path().join("escape.log");
-    // A path that cannot exist on the filesystem; its final component
-    // (`install`) echoes the `after_help` example `ghost-complete -- install`.
-    let bogus_shell = "/tmp/ghost-complete-bogus-shell-does-not-exist/install";
-
-    let output = cmd_with_isolated_home(tmp.path())
+    let escaped = cmd_with_isolated_home(tmp.path())
         .arg("--log-level")
         .arg("info")
         .arg("--log-file")
         .arg(&log_file)
         .arg("--")
-        .arg(bogus_shell)
+        .arg(escape_token)
         .arg("--some-flag")
         .output()
         .unwrap();
 
     assert!(
-        !output.status.success(),
+        !escaped.status.success(),
         "spawning a non-existent shell must fail with non-zero exit.\n\
          stdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&escaped.stdout),
+        String::from_utf8_lossy(&escaped.stderr),
     );
 
     // clap's "unrecognized subcommand" / "unknown argument" / "for more
     // information, try '--help'" wording must NOT appear — those signal the
     // `External` arm did not catch the routing and clap rejected the input
     // at parse time.
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let escaped_stderr = String::from_utf8_lossy(&escaped.stderr);
     let clap_signatures = [
         "unrecognized subcommand",
         "error: unrecognized",
@@ -722,19 +729,18 @@ fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
     ];
     for sig in &clap_signatures {
         assert!(
-            !stderr.to_lowercase().contains(&sig.to_lowercase()),
+            !escaped_stderr.to_lowercase().contains(&sig.to_lowercase()),
             "stderr must not contain clap-level `{sig}` — the `--` escape \
              hatch should route past clap into the External arm.\n\
-             stderr:\n{stderr}"
+             stderr:\n{escaped_stderr}"
         );
     }
 
     // Positive signal: the `External` arm reached `run_proxy`, which logs
     // `starting ghost-complete proxy` with `shell=<argv[0]>`. Both strings
-    // present proves the `--`-escaped argv was forwarded into proxy mode as
-    // the shell rather than being rejected by clap at parse time. Reading
-    // the log keeps the assertion independent of the headless-CI
-    // terminal-size failure described above.
+    // present prove the `--`-escaped subcommand name was forwarded into
+    // proxy mode as the shell. Reading the log keeps the assertion
+    // independent of the environment-dependent failure message above.
     let log = std::fs::read_to_string(&log_file)
         .unwrap_or_else(|e| panic!("log file at {} unreadable: {e}", log_file.display()));
     assert!(
@@ -743,9 +749,31 @@ fn dash_dash_escape_routes_subcommand_named_shell_to_external() {
          routed into the External arm and reached run_proxy.\nlog:\n{log}"
     );
     assert!(
-        log.contains(bogus_shell),
-        "log must record `shell={bogus_shell}` — proves the `--`-escaped \
-         argv[0] became the proxy's shell.\nlog:\n{log}"
+        log.contains(&format!("shell={escape_token}")),
+        "log must record `shell={escape_token}` — proves the `--`-escaped \
+         subcommand name became the proxy's shell.\nlog:\n{log}"
+    );
+
+    // Negative control: the SAME argv without the leading `--`. clap must
+    // now claim `validate-specs` as `Command::ValidateSpecs` and reject the
+    // bogus `--some-flag` at parse time. Without this half a regression that
+    // made `--` decorative would go unnoticed — the positive case alone
+    // cannot tell "escaped by `--`" from "never collided in the first place".
+    let tmp_claimed = isolated_home();
+    let claimed = cmd_with_isolated_home(tmp_claimed.path())
+        .arg(escape_token)
+        .arg("--some-flag")
+        .output()
+        .unwrap();
+
+    let claimed_stderr = String::from_utf8_lossy(&claimed.stderr);
+    assert!(
+        !claimed.status.success()
+            && claimed_stderr.contains(escape_token)
+            && claimed_stderr.contains("--some-flag"),
+        "without `--`, `{escape_token}` must be claimed as a clap subcommand \
+         that rejects `--some-flag` at parse time — proving the `--` in the \
+         positive case is load-bearing.\nstderr:\n{claimed_stderr}"
     );
 }
 

--- a/crates/ghost-complete/tests/install_help_is_readonly.rs
+++ b/crates/ghost-complete/tests/install_help_is_readonly.rs
@@ -1,0 +1,82 @@
+//! Regression tests for help paths on write-capable commands.
+//!
+//! `install --help` must be read-only. These tests run with an isolated HOME so
+//! a regression cannot mutate the caller's real shell files.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn ghost_bin() -> PathBuf {
+    env!("CARGO_BIN_EXE_ghost-complete").into()
+}
+
+fn command_with_isolated_home(home: &std::path::Path) -> Command {
+    let mut cmd = Command::new(ghost_bin());
+    cmd.env("HOME", home)
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("XDG_STATE_HOME");
+    cmd
+}
+
+#[test]
+fn install_help_does_not_write_zshrc() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path();
+
+    let output = command_with_isolated_home(home)
+        .arg("install")
+        .arg("--help")
+        .output()
+        .expect("spawn ghost-complete");
+
+    assert!(
+        output.status.success(),
+        "install --help should exit 0; got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("install") && stdout.to_lowercase().contains("help"),
+        "expected install help text; got:\n{stdout}",
+    );
+
+    assert!(
+        !home.join(".zshrc").exists(),
+        "install --help must NOT create ~/.zshrc",
+    );
+    assert!(
+        !home.join(".config/ghost-complete").exists(),
+        "install --help must NOT create ~/.config/ghost-complete/",
+    );
+    assert!(
+        !home.join(".backup.ghost-complete").exists(),
+        "install --help must NOT create ~/.backup.ghost-complete",
+    );
+}
+
+#[test]
+fn uninstall_help_does_not_write_zshrc() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path();
+
+    let output = command_with_isolated_home(home)
+        .arg("uninstall")
+        .arg("--help")
+        .output()
+        .expect("spawn ghost-complete");
+
+    assert!(
+        output.status.success(),
+        "uninstall --help should exit 0; got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        !home.join(".zshrc").exists(),
+        "uninstall --help must NOT create ~/.zshrc",
+    );
+}

--- a/crates/ghost-complete/tests/install_help_is_readonly.rs
+++ b/crates/ghost-complete/tests/install_help_is_readonly.rs
@@ -1,7 +1,8 @@
-//! Regression tests for help paths on write-capable commands.
+//! Regression tests pinning read-only invocations on write-capable commands.
 //!
-//! `install --help` must be read-only. These tests run with an isolated HOME so
-//! a regression cannot mutate the caller's real shell files.
+//! `install --help` and `install --dry-run` must never mutate the caller's
+//! HOME. These tests run with an isolated HOME so a regression cannot touch
+//! the caller's real shell files.
 
 use std::path::PathBuf;
 use std::process::Command;

--- a/crates/ghost-complete/tests/install_help_is_readonly.rs
+++ b/crates/ghost-complete/tests/install_help_is_readonly.rs
@@ -79,4 +79,54 @@ fn uninstall_help_does_not_write_zshrc() {
         !home.join(".zshrc").exists(),
         "uninstall --help must NOT create ~/.zshrc",
     );
+    assert!(
+        !home.join(".config/ghost-complete").exists(),
+        "uninstall --help must NOT create ~/.config/ghost-complete/",
+    );
+    assert!(
+        !home.join(".backup.ghost-complete").exists(),
+        "uninstall --help must NOT create ~/.backup.ghost-complete",
+    );
+}
+
+#[test]
+fn install_dry_run_through_clap_does_not_write() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path();
+
+    let output = command_with_isolated_home(home)
+        .arg("install")
+        .arg("--dry-run")
+        .output()
+        .expect("spawn ghost-complete");
+
+    assert!(
+        output.status.success(),
+        "install --dry-run should exit 0; got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Dry run:"),
+        "expected dry-run banner in stdout; got:\n{stdout}",
+    );
+
+    assert!(
+        !home.join(".zshrc").exists(),
+        "install --dry-run must NOT create ~/.zshrc",
+    );
+    assert!(
+        !home.join(".config/ghost-complete/shell").exists(),
+        "install --dry-run must NOT create ~/.config/ghost-complete/shell",
+    );
+    assert!(
+        !home.join(".config/ghost-complete/specs").exists(),
+        "install --dry-run must NOT create ~/.config/ghost-complete/specs",
+    );
+    assert!(
+        !home.join(".config/ghost-complete/config.toml").exists(),
+        "install --dry-run must NOT create ~/.config/ghost-complete/config.toml",
+    );
 }


### PR DESCRIPTION
## What

- Replace the top-level trailing `shell_args` dispatcher with real clap subcommands for `install`, `uninstall`, `status`, `validate-specs`, `config`, `config edit`, and `doctor`.
- Mark `--config`, `--log-level`, and `--log-file` as global flags so they parse before or after real subcommands.
- Preserve proxy fallback through clap external subcommands and add coverage for scoped help, unknown flags, global flag placement, `status --baseline`, and the `install --help` write-on-help regression.

## Why

`ghost-complete install --help` was previously parsed as trailing shell args and ran installation instead of printing help. Real clap subcommands make help and flag validation command-scoped, remove manual flag scans, and keep proxy mode explicit for shell invocations such as `ghost-complete /bin/zsh -l`.

## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `TERM_PROGRAM=ghostty cargo run -p ghost-complete -- /bin/sh -c 'echo proxy-works; exit 0'`
- [x] `make release && ./target/release/ghost-complete status --json | head -20`
- [x] `make build && ./target/release/ghost-complete status --json | head -20`
- [x] Manual proxy smoke under `TERM_PROGRAM=ghostty` with `/bin/zsh` exits 0
