### PR TITLE
0.17 zsh/macOS correctness sweep: OSC framing, detection & diagnostics

### DIFF
--- a/crates/gc-buffer/src/context.rs
+++ b/crates/gc-buffer/src/context.rs
@@ -24,7 +24,7 @@ pub struct CommandContext {
     pub in_redirect: bool,
     /// Whether the cursor is inside an unclosed quote.
     pub quote_state: QuoteState,
-    /// True when there are no preceding `|`, `&&`, `||`, or `;` operators.
+    /// True when there are no preceding `|`, `&&`, `||`, `&`, or `;` operators.
     pub is_first_segment: bool,
 }
 
@@ -41,7 +41,7 @@ pub fn parse_command_context(buffer: &str, cursor: usize) -> CommandContext {
     let result = tokenize(before_cursor);
     let tokens = &result.tokens;
 
-    // Find the last pipeline segment: everything after the last |, &&, ||, or ;
+    // Find the last pipeline segment: everything after the last |, &&, ||, &, or ;
     let mut segment_start = 0;
     let mut found_pipe = false;
     for (i, tok) in tokens.iter().enumerate() {
@@ -413,5 +413,16 @@ mod tests {
     fn ampersand_redirect_does_not_split() {
         let ctx = parse_command_context("cmd &>file ", 11);
         assert_eq!(ctx.command, Some("cmd".to_string()));
+    }
+
+    #[test]
+    fn background_after_pipe_resets_in_pipe() {
+        // "cat f | grep x & ls " — `&` starts a new segment, so `in_pipe`
+        // must reset to false for `ls` even though the earlier segment had a pipe.
+        // Cursor at 20 (past the trailing space) puts `ls` in command-completed
+        // position with empty current_word.
+        let ctx = parse_command_context("cat f | grep x & ls ", 20);
+        assert!(!ctx.in_pipe, "`&` must reset in_pipe for the new segment");
+        assert_eq!(ctx.command, Some("ls".into()));
     }
 }

--- a/crates/gc-buffer/src/context.rs
+++ b/crates/gc-buffer/src/context.rs
@@ -50,7 +50,7 @@ pub fn parse_command_context(buffer: &str, cursor: usize) -> CommandContext {
                 segment_start = i + 1;
                 found_pipe = true;
             }
-            Token::And | Token::Or | Token::Semicolon => {
+            Token::And | Token::Or | Token::Semicolon | Token::Background => {
                 segment_start = i + 1;
                 found_pipe = false;
             }
@@ -386,5 +386,32 @@ mod tests {
         assert_eq!(ctx.command, Some("echo".into()));
         assert!(!ctx.in_pipe);
         assert!(ctx.is_first_segment);
+    }
+
+    #[test]
+    fn background_starts_new_segment_in_command_position() {
+        let ctx = parse_command_context("sleep 1 & git ", 14);
+        assert_eq!(ctx.command, Some("git".to_string()));
+        assert_eq!(ctx.word_index, 1, "git should be in command position");
+    }
+
+    #[test]
+    fn background_alone_puts_cursor_in_command_position() {
+        let ctx = parse_command_context("sleep 1 & ", 10);
+        assert_eq!(ctx.command, None, "no command yet after &");
+        assert!(!ctx.is_first_segment, "this is not the first segment");
+    }
+
+    #[test]
+    fn fd_redirect_2_ampersand_1_does_not_split() {
+        let ctx = parse_command_context("cmd 2>&1 arg ", 13);
+        assert_eq!(ctx.command, Some("cmd".to_string()));
+        assert_eq!(ctx.word_index, 2);
+    }
+
+    #[test]
+    fn ampersand_redirect_does_not_split() {
+        let ctx = parse_command_context("cmd &>file ", 11);
+        assert_eq!(ctx.command, Some("cmd".to_string()));
     }
 }

--- a/crates/gc-parser/src/lib.rs
+++ b/crates/gc-parser/src/lib.rs
@@ -6,7 +6,7 @@
 mod performer;
 mod state;
 
-pub use state::{CprOwner, CprToken, TerminalState};
+pub use state::{CprOwner, CprToken, Diagnostic, TerminalState};
 
 /// Wraps `vte::Parser` and `TerminalState` into a single unit.
 ///

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -422,7 +422,7 @@ impl Perform for TerminalState {
                         detail: detail.unwrap_or("").to_string(),
                     },
                 };
-                tracing::warn!(?diagnostic, "shell-side runtime diagnostic");
+                tracing::warn!("shell-side runtime diagnostic: {diagnostic}");
                 self.record_diagnostic(diagnostic);
             }
             _ => {}
@@ -1883,6 +1883,25 @@ mod tests {
     fn osc7774_empty_frame_does_not_panic() {
         let mut p = TerminalParser::new(24, 80);
         p.process_bytes(b"\x1b]7774\x07");
+        assert_eq!(p.state_mut().take_diagnostic(), None);
+    }
+
+    #[test]
+    fn osc7774_env_truncated_malformed_byte_count_is_dropped() {
+        // Non-numeric detail for env_truncated must hit the drop branch —
+        // a regression that silently substitutes 0 (e.g. `.unwrap_or(0)`)
+        // would record `EnvTruncated { bytes_emitted: 0 }` instead.
+        let mut p = TerminalParser::new(24, 80);
+        p.process_bytes(b"\x1b]7774;env_truncated;not-a-number\x07");
+        assert_eq!(p.state_mut().take_diagnostic(), None);
+    }
+
+    #[test]
+    fn osc7774_empty_reason_is_dropped() {
+        // Empty reason code (the param between the two semicolons) must hit
+        // the drop branch — never recorded as an `Unknown` with empty code.
+        let mut p = TerminalParser::new(24, 80);
+        p.process_bytes(b"\x1b]7774;;detail\x07");
         assert_eq!(p.state_mut().take_diagnostic(), None);
     }
 }

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use unicode_width::UnicodeWidthChar;
 use vte::Perform;
 
-use crate::state::{CprOwner, TerminalState};
+use crate::state::{CprOwner, Diagnostic, TerminalState};
 
 const OSC7773_MAX_ENCODED_ENV_BYTES: usize = 1024 * 1024;
 
@@ -387,20 +387,43 @@ impl Perform for TerminalState {
             // by `PrivateOscFilter` so the terminal never sees these frames.
             // Recorded into `last_diagnostic` and surfaced via `tracing::warn!`.
             b"7774" => {
-                let payload = std::str::from_utf8(params.get(1).copied().unwrap_or(b""))
-                    .ok()
-                    .unwrap_or("");
-                let detail = params
-                    .get(2)
-                    .map(|b| std::str::from_utf8(b).unwrap_or(""))
-                    .unwrap_or("");
-                let msg = if detail.is_empty() {
-                    payload.to_string()
-                } else {
-                    format!("{payload}:{detail}")
+                if params.len() < 2 {
+                    tracing::warn!("OSC 7774 — missing reason code, dropping");
+                    return;
+                }
+                let reason = match std::str::from_utf8(params[1]) {
+                    Ok(s) if !s.is_empty() => s,
+                    _ => {
+                        tracing::warn!(
+                            raw = ?params[1],
+                            "OSC 7774 — invalid reason code, dropping"
+                        );
+                        return;
+                    }
                 };
-                tracing::warn!(diagnostic = %msg, "shell-side runtime diagnostic");
-                self.last_diagnostic = Some(msg);
+                let detail_bytes = params.get(2).copied().unwrap_or(b"");
+                let detail = std::str::from_utf8(detail_bytes).ok();
+                let diagnostic = match reason {
+                    "env_truncated" => match detail.and_then(|s| s.parse::<u64>().ok()) {
+                        Some(bytes_emitted) => Diagnostic::EnvTruncated { bytes_emitted },
+                        None => {
+                            tracing::warn!(
+                                detail = ?detail_bytes,
+                                "OSC 7774 env_truncated — invalid byte count, dropping"
+                            );
+                            return;
+                        }
+                    },
+                    "zle_hook_disabled" => Diagnostic::ZleHookDisabled {
+                        widget_descriptor: detail.unwrap_or("").to_string(),
+                    },
+                    other => Diagnostic::Unknown {
+                        code: other.to_string(),
+                        detail: detail.unwrap_or("").to_string(),
+                    },
+                };
+                tracing::warn!(?diagnostic, "shell-side runtime diagnostic");
+                self.record_diagnostic(diagnostic);
             }
             _ => {}
         }
@@ -1823,11 +1846,43 @@ mod tests {
     fn osc7774_env_truncated_diagnostic_is_logged() {
         let mut p = TerminalParser::new(24, 80);
         p.process_bytes(b"\x1b]7774;env_truncated;65536\x07");
-        let state = p.state();
-        assert!(
-            state.last_diagnostic.as_deref() == Some("env_truncated:65536"),
-            "OSC 7774 should record a diagnostic; got {:?}",
-            state.last_diagnostic,
+        assert_eq!(
+            p.state_mut().take_diagnostic(),
+            Some(Diagnostic::EnvTruncated {
+                bytes_emitted: 65536
+            }),
         );
+    }
+
+    #[test]
+    fn osc7774_zle_hook_disabled_records_percent_encoded_detail() {
+        let mut p = TerminalParser::new(24, 80);
+        p.process_bytes(b"\x1b]7774;zle_hook_disabled;completion%3Afoo\x07");
+        assert_eq!(
+            p.state_mut().take_diagnostic(),
+            Some(Diagnostic::ZleHookDisabled {
+                widget_descriptor: "completion%3Afoo".to_string()
+            }),
+        );
+    }
+
+    #[test]
+    fn osc7774_payload_only_no_detail_records_payload_alone() {
+        let mut p = TerminalParser::new(24, 80);
+        p.process_bytes(b"\x1b]7774;some_reason\x07");
+        assert_eq!(
+            p.state_mut().take_diagnostic(),
+            Some(Diagnostic::Unknown {
+                code: "some_reason".to_string(),
+                detail: String::new(),
+            }),
+        );
+    }
+
+    #[test]
+    fn osc7774_empty_frame_does_not_panic() {
+        let mut p = TerminalParser::new(24, 80);
+        p.process_bytes(b"\x1b]7774\x07");
+        assert_eq!(p.state_mut().take_diagnostic(), None);
     }
 }

--- a/crates/gc-parser/src/performer.rs
+++ b/crates/gc-parser/src/performer.rs
@@ -378,6 +378,30 @@ impl Perform for TerminalState {
                     tracing::warn!("OSC 7773 — malformed shell env snapshot, skipping");
                 }
             },
+            // OSC 7774 — Ghost Complete runtime diagnostic.
+            //
+            // Shell side emits e.g. `\e]7774;env_truncated;65536\a` when it
+            // cannot fit the env snapshot within budget, or
+            // `\e]7774;zle_hook_disabled;<encoded_descriptor>\a` when
+            // `_gc_install_zle_hook` bails on a non-user widget. Filtered
+            // by `PrivateOscFilter` so the terminal never sees these frames.
+            // Recorded into `last_diagnostic` and surfaced via `tracing::warn!`.
+            b"7774" => {
+                let payload = std::str::from_utf8(params.get(1).copied().unwrap_or(b""))
+                    .ok()
+                    .unwrap_or("");
+                let detail = params
+                    .get(2)
+                    .map(|b| std::str::from_utf8(b).unwrap_or(""))
+                    .unwrap_or("");
+                let msg = if detail.is_empty() {
+                    payload.to_string()
+                } else {
+                    format!("{payload}:{detail}")
+                };
+                tracing::warn!(diagnostic = %msg, "shell-side runtime diagnostic");
+                self.last_diagnostic = Some(msg);
+            }
             _ => {}
         }
     }
@@ -1793,5 +1817,17 @@ mod tests {
         p.process_bytes(b"\x1b]7770;6;abcdef\x07");
         assert_eq!(p.state().command_buffer(), Some("abcdef"));
         assert_eq!(p.state().buffer_cursor(), 6);
+    }
+
+    #[test]
+    fn osc7774_env_truncated_diagnostic_is_logged() {
+        let mut p = TerminalParser::new(24, 80);
+        p.process_bytes(b"\x1b]7774;env_truncated;65536\x07");
+        let state = p.state();
+        assert!(
+            state.last_diagnostic.as_deref() == Some("env_truncated:65536"),
+            "OSC 7774 should record a diagnostic; got {:?}",
+            state.last_diagnostic,
+        );
     }
 }

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -18,6 +18,19 @@ pub enum CprOwner {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CprToken(u64);
 
+/// Structured shell-side runtime diagnostic carried by OSC 7774.
+///
+/// The reason-code set is documented in ADR 0007. `Unknown` exists so a
+/// stale parser observing a new reason code from a newer shell integration
+/// does not silently drop the frame — downstream consumers can still log
+/// the raw code and detail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Diagnostic {
+    EnvTruncated { bytes_emitted: u64 },
+    ZleHookDisabled { widget_descriptor: String },
+    Unknown { code: String, detail: String },
+}
+
 #[derive(Debug)]
 struct CprEntry {
     owner: CprOwner,
@@ -75,10 +88,12 @@ pub struct TerminalState {
     /// currently constructs a single parser per proxy session, so this is
     /// effectively per-process. See ADR 0003.
     legacy_osc7770_warned: bool,
-    /// Last GC-private diagnostic frame (OSC 7774). Used by the proxy to
-    /// surface shell-side warnings such as `env_truncated:<bytes>` or
-    /// `zle_hook_disabled:<widget_descriptor>`. Reset on next diagnostic.
-    pub last_diagnostic: Option<String>,
+    /// Last OSC 7774 diagnostic frame; consumers drain via
+    /// [`Self::take_diagnostic`]. Currently observation-only (parser tests
+    /// and the `tracing::warn!` emitted inline by `osc_dispatch`); reserved
+    /// for future proxy consumers. Overwritten by each new diagnostic until
+    /// drained.
+    last_diagnostic: Option<Diagnostic>,
     /// FIFO queue of pending CPR requests in send-order.
     ///
     /// Terminals respond to `CSI 6n` requests in the same order they
@@ -216,6 +231,17 @@ impl TerminalState {
         let dirty = self.display_dirty;
         self.display_dirty = false;
         dirty
+    }
+
+    /// Drains and returns the most recent OSC 7774 diagnostic, if any.
+    /// One-shot per ADR 0007 — repeated polls without an intervening
+    /// dispatch yield `None`.
+    pub fn take_diagnostic(&mut self) -> Option<Diagnostic> {
+        self.last_diagnostic.take()
+    }
+
+    pub(crate) fn record_diagnostic(&mut self, diagnostic: Diagnostic) {
+        self.last_diagnostic = Some(diagnostic);
     }
 
     pub fn take_viewport_scroll_count(&mut self) -> u16 {

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -75,6 +75,10 @@ pub struct TerminalState {
     /// currently constructs a single parser per proxy session, so this is
     /// effectively per-process. See ADR 0003.
     legacy_osc7770_warned: bool,
+    /// Last GC-private diagnostic frame (OSC 7774). Used by the proxy to
+    /// surface shell-side warnings such as `env_truncated:<bytes>` or
+    /// `zle_hook_disabled:<widget_descriptor>`. Reset on next diagnostic.
+    pub last_diagnostic: Option<String>,
     /// FIFO queue of pending CPR requests in send-order.
     ///
     /// Terminals respond to `CSI 6n` requests in the same order they
@@ -114,6 +118,7 @@ impl TerminalState {
             cursor_sync_requested: false,
             cpr_synced: false,
             legacy_osc7770_warned: false,
+            last_diagnostic: None,
             cpr_queue: VecDeque::new(),
             next_cpr_id: 0,
         }

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::fmt;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -29,6 +30,31 @@ pub enum Diagnostic {
     EnvTruncated { bytes_emitted: u64 },
     ZleHookDisabled { widget_descriptor: String },
     Unknown { code: String, detail: String },
+}
+
+/// Operator-friendly colon-separated rendering, matched against the trace
+/// shape promised by ADR 0007 (`<reason_code>:<detail>`). Used by the
+/// `tracing::warn!` emission in `performer.rs` so the operator sees
+/// `shell-side runtime diagnostic: env_truncated:65536` rather than the
+/// derived `Debug` output.
+impl fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Diagnostic::EnvTruncated { bytes_emitted } => {
+                write!(f, "env_truncated:{bytes_emitted}")
+            }
+            Diagnostic::ZleHookDisabled { widget_descriptor } => {
+                write!(f, "zle_hook_disabled:{widget_descriptor}")
+            }
+            Diagnostic::Unknown { code, detail } => {
+                if detail.is_empty() {
+                    write!(f, "{code}")
+                } else {
+                    write!(f, "{code}:{detail}")
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/gc-parser/src/state.rs
+++ b/crates/gc-parser/src/state.rs
@@ -683,6 +683,46 @@ mod tests {
     use super::*;
 
     #[test]
+    fn diagnostic_display_renders_adr_format() {
+        // ADR 0007 commits to a colon-separated operator-visible shape so
+        // shell-side diagnostics (`tracing::warn!("shell-side runtime
+        // diagnostic: {diagnostic}")`) read cleanly in proxy logs. Pin each
+        // arm against accidental `Debug`-vs-`Display` swaps or `:`→`=`
+        // separator regressions. The Unknown arm has two sub-shapes
+        // (empty-detail and present-detail) — both are covered.
+        assert_eq!(
+            Diagnostic::EnvTruncated {
+                bytes_emitted: 65536
+            }
+            .to_string(),
+            "env_truncated:65536"
+        );
+        assert_eq!(
+            Diagnostic::ZleHookDisabled {
+                widget_descriptor: "completion%3Afoo".into(),
+            }
+            .to_string(),
+            "zle_hook_disabled:completion%3Afoo"
+        );
+        assert_eq!(
+            Diagnostic::Unknown {
+                code: "x".into(),
+                detail: "".into(),
+            }
+            .to_string(),
+            "x"
+        );
+        assert_eq!(
+            Diagnostic::Unknown {
+                code: "x".into(),
+                detail: "y".into(),
+            }
+            .to_string(),
+            "x:y"
+        );
+    }
+
+    #[test]
     fn validate_cpr_accepts_valid_coordinates() {
         let state = TerminalState::new(24, 80);
         assert!(state.validate_cpr_coordinates(1, 1));

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -1851,9 +1851,9 @@ mod tests {
 
     #[test]
     fn private_osc_filter_passes_long_six_digit_osc_through_unchanged() {
-        // Regression: the `acc.len() >= 5` overflow branch must flush 6+ digit
-        // OSC codes as non-private. A regression that flipped `>= 5` to `> 5`
-        // would let a 6-digit code accumulate forever and produce wrong output.
+        // Pin that long OSC codes pass through unchanged so a 6+ digit input
+        // is never silently consumed — the filter must only intercept the
+        // known private 4-digit `777x` band.
         let mut f = PrivateOscFilter::default();
         let input = b"\x1b]123456;x\x07tail";
         assert_eq!(f.filter(input), &input[..]);

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -1052,14 +1052,15 @@ enum PrivateOscFilterState {
 impl PrivateOscFilter {
     /// OSC codes considered Ghost-Complete-private. These are produced by
     /// `shell/ghost-complete.zsh` for the proxy's consumption only and MUST
-    /// NOT reach the terminal. The proxy `gc-parser` consumes them before
-    /// this filter runs; we strip them from the byte stream so the terminal
+    /// NOT reach the terminal. The proxy's `gc-parser` dispatches these
+    /// frames for state updates before this filter runs; the bytes themselves
+    /// remain in the stream until this filter strips them so the terminal
     /// never sees them.
     ///
     /// Per ADR 0003: 7770 is the legacy raw buffer (deprecated; parser still
     /// accepts it with a one-shot warning); 7771 is the prompt-boundary
     /// fallback; 7772 is the percent-encoded buffer report; 7773 is the
-    /// env snapshot; 7774 is the runtime diagnostic frame (Task 9 / Task 10).
+    /// env snapshot; 7774 is the runtime diagnostic frame.
     const PRIVATE_CODES: &'static [&'static [u8]] = &[b"7770", b"7771", b"7772", b"7773", b"7774"];
 
     fn filter(&mut self, input: &[u8]) -> Vec<u8> {
@@ -1831,6 +1832,27 @@ mod tests {
         // `777` is a prefix of `7770`-`7774` but is not itself private.
         let mut f = PrivateOscFilter::default();
         let input = b"\x1b]777;x\x07tail";
+        assert_eq!(f.filter(input), &input[..]);
+    }
+
+    #[test]
+    fn private_osc_filter_preserves_st_terminated_non_private_frame() {
+        // Regression: the `byte == 0x1b` branch in `CodeAcc` must flush the
+        // prefix and re-enter `Esc` (not `StripEsc`) when `acc` is not a
+        // private code. A regression that always entered `StripEsc` here
+        // would silently swallow legitimate OSC 133 ST-terminated frames.
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]133\x1b\\tail";
+        assert_eq!(f.filter(input), &input[..]);
+    }
+
+    #[test]
+    fn private_osc_filter_passes_long_six_digit_osc_through_unchanged() {
+        // Regression: the `acc.len() >= 5` overflow branch must flush 6+ digit
+        // OSC codes as non-private. A regression that flipped `>= 5` to `> 5`
+        // would let a 6-digit code accumulate forever and produce wrong output.
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]123456;x\x07tail";
         assert_eq!(f.filter(input), &input[..]);
     }
 

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -1781,6 +1781,20 @@ mod tests {
     }
 
     #[test]
+    fn private_osc_filter_strips_osc_7774_env_truncated() {
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]7774;env_truncated;65536\x07tail";
+        assert_eq!(f.filter(input), b"tail");
+    }
+
+    #[test]
+    fn private_osc_filter_strips_osc_7774_zle_hook_disabled() {
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]7774;zle_hook_disabled;completion%3Afoo\x07tail";
+        assert_eq!(f.filter(input), b"tail");
+    }
+
+    #[test]
     fn private_osc_filter_preserves_osc_7_cwd() {
         let mut f = PrivateOscFilter::default();
         let input = b"\x1b]7;file:///tmp\x07tail";

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -1042,16 +1042,27 @@ enum PrivateOscFilterState {
     #[default]
     Normal,
     Esc,
-    OscPrefix {
-        matched: usize,
+    CodeAcc {
+        acc: Vec<u8>,
     },
     Strip,
     StripEsc,
 }
 
 impl PrivateOscFilter {
+    /// OSC codes considered Ghost-Complete-private. These are produced by
+    /// `shell/ghost-complete.zsh` for the proxy's consumption only and MUST
+    /// NOT reach the terminal. The proxy `gc-parser` consumes them before
+    /// this filter runs; we strip them from the byte stream so the terminal
+    /// never sees them.
+    ///
+    /// Per ADR 0003: 7770 is the legacy raw buffer (deprecated; parser still
+    /// accepts it with a one-shot warning); 7771 is the prompt-boundary
+    /// fallback; 7772 is the percent-encoded buffer report; 7773 is the
+    /// env snapshot; 7774 is the runtime diagnostic frame (Task 9 / Task 10).
+    const PRIVATE_CODES: &'static [&'static [u8]] = &[b"7770", b"7771", b"7772", b"7773", b"7774"];
+
     fn filter(&mut self, input: &[u8]) -> Vec<u8> {
-        const CODE: &[u8; 4] = b"7773";
         let mut out = Vec::with_capacity(input.len());
 
         for &byte in input {
@@ -1065,29 +1076,57 @@ impl PrivateOscFilter {
                 }
                 PrivateOscFilterState::Esc => {
                     if byte == b']' {
-                        self.state = PrivateOscFilterState::OscPrefix { matched: 0 };
+                        self.state = PrivateOscFilterState::CodeAcc { acc: Vec::new() };
                     } else {
                         out.push(0x1b);
                         out.push(byte);
                         self.state = PrivateOscFilterState::Normal;
                     }
                 }
-                PrivateOscFilterState::OscPrefix { matched } => {
-                    if matched < CODE.len() && byte == CODE[matched] {
-                        self.state = PrivateOscFilterState::OscPrefix {
-                            matched: matched + 1,
-                        };
-                    } else if matched == CODE.len() && (byte == b';' || byte == 0x07) {
-                        self.state = if byte == 0x07 {
-                            PrivateOscFilterState::Normal
+                PrivateOscFilterState::CodeAcc { ref mut acc } => {
+                    if byte.is_ascii_digit() {
+                        if acc.len() >= 5 {
+                            // Too long to be one of our codes; flush as non-private.
+                            out.extend_from_slice(b"\x1b]");
+                            out.extend_from_slice(acc);
+                            out.push(byte);
+                            self.state = PrivateOscFilterState::Normal;
                         } else {
-                            PrivateOscFilterState::Strip
-                        };
-                    } else if matched == CODE.len() && byte == 0x1b {
-                        self.state = PrivateOscFilterState::StripEsc;
+                            acc.push(byte);
+                        }
+                    } else if byte == b';' || byte == 0x07 {
+                        let is_private = Self::PRIVATE_CODES.contains(&acc.as_slice());
+                        if is_private {
+                            self.state = if byte == 0x07 {
+                                PrivateOscFilterState::Normal
+                            } else {
+                                PrivateOscFilterState::Strip
+                            };
+                        } else {
+                            // Non-private OSC: flush prefix and byte unchanged.
+                            out.extend_from_slice(b"\x1b]");
+                            out.extend_from_slice(acc);
+                            out.push(byte);
+                            self.state = PrivateOscFilterState::Normal;
+                        }
+                    } else if byte == 0x1b {
+                        // ESC inside an OSC. If `acc` is a private code, this
+                        // ESC begins an ST terminator (`ESC \`) for a private
+                        // frame with no `;` payload (e.g. `\x1b]7773\x1b\\`):
+                        // drop everything and let StripEsc consume the `\`.
+                        // Otherwise it's a bare ESC in a non-private OSC —
+                        // flush the prefix and re-enter Esc for the next byte.
+                        if Self::PRIVATE_CODES.contains(&acc.as_slice()) {
+                            self.state = PrivateOscFilterState::StripEsc;
+                        } else {
+                            out.extend_from_slice(b"\x1b]");
+                            out.extend_from_slice(acc);
+                            self.state = PrivateOscFilterState::Esc;
+                        }
                     } else {
+                        // Anything else: not a GC-private OSC.
                         out.extend_from_slice(b"\x1b]");
-                        out.extend_from_slice(&CODE[..matched]);
+                        out.extend_from_slice(acc);
                         out.push(byte);
                         self.state = PrivateOscFilterState::Normal;
                     }
@@ -1689,7 +1728,8 @@ mod tests {
     fn private_osc_filter_preserves_other_osc_frames() {
         let mut filter = PrivateOscFilter::default();
 
-        let input = b"before\x1b]7772;0;echo\x07after";
+        // OSC 7 (CWD) is non-private and must pass through unchanged.
+        let input = b"before\x1b]7;file:///tmp/work\x07after";
         let out = filter.filter(input);
 
         assert_eq!(out, input);
@@ -1706,6 +1746,92 @@ mod tests {
         assert_eq!(first, b"before");
         assert!(second.is_empty());
         assert_eq!(third, b"after");
+    }
+
+    #[test]
+    fn private_osc_filter_strips_osc_7770() {
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]7770;git checkout\x07hello";
+        assert_eq!(f.filter(input), b"hello");
+    }
+
+    #[test]
+    fn private_osc_filter_strips_osc_7771() {
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]7771;A\x07prompt";
+        assert_eq!(f.filter(input), b"prompt");
+    }
+
+    #[test]
+    fn private_osc_filter_strips_osc_7772() {
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]7772;0;buffer\x07tail";
+        assert_eq!(f.filter(input), b"tail");
+    }
+
+    #[test]
+    fn private_osc_filter_still_strips_osc_7773() {
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]7773;PATH%3D%2Fbin%00\x07rest";
+        assert_eq!(f.filter(input), b"rest");
+    }
+
+    #[test]
+    fn private_osc_filter_preserves_osc_7_cwd() {
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]7;file:///tmp\x07tail";
+        // Non-GC-private OSC must pass through.
+        assert_eq!(f.filter(input), &input[..]);
+    }
+
+    #[test]
+    fn private_osc_filter_preserves_osc_133() {
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]133;A\x07tail";
+        assert_eq!(f.filter(input), &input[..]);
+    }
+
+    #[test]
+    fn private_osc_filter_preserves_osc_633_vscode() {
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]633;A\x07tail";
+        assert_eq!(f.filter(input), &input[..]);
+    }
+
+    #[test]
+    fn private_osc_filter_strips_st_terminated_private_frame_without_semicolon() {
+        // Regression: vte parses `\x1b]7773\x1b\\` as a complete OSC 7773
+        // terminated by ST with no `;`. The filter must strip it entirely
+        // rather than leaking the `\x1b]7773` prefix to the terminal.
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]7773\x1b\\rest";
+        assert_eq!(f.filter(input), b"rest");
+    }
+
+    #[test]
+    fn private_osc_filter_strips_st_terminated_private_frame_across_chunks() {
+        let mut f = PrivateOscFilter::default();
+        let first = f.filter(b"\x1b]7773;da");
+        let second = f.filter(b"ta\x1b\\rest");
+        assert!(first.is_empty());
+        assert_eq!(second, b"rest");
+    }
+
+    #[test]
+    fn private_osc_filter_preserves_osc8_hyperlink_with_multiple_semicolons() {
+        // OSC 8 hyperlinks carry multiple `;` in the payload; a non-private
+        // code must pass through unchanged regardless of payload structure.
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]8;;https://example.com\x07tail";
+        assert_eq!(f.filter(input), &input[..]);
+    }
+
+    #[test]
+    fn private_osc_filter_preserves_osc_code_that_is_prefix_of_private_code() {
+        // `777` is a prefix of `7770`-`7774` but is not itself private.
+        let mut f = PrivateOscFilter::default();
+        let input = b"\x1b]777;x\x07tail";
+        assert_eq!(f.filter(input), &input[..]);
     }
 
     #[test]

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -1058,9 +1058,12 @@ impl PrivateOscFilter {
     /// never sees them.
     ///
     /// Per ADR 0003: 7770 is the legacy raw buffer (deprecated; parser still
-    /// accepts it with a one-shot warning); 7771 is the prompt-boundary
-    /// fallback; 7772 is the percent-encoded buffer report; 7773 is the
-    /// env snapshot; 7774 is the runtime diagnostic frame.
+    /// accepts it with a one-shot warning) and 7772 is the percent-encoded
+    /// buffer report. 7771 is the prompt-boundary fallback (defined inline in
+    /// `gc-parser`'s performer and emitted by `shell/ghost-complete.zsh`; see
+    /// `docs/ARCHITECTURE.md`). 7773 is the env snapshot (see
+    /// `docs/ARCHITECTURE.md`). Per ADR 0007: 7774 is the runtime diagnostic
+    /// frame.
     const PRIVATE_CODES: &'static [&'static [u8]] = &[b"7770", b"7771", b"7772", b"7773", b"7774"];
 
     fn filter(&mut self, input: &[u8]) -> Vec<u8> {

--- a/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
@@ -57,8 +57,8 @@ fn emit_via_real_zsh(buffer: &[u8], cursor: usize) -> Vec<u8> {
     // CURSOR, invoke the reporter. `$'…'` escapes through every byte
     // literally — no quoting hazards.
     // GHOST_COMPLETE_ACTIVE=1 must be set so _gc_report_buffer does not
-    // early-return (the gate added in Task 7 guards against leaking
-    // OSC 7772 to terminals when the proxy is absent).
+    // early-return (the gate guards against leaking OSC 7772 to terminals
+    // when the proxy is absent).
     let script = format!(
         "GHOST_COMPLETE_ACTIVE=1; source {init_q}; BUFFER={buf_lit}; CURSOR={cursor}; _gc_report_buffer",
         init_q = shell_quote(zsh_init.to_str().expect("path is utf-8")),
@@ -587,6 +587,41 @@ fn osc7774_zle_hook_disabled_silent_when_inactive() {
         count_subslices(&stdout, b"\x1b]7774;"),
         0,
         "no 7774 frame should be emitted when GHOST_COMPLETE_ACTIVE is unset; stdout = {stdout:02X?}"
+    );
+}
+
+#[test]
+fn osc7772_silent_when_inactive() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!("skipping osc7772_silent_when_inactive: zsh not on PATH (local dev)");
+        return;
+    }
+
+    // OSC 7772 carries the live command-line buffer (cursor + percent-encoded
+    // bytes). With GHOST_COMPLETE_ACTIVE unset the proxy is not watching, and
+    // the raw OSC frame would otherwise render into the terminal's scrollback
+    // on every keystroke. Static `report_buffer_is_gated_on_active` pins the
+    // source-level gate; this runtime negative test guards against the gate
+    // being present but wired incorrectly (e.g. an inverted predicate or
+    // wrong-action variant that would pass the source-level grep).
+    //
+    // The gate uses `|| return`, so `_gc_report_buffer` returns 1 when
+    // inactive. `run_zsh_after_source` asserts the script exits zero, so we
+    // discard the reporter's exit status — we care about its stdout, not its
+    // rc.
+    let stdout = run_zsh_after_source(
+        "unset GHOST_COMPLETE_ACTIVE; BUFFER=hello; CURSOR=5; _gc_report_buffer || true",
+    );
+
+    assert_eq!(
+        count_subslices(&stdout, b"\x1b]7772;"),
+        0,
+        "no 7772 frame should be emitted when GHOST_COMPLETE_ACTIVE is unset; stdout = {stdout:02X?}"
     );
 }
 

--- a/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
@@ -101,6 +101,76 @@ fn emit_env_via_real_zsh(setup: &str) -> Vec<u8> {
     output.stdout
 }
 
+/// Run an arbitrary zsh script body inside a single subshell that has
+/// already sourced `shell/ghost-complete.zsh`. The script body runs
+/// AFTER the source completes — so `_gc_install_zle_hook` has already
+/// been unset and any state established by sourcing is observable.
+fn run_zsh_after_source(body: &str) -> Vec<u8> {
+    let zsh_init = repo_root().join("shell/ghost-complete.zsh");
+    assert!(zsh_init.exists(), "shell/ghost-complete.zsh not found");
+
+    let script = format!(
+        "source {init_q}; {body}",
+        init_q = shell_quote(zsh_init.to_str().expect("path is utf-8")),
+    );
+
+    let output = Command::new("zsh")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("zsh -c failed to launch");
+    assert!(
+        output.status.success(),
+        "zsh exited non-zero: stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+/// Run a zsh script body BEFORE sourcing `shell/ghost-complete.zsh`,
+/// so the script can stage preconditions (e.g. pre-register a non-user
+/// `zle-line-pre-redraw` widget) that the integration observes at source
+/// time. The `before` body runs first, then the integration is sourced.
+fn run_zsh_before_source(before: &str) -> Vec<u8> {
+    let zsh_init = repo_root().join("shell/ghost-complete.zsh");
+    assert!(zsh_init.exists(), "shell/ghost-complete.zsh not found");
+
+    let script = format!(
+        "{before}; source {init_q}",
+        init_q = shell_quote(zsh_init.to_str().expect("path is utf-8")),
+    );
+
+    let output = Command::new("zsh")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("zsh -c failed to launch");
+    assert!(
+        output.status.success(),
+        "zsh exited non-zero: stderr={:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+/// Count non-overlapping occurrences of `needle` in `haystack`.
+fn count_subslices(haystack: &[u8], needle: &[u8]) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    let mut count = 0;
+    let mut i = 0;
+    while i + needle.len() <= haystack.len() {
+        if &haystack[i..i + needle.len()] == needle {
+            count += 1;
+            i += needle.len();
+        } else {
+            i += 1;
+        }
+    }
+    count
+}
+
 /// POSIX-quote a string for safe interpolation as one zsh argument.
 fn shell_quote(s: &str) -> String {
     // Single-quote everything; close-quote, escape any `'` as `'\''`,
@@ -208,4 +278,261 @@ fn osc7773_real_zsh_env_roundtrip() {
     assert_eq!(env.get("EMPTY").map(String::as_str), Some(""));
     assert_eq!(env.get("FOO").map(String::as_str), Some("a;b\nc"));
     assert_eq!(env.get("UNEXPORTED"), None);
+}
+
+#[test]
+fn osc7773_per_value_cap_drops_oversized_value_keeps_others() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!(
+            "skipping osc7773_per_value_cap_drops_oversized_value_keeps_others: zsh not on PATH (local dev)"
+        );
+        return;
+    }
+
+    // 20000 bytes > _GC_ENV_PER_VALUE_CAP (16384). Build the oversized
+    // value entirely in zsh to avoid bloating the Rust-side command line.
+    let stdout = emit_env_via_real_zsh(
+        "export GHOST_COMPLETE_ACTIVE=1; export FOO=${(l:20000::x:)}; export BAR=baz",
+    );
+
+    let mut p = TerminalParser::new(24, 80);
+    p.process_bytes(&stdout);
+    let env = p.state().shell_env().expect("OSC 7773 env report expected");
+
+    assert_eq!(env.get("BAR").map(String::as_str), Some("baz"));
+    assert!(
+        env.get("FOO").is_none(),
+        "FOO ({} bytes) should have been dropped by per-value cap",
+        env.get("FOO").map(String::len).unwrap_or(0)
+    );
+}
+
+#[test]
+fn osc7773_total_budget_drops_late_entries_keeps_essentials() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!(
+            "skipping osc7773_total_budget_drops_late_entries_keeps_essentials: zsh not on PATH (local dev)"
+        );
+        return;
+    }
+
+    // 200 vars × ~4 KiB each ≫ _GC_ENV_TOTAL_BUDGET (512 KiB) — guaranteed
+    // total-budget exhaustion. Set PATH and HOME explicitly so essentials
+    // emission has known values that must survive.
+    let stdout = emit_env_via_real_zsh(
+        "export GHOST_COMPLETE_ACTIVE=1; \
+         export PATH=/usr/bin:/bin; \
+         export HOME=/tmp/gc-test-home; \
+         local i; for i in {1..200}; do export GC_BUDGET_VAR_${i}=${(l:4096::y:)}; done",
+    );
+
+    let mut p = TerminalParser::new(24, 80);
+    p.process_bytes(&stdout);
+    let env = p.state().shell_env().expect("OSC 7773 env report expected");
+
+    assert_eq!(
+        env.get("PATH").map(String::as_str),
+        Some("/usr/bin:/bin"),
+        "essentials (PATH) must survive total-budget exhaustion"
+    );
+    assert_eq!(
+        env.get("HOME").map(String::as_str),
+        Some("/tmp/gc-test-home"),
+        "essentials (HOME) must survive total-budget exhaustion"
+    );
+
+    let kept: usize = (1..=200)
+        .filter(|i| env.contains_key(&format!("GC_BUDGET_VAR_{i}")))
+        .count();
+    assert!(
+        kept < 200,
+        "expected total-budget pressure to drop at least one GC_BUDGET_VAR_* (kept {kept}/200)"
+    );
+}
+
+#[test]
+fn osc7773_emits_env_truncated_diagnostic_when_dropping() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!(
+            "skipping osc7773_emits_env_truncated_diagnostic_when_dropping: zsh not on PATH (local dev)"
+        );
+        return;
+    }
+
+    let stdout = emit_env_via_real_zsh(
+        "export GHOST_COMPLETE_ACTIVE=1; export FOO=${(l:20000::x:)}; export BAR=baz",
+    );
+
+    let needle = b"\x1b]7774;env_truncated;";
+    assert!(
+        count_subslices(&stdout, needle) >= 1,
+        "expected at least one OSC 7774 env_truncated frame, got stdout = {stdout:02X?}"
+    );
+}
+
+#[test]
+fn osc7773_excludes_gc_internal_vars() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!("skipping osc7773_excludes_gc_internal_vars: zsh not on PATH (local dev)");
+        return;
+    }
+
+    let stdout = emit_env_via_real_zsh(
+        "export GHOST_COMPLETE_ACTIVE=1; \
+         export GHOST_COMPLETE_PANE=42; \
+         typeset -gx _GC_LAST_ENV_PAYLOAD=anything; \
+         export REGULAR_VAR=ok",
+    );
+
+    let mut p = TerminalParser::new(24, 80);
+    p.process_bytes(&stdout);
+    let env = p.state().shell_env().expect("OSC 7773 env report expected");
+
+    assert_eq!(env.get("REGULAR_VAR").map(String::as_str), Some("ok"));
+    assert!(
+        env.get("GHOST_COMPLETE_ACTIVE").is_none(),
+        "GHOST_COMPLETE_ACTIVE must not leak into the env snapshot"
+    );
+    assert!(
+        env.get("GHOST_COMPLETE_PANE").is_none(),
+        "GHOST_COMPLETE_PANE must not leak into the env snapshot"
+    );
+    assert!(
+        env.get("_GC_LAST_ENV_PAYLOAD").is_none(),
+        "_GC_LAST_ENV_PAYLOAD must not leak into the env snapshot"
+    );
+}
+
+#[test]
+fn osc7774_env_truncated_emits_at_most_once_per_session() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!(
+            "skipping osc7774_env_truncated_emits_at_most_once_per_session: zsh not on PATH (local dev)"
+        );
+        return;
+    }
+
+    // Two report cycles in the same zsh session, both with conditions
+    // that force `truncated=1`. The second call mutates BAR so the
+    // payload differs from the cached `_GC_LAST_ENV_PAYLOAD` (otherwise
+    // the dedup guard short-circuits before the 7774 emission branch is
+    // even reached). The one-shot latch must still suppress the second
+    // diagnostic.
+    let stdout = run_zsh_after_source(
+        "export GHOST_COMPLETE_ACTIVE=1; \
+         export FOO=${(l:20000::x:)}; \
+         export BAR=first; \
+         _gc_report_env; \
+         export BAR=second; \
+         _gc_report_env",
+    );
+
+    let needle = b"\x1b]7774;env_truncated;";
+    let count = count_subslices(&stdout, needle);
+    assert_eq!(
+        count, 1,
+        "expected exactly one OSC 7774 env_truncated diagnostic per session, got {count}: stdout = {stdout:02X?}"
+    );
+}
+
+#[test]
+fn osc7774_zle_hook_disabled_emits_for_non_user_widget_when_active() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!(
+            "skipping osc7774_zle_hook_disabled_emits_for_non_user_widget_when_active: zsh not on PATH (local dev)"
+        );
+        return;
+    }
+
+    // Pre-register a non-user widget at the zle-line-pre-redraw slot
+    // (`zle -C` produces a `completion:…:…` descriptor) BEFORE sourcing
+    // the integration. With GHOST_COMPLETE_ACTIVE set, the installer's
+    // else-branch must emit `\e]7774;zle_hook_disabled;<encoded>\a`.
+    let stdout = run_zsh_before_source(
+        "export GHOST_COMPLETE_ACTIVE=1; \
+         zmodload zsh/zle; \
+         zmodload zsh/complete; \
+         zle -C zle-line-pre-redraw complete-word _bash_complete-word",
+    );
+
+    let prefix = b"\x1b]7774;zle_hook_disabled;";
+    assert!(
+        count_subslices(&stdout, prefix) == 1,
+        "expected exactly one OSC 7774 zle_hook_disabled frame, stdout = {stdout:02X?}"
+    );
+    // Verify percent-encoding of the `:` byte made it into the payload.
+    assert!(
+        count_subslices(&stdout, b"completion%3A") >= 1,
+        "zle_hook_disabled detail should percent-encode `:` as `%3A`, stdout = {stdout:02X?}"
+    );
+    // Frame must be BEL-terminated, matching every other 777x emission.
+    let frame_start = stdout
+        .windows(prefix.len())
+        .position(|w| w == prefix)
+        .expect("prefix located above");
+    assert!(
+        stdout[frame_start..].contains(&0x07),
+        "zle_hook_disabled frame must terminate with BEL (\\x07)"
+    );
+}
+
+#[test]
+fn osc7774_zle_hook_disabled_silent_when_inactive() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!(
+            "skipping osc7774_zle_hook_disabled_silent_when_inactive: zsh not on PATH (local dev)"
+        );
+        return;
+    }
+
+    // Same setup as the active case but WITHOUT GHOST_COMPLETE_ACTIVE.
+    // The installer must still no-op (no clobber, no chain) AND must not
+    // leak a 7774 frame to the terminal.
+    let stdout = run_zsh_before_source(
+        "unset GHOST_COMPLETE_ACTIVE; \
+         zmodload zsh/zle; \
+         zmodload zsh/complete; \
+         zle -C zle-line-pre-redraw complete-word _bash_complete-word",
+    );
+
+    assert_eq!(
+        count_subslices(&stdout, b"\x1b]7774;"),
+        0,
+        "no 7774 frame should be emitted when GHOST_COMPLETE_ACTIVE is unset; stdout = {stdout:02X?}"
+    );
 }

--- a/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
@@ -361,6 +361,59 @@ fn osc7773_total_budget_drops_late_entries_keeps_essentials() {
 }
 
 #[test]
+fn osc7773_auth_prefix_vars_survive_budget_pressure() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!(
+            "skipping osc7773_auth_prefix_vars_survive_budget_pressure: zsh not on PATH (local dev)"
+        );
+        return;
+    }
+
+    // 200 filler vars alphabetized BEFORE `AWS_` (`AAA_*` < `AWS_*`),
+    // each ~4 KiB, exhaust the catch-all `(ok)parameters` sweep long
+    // before it reaches the AWS_/GITHUB_ entries. Without the
+    // auth_prefixes priority loop in _gc_report_env, AWS_PROFILE and
+    // GITHUB_TOKEN would be dropped silently. Pin the priority intent.
+    let stdout = emit_env_via_real_zsh(
+        "export GHOST_COMPLETE_ACTIVE=1; \
+         export AWS_PROFILE=dev; \
+         export GITHUB_TOKEN=tok; \
+         local i; for i in {1..200}; do export AAA_FILLER_${i}=${(l:4096::x:)}; done",
+    );
+
+    let mut p = TerminalParser::new(24, 80);
+    p.process_bytes(&stdout);
+    let env = p.state().shell_env().expect("OSC 7773 env report expected");
+
+    assert_eq!(
+        env.get("AWS_PROFILE").map(String::as_str),
+        Some("dev"),
+        "auth-prefixed AWS_PROFILE must survive budget pressure via the auth_prefixes priority loop"
+    );
+    assert_eq!(
+        env.get("GITHUB_TOKEN").map(String::as_str),
+        Some("tok"),
+        "auth-prefixed GITHUB_TOKEN must survive budget pressure via the auth_prefixes priority loop"
+    );
+
+    // Sanity: the filler set must actually have pushed the catch-all
+    // past the budget — otherwise the assertion above is vacuous.
+    let kept_fillers: usize = (1..=200)
+        .filter(|i| env.contains_key(&format!("AAA_FILLER_{i}")))
+        .count();
+    assert!(
+        kept_fillers < 200,
+        "expected catch-all sweep to exhaust budget on AAA_FILLER_* (kept {kept_fillers}/200); \
+         without budget pressure this test does not exercise the priority loop"
+    );
+}
+
+#[test]
 fn osc7773_emits_env_truncated_diagnostic_when_dropping() {
     if !zsh_available() {
         if std::env::var_os("CI").is_some() {

--- a/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
@@ -56,8 +56,11 @@ fn emit_via_real_zsh(buffer: &[u8], cursor: usize) -> Vec<u8> {
     // Single-line zsh script: source the integration, set BUFFER and
     // CURSOR, invoke the reporter. `$'…'` escapes through every byte
     // literally — no quoting hazards.
+    // GHOST_COMPLETE_ACTIVE=1 must be set so _gc_report_buffer does not
+    // early-return (the gate added in Task 7 guards against leaking
+    // OSC 7772 to terminals when the proxy is absent).
     let script = format!(
-        "source {init_q}; BUFFER={buf_lit}; CURSOR={cursor}; _gc_report_buffer",
+        "GHOST_COMPLETE_ACTIVE=1; source {init_q}; BUFFER={buf_lit}; CURSOR={cursor}; _gc_report_buffer",
         init_q = shell_quote(zsh_init.to_str().expect("path is utf-8")),
         buf_lit = to_zsh_literal(buffer),
     );

--- a/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7772_zsh_roundtrip.rs
@@ -589,3 +589,35 @@ fn osc7774_zle_hook_disabled_silent_when_inactive() {
         "no 7774 frame should be emitted when GHOST_COMPLETE_ACTIVE is unset; stdout = {stdout:02X?}"
     );
 }
+
+#[test]
+fn osc7773_silent_when_inactive() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "zsh not on PATH but running under CI — install zsh or mark this test #[ignore] explicitly"
+            );
+        }
+        eprintln!("skipping osc7773_silent_when_inactive: zsh not on PATH (local dev)");
+        return;
+    }
+
+    // OSC 7773 carries an env snapshot (PATH, AWS_PROFILE, GITHUB_TOKEN, …).
+    // With GHOST_COMPLETE_ACTIVE unset the proxy is not watching, and the
+    // raw OSC frame would otherwise render into the terminal's scrollback.
+    // Static `report_env_is_gated_on_active` pins the source-level gate;
+    // this runtime negative test guards against the gate being present but
+    // wired incorrectly (e.g. `[[ -z … ]] || return`).
+    //
+    // The gate uses `|| return`, so `_gc_report_env` returns 1 when inactive.
+    // `run_zsh_after_source` asserts the script exits zero, so we discard
+    // the reporter's exit status — we care about its stdout, not its rc.
+    let stdout =
+        run_zsh_after_source("unset GHOST_COMPLETE_ACTIVE; export FOO=x; _gc_report_env || true");
+
+    assert_eq!(
+        count_subslices(&stdout, b"\x1b]7773;"),
+        0,
+        "no 7773 frame should be emitted when GHOST_COMPLETE_ACTIVE is unset; stdout = {stdout:02X?}"
+    );
+}

--- a/crates/gc-pty/tests/osc7_zsh_semicolon_roundtrip.rs
+++ b/crates/gc-pty/tests/osc7_zsh_semicolon_roundtrip.rs
@@ -1,0 +1,69 @@
+//! Real-zsh OSC 7 round-trip test: a directory whose name contains a
+//! semicolon must survive end-to-end. vte splits OSC parameters on ';',
+//! so the shell-side encoder must percent-encode ';' even though RFC 3986
+//! allows it as a sub-delimiter in URI paths.
+
+use gc_parser::TerminalParser;
+use std::process::Command;
+
+fn zsh_available() -> bool {
+    Command::new("zsh")
+        .arg("-c")
+        .arg("exit 0")
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn osc7_roundtrip_with_semicolon_in_path() {
+    if !zsh_available() {
+        if std::env::var_os("CI").is_some() {
+            panic!("zsh not found on CI runner");
+        }
+        eprintln!("zsh not available; skipping");
+        return;
+    }
+
+    let zsh_src = std::fs::read_to_string("../../shell/ghost-complete.zsh")
+        .expect("read shell/ghost-complete.zsh");
+
+    // Drive the encoder directly with a path containing ';'.
+    let path = "/tmp/foo;bar/baz";
+    let script = format!(
+        r#"set -e
+{src}
+printf 'OSC7=%s\n' "$(_gc_urlencode_path {path:?})"
+"#,
+        src = zsh_src,
+        path = path,
+    );
+    let out = Command::new("zsh")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("run zsh");
+    assert!(
+        out.status.success(),
+        "zsh failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let encoded = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("OSC7="))
+        .expect("encoder output");
+
+    assert!(
+        !encoded.contains(';'),
+        "encoder must percent-encode ';' (got {encoded:?})",
+    );
+
+    // Feed the OSC 7 framing through the parser and check the decoded CWD.
+    let osc7 = format!("\x1b]7;file://localhost{encoded}\x07");
+    let mut parser = TerminalParser::new(24, 80);
+    parser.process_bytes(osc7.as_bytes());
+    let cwd = parser.state().cwd().cloned().expect("OSC 7 must set CWD");
+    assert_eq!(cwd, std::path::PathBuf::from(path));
+}

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -791,6 +791,17 @@ mod tests {
             "non-tmux branch must honor the guard on both 'descendant' and \
              'ps uncertain' outcomes"
         );
+
+        // Ensure the OSC 7 encoder cannot pass ';' through unencoded — vte would
+        // split the OSC param list and silently truncate the CWD.
+        assert!(
+            !ZSH_INTEGRATION.contains(";=/-"),
+            "_gc_urlencode_path allow-list must not include URI sub-delimiters; see ADR 0003"
+        );
+        assert!(
+            ZSH_INTEGRATION.contains("[a-zA-Z0-9._~/-])"),
+            "_gc_urlencode_path must use the strict allow-list"
+        );
     }
 
     #[test]

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -1543,6 +1543,18 @@ mod tests {
     }
 
     #[test]
+    fn report_env_respects_per_value_and_total_budgets() {
+        assert!(
+            ZSH_INTEGRATION.contains("_GC_ENV_TOTAL_BUDGET"),
+            "_gc_report_env must declare a total byte budget"
+        );
+        assert!(
+            ZSH_INTEGRATION.contains("_GC_ENV_PER_VALUE_CAP"),
+            "_gc_report_env must declare a per-value cap"
+        );
+    }
+
+    #[test]
     fn test_post_install_summary_uses_sanitized_paths() {
         // Pin the sanitization invariant. We can't blanket-assert
         // `!contains('\x1b')` because the helper intentionally emits ANSI

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -859,6 +859,28 @@ mod tests {
     }
 
     #[test]
+    fn report_env_is_gated_on_active() {
+        // OSC 7773 carries an env snapshot (PATH, AWS_PROFILE, GITHUB_TOKEN, …).
+        // A regression that dropped or inverted the gate would leak the frame
+        // to a bare terminal — and unlike OSC 7772 (line buffer), an env frame
+        // contains values the user reasonably expects never to be rendered
+        // verbatim. Pin the gate the same way `report_buffer_is_gated_on_active`
+        // pins the OSC 7772 gate, so a `[[ -z … ]] || return` typo or an
+        // accidental gate removal fails this test loudly.
+        let body = ZSH_INTEGRATION
+            .split("_gc_report_env()")
+            .nth(1)
+            .expect("found _gc_report_env")
+            .split("\n}\n")
+            .next()
+            .expect("found end brace");
+        assert!(
+            body.contains("GHOST_COMPLETE_ACTIVE"),
+            "_gc_report_env must check $GHOST_COMPLETE_ACTIVE before emitting OSC 7773"
+        );
+    }
+
+    #[test]
     fn test_zsh_integration_vscode_injection_not_ipc_hook() {
         // Extract just the _gc_native_osc133 helper body to avoid matching
         // the unrelated __ghost_complete_init block (which does check

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -825,6 +825,19 @@ mod tests {
             ZSH_INTEGRATION.contains("_gc_native_osc133 || printf '\\e]7771;C"),
             "_gc_preexec must suppress OSC 7771 when terminal parses OSC 133 natively"
         );
+        // New native-OSC-133 terminals — match PromptDetection::Osc133 in gc-terminal.
+        assert!(
+            ZSH_INTEGRATION.contains("KITTY_WINDOW_ID") || ZSH_INTEGRATION.contains("kitty"),
+            "_gc_native_osc133 must recognise Kitty"
+        );
+        assert!(
+            ZSH_INTEGRATION.contains("WEZTERM_UNIX_SOCKET") || ZSH_INTEGRATION.contains("WezTerm"),
+            "_gc_native_osc133 must recognise WezTerm"
+        );
+        assert!(
+            ZSH_INTEGRATION.contains("\"rio\""),
+            "_gc_native_osc133 must recognise Rio"
+        );
     }
 
     #[test]

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -841,6 +841,22 @@ mod tests {
     }
 
     #[test]
+    fn report_buffer_is_gated_on_active() {
+        // GC-private frames must not leak to terminals when the proxy is absent.
+        let body = ZSH_INTEGRATION
+            .split("_gc_report_buffer()")
+            .nth(1)
+            .expect("found _gc_report_buffer")
+            .split("\n}\n")
+            .next()
+            .expect("found end brace");
+        assert!(
+            body.contains("GHOST_COMPLETE_ACTIVE"),
+            "_gc_report_buffer must check $GHOST_COMPLETE_ACTIVE before emitting OSC 7772"
+        );
+    }
+
+    #[test]
     fn test_zsh_integration_vscode_injection_not_ipc_hook() {
         // Extract just the _gc_native_osc133 helper body to avoid matching
         // the unrelated __ghost_complete_init block (which does check

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -796,7 +796,9 @@ mod tests {
         // split the OSC param list and silently truncate the CWD.
         assert!(
             !ZSH_INTEGRATION.contains(";=/-"),
-            "_gc_urlencode_path allow-list must not include URI sub-delimiters; see ADR 0003"
+            "_gc_urlencode_path allow-list must not include URI sub-delimiters; \
+             see ghost-complete.zsh _gc_urlencode_path doc and \
+             osc7_roundtrip_with_semicolon_in_path test"
         );
         assert!(
             ZSH_INTEGRATION.contains("[a-zA-Z0-9._~/-])"),

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -1572,4 +1572,12 @@ mod tests {
             "raw ESC sequence from hostile path leaked: {summary:?}"
         );
     }
+
+    #[test]
+    fn zle_install_hook_emits_diagnostic_on_non_user_widget() {
+        assert!(
+            ZSH_INTEGRATION.contains("7774;zle_hook_disabled"),
+            "_gc_install_zle_hook must emit OSC 7774 zle_hook_disabled when bailing on a non-user widget"
+        );
+    }
 }

--- a/crates/ghost-complete/tests/init_zsh_terminal_matrix.rs
+++ b/crates/ghost-complete/tests/init_zsh_terminal_matrix.rs
@@ -80,10 +80,13 @@ fn init_zsh_tmux_branch_recognises_required_env_vars() {
 }
 
 #[test]
-fn rust_detection_recognises_wezterm_in_direct_branch() {
-    // Sanity: Rust matrix MUST detect WezTerm via socket in direct mode;
-    // shell side must keep parity. If this ever changes on the Rust side,
-    // update SHELL_DIRECT_ENV_VARS above.
+fn rust_terminal_enum_has_wezterm_variant() {
+    // Sanity: the WezTerm variant exists in the Rust matrix so the shell
+    // side has a counterpart to keep parity with. Env-based detection of
+    // WezTerm via socket is exercised by gc-terminal's own unit tests
+    // (test_detect_wezterm_direct_via_socket); we can't drive that path
+    // from an integration test without mutating process-global env vars,
+    // which is unsafe under cargo test's parallel runner.
     let profile = TerminalProfile::for_wezterm();
     assert!(matches!(profile.terminal(), gc_terminal::Terminal::WezTerm));
 }

--- a/crates/ghost-complete/tests/init_zsh_terminal_matrix.rs
+++ b/crates/ghost-complete/tests/init_zsh_terminal_matrix.rs
@@ -1,0 +1,89 @@
+//! Pin the shell init terminal-detection matrix against
+//! `TerminalProfile::detect_from_env`. New terminals MUST be added in both
+//! sides or this test fails.
+
+use gc_terminal::TerminalProfile;
+
+/// The minimum direct-branch env vars that init.zsh must recognise.
+const SHELL_DIRECT_ENV_VARS: &[&str] = &[
+    "KITTY_WINDOW_ID",
+    "WEZTERM_UNIX_SOCKET",
+    "ALACRITTY_SOCKET",
+    "ZED_TERM",
+    "VSCODE_IPC_HOOK_CLI",
+];
+
+/// The minimum tmux-branch env vars that init.zsh must recognise.
+const SHELL_TMUX_ENV_VARS: &[&str] = &[
+    "GHOSTTY_RESOURCES_DIR",
+    "KITTY_WINDOW_ID",
+    "WEZTERM_UNIX_SOCKET",
+    "ALACRITTY_SOCKET",
+    "ZED_TERM",
+    "VSCODE_IPC_HOOK_CLI",
+    "ITERM_SESSION_ID",
+];
+
+fn init_zsh_text() -> String {
+    std::fs::read_to_string("../../shell/init.zsh").expect("read shell/init.zsh")
+}
+
+/// Extract the non-tmux direct branch from init.zsh.
+///
+/// The file has two branches delimited by these unique comment strings:
+///   - `# Inside tmux:` — start of the tmux branch (inside `if [[ -n "$TMUX" ]]; then`)
+///   - `# Outside tmux:` — start of the direct (non-tmux) branch (inside `else`)
+///
+/// The direct branch is everything after `# Outside tmux:`.
+fn direct_branch(src: &str) -> &str {
+    src.split("# Outside tmux:")
+        .nth(1)
+        .expect("init.zsh must contain the '# Outside tmux:' marker")
+}
+
+/// Extract the tmux branch from init.zsh.
+///
+/// The tmux branch is the text between `# Inside tmux:` and `# Outside tmux:`.
+fn tmux_branch(src: &str) -> &str {
+    src.split("# Inside tmux:")
+        .nth(1)
+        .expect("init.zsh must contain the '# Inside tmux:' marker")
+        .split("# Outside tmux:")
+        .next()
+        .expect("tmux branch must be terminated by '# Outside tmux:'")
+}
+
+#[test]
+fn init_zsh_direct_branch_recognises_required_env_vars() {
+    let src = init_zsh_text();
+    let direct = direct_branch(&src);
+    for var in SHELL_DIRECT_ENV_VARS {
+        assert!(
+            direct.contains(var),
+            "init.zsh non-tmux direct branch must check ${} (Rust does)",
+            var
+        );
+    }
+}
+
+#[test]
+fn init_zsh_tmux_branch_recognises_required_env_vars() {
+    let src = init_zsh_text();
+    let tmux = tmux_branch(&src);
+    for var in SHELL_TMUX_ENV_VARS {
+        assert!(
+            tmux.contains(var),
+            "init.zsh tmux branch must check ${} (Rust does)",
+            var
+        );
+    }
+}
+
+#[test]
+fn rust_detection_recognises_wezterm_in_direct_branch() {
+    // Sanity: Rust matrix MUST detect WezTerm via socket in direct mode;
+    // shell side must keep parity. If this ever changes on the Rust side,
+    // update SHELL_DIRECT_ENV_VARS above.
+    let profile = TerminalProfile::for_wezterm();
+    assert!(matches!(profile.terminal(), gc_terminal::Terminal::WezTerm));
+}

--- a/docs/adr/0007-osc7774-runtime-diagnostics.md
+++ b/docs/adr/0007-osc7774-runtime-diagnostics.md
@@ -1,0 +1,173 @@
+# 0007. OSC 7774 runtime diagnostic frame
+
+- **Status:** Accepted
+- **Date:** 2026-05-21
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context
+
+Two shell-side failure modes degraded silently before this ADR:
+
+1. **`_gc_report_env` budget exhaustion.** `_gc_report_env` builds an
+   OSC 7773 env snapshot payload under a shell-side byte budget (512 KiB
+   total, 16 KiB per encoded `KEY=VALUE` entry). When a variable exceeds
+   the per-value cap, or the running total would exceed the total budget,
+   the variable is silently dropped and a `truncated` flag is set. Prior
+   to this ADR the proxy had no way to distinguish "env snapshot is
+   complete" from "env snapshot was truncated mid-way" — both produced
+   identical OSC 7773 frames.
+
+2. **`_gc_install_zle_hook` non-user widget.** The ZLE hook installer
+   registers `zle-line-pre-redraw` so the proxy receives buffer updates
+   on every keystroke. When that widget slot is already occupied by a
+   non-user widget (`completion:*`, `builtin:*`, etc.), chaining is
+   unsafe and the installer intentionally no-ops. Prior to this ADR the
+   hook was silently absent: buffer reports never arrived and the proxy
+   had no visibility into why.
+
+Both failure modes called for a structured, machine-readable channel that
+carries shell-side warnings to the proxy without producing any visible
+artifacts in the terminal emulator. OSC 7773 (env snapshot) and OSC 7772
+(buffer report) are already stripped from the terminal-bound byte stream
+by `PrivateOscFilter` in `crates/gc-pty/src/proxy.rs`. Extending the
+same stripping to a new code is trivial and free of terminal-side risk.
+
+## Decision
+
+Reserve OSC code `7774` for Ghost-Complete-private runtime diagnostics:
+
+```
+\e]7774;<reason_code>;<percent_encoded_detail>\a
+```
+
+BEL-terminated, consistent with the other GC-private 777x frames. The
+code joins `PrivateOscFilter`'s `PRIVATE_CODES` set alongside 7770–7773
+and is stripped before any bytes reach the terminal emulator.
+
+### Wire format
+
+- **`<reason_code>`** — plain ASCII token identifying the failure class.
+  Initial set: `env_truncated`, `zle_hook_disabled`.
+- **`<percent_encoded_detail>`** — an additional payload, percent-encoded
+  using `_gc_urlencode_buffer`'s allow-list (`[A-Za-z0-9._~/-% ]`; all
+  other bytes as `%XX` uppercase hex). The encoding rules are identical
+  to those specified for OSC 7772 in ADR 0003.
+
+### `env_truncated` emission
+
+Emitted by `_gc_report_env` in `shell/ghost-complete.zsh` when at least
+one variable was dropped due to the per-value cap or the total-budget
+ceiling. The detail field is a **decimal byte count equal to the number
+of bytes successfully emitted** into the OSC 7773 payload — it is the
+final value of the shell's `$used` accumulator (the total size of the
+payload actually emitted), not the number of bytes dropped. A small
+`$used` value therefore signals a per-value-cap rejection of a single
+oversized variable early in the iteration (e.g. a multi-MB `LS_COLORS`)
+rather than total-budget exhaustion after a nearly-full sweep.
+
+The frame is guarded by a one-shot latch (`_GC_ENV_TRUNCATED_REPORTED`)
+so at most one `env_truncated` diagnostic is emitted per shell session,
+regardless of how many subsequent `_gc_report_env` calls truncate.
+
+Example wire frame: `\e]7774;env_truncated;65536\a` — 65536 bytes of
+env payload were successfully included; further entries were dropped.
+
+### `zle_hook_disabled` emission
+
+Emitted by `_gc_install_zle_hook` in `shell/ghost-complete.zsh` when the
+`zle-line-pre-redraw` widget slot is occupied by a non-user widget and
+cannot be safely chained. The detail field is the full widget descriptor
+(e.g. `completion:...`), percent-encoded with `_gc_urlencode_buffer`.
+
+Example wire frame: `\e]7774;zle_hook_disabled;completion%3Afoo\a`.
+
+### Emission gating
+
+Both emission sites check `[[ -n "$GHOST_COMPLETE_ACTIVE" ]]` before
+printing, consistent with every other GC-private 777x frame. The
+diagnostic is therefore only ever emitted when the proxy is the process
+receiving the output.
+
+### Parser-side consumption
+
+`crates/gc-parser/src/performer.rs::osc_dispatch` matches `b"7774"`,
+concatenates `params[1]` and `params[2]` as `<reason_code>:<detail>`,
+stores the result in `TerminalState.last_diagnostic` (an
+`Option<String>`), and emits a `tracing::warn!` with the full message.
+`last_diagnostic` is overwritten on each received diagnostic; callers
+that need to act on it should drain it promptly.
+
+### Filter-side consumption
+
+`PrivateOscFilter::PRIVATE_CODES` in `crates/gc-pty/src/proxy.rs` was
+extended from `[b"7773"]` (single fixed match) to the full set
+`[b"7770", b"7771", b"7772", b"7773", b"7774"]`. The digit-accumulating
+state machine matches on the terminator byte, so adding `b"7774"` to the
+slice is sufficient — no other filter logic changes.
+
+## Consequences
+
+### Positive
+
+- **Silent failures become observable.** Both failure modes now produce a
+  structured `tracing::warn!` in the proxy log. An operator watching
+  the proxy's trace output sees
+  `shell-side runtime diagnostic: env_truncated:65536` or
+  `shell-side runtime diagnostic: zle_hook_disabled:completion%3A...`
+  instead of guessing why env completions are incomplete or why buffer
+  reports are absent.
+- **No terminal-visible artifacts.** `PrivateOscFilter` strips 7774
+  frames from the terminal-bound byte stream by the same mechanism as
+  7770–7773. Terminals that don't understand GC-private codes (every
+  terminal) never see them.
+- **Wire-safe encoding.** The `_gc_urlencode_buffer` alphabet contains no
+  OSC delimiters (`\a`, `\x1b`, `;`), so the frame is safe against the
+  same injection classes documented in ADR 0003.
+
+### Negative
+
+- **One-shot latch for `env_truncated`.** The `_GC_ENV_TRUNCATED_REPORTED`
+  latch suppresses subsequent diagnostics in the same shell session. If
+  the user sources an update to `ghost-complete.zsh` mid-session, the
+  latch will be stale. This is acceptable for the diagnostic use case —
+  the proxy only needs to know once that the snapshot is incomplete.
+- **`last_diagnostic` is last-write-wins.** If two diagnostics arrive in
+  quick succession the first is overwritten. In practice `env_truncated`
+  is one-shot and `zle_hook_disabled` fires once at ZLE init time, so
+  concurrent delivery is not expected.
+
+### Neutral
+
+- The parser-side `last_diagnostic` field is also exposed in the public
+  `TerminalState` struct. Callers that do not use OSC 7774 see `None`
+  and are unaffected.
+
+## Alternatives considered
+
+- **Append a suffix to the OSC 7773 frame.** Rejected. OSC 7773 is
+  purpose-built for the env snapshot payload; mixing diagnostic metadata
+  into the payload would require the Rust parser to differentiate "is this
+  a partial snapshot or a complete one with a trailing diagnostic token",
+  adding ambiguity with no benefit over a dedicated code.
+- **Write a plain log line from the shell to a temp file.** Rejected. The
+  proxy process and the shell are connected only via the PTY pair; a
+  shared temp file introduces a race, a cleanup concern, and a potential
+  TOCTOU. OSC frames are already the established in-band channel.
+- **Reuse OSC 7771 with an extended payload.** Rejected. OSC 7771 is the
+  prompt-boundary fallback marker (analogous to OSC 133 for terminals that
+  mangle it). Multiplexing a diagnostic channel onto a timing-sensitive
+  prompt-boundary code would conflate two unrelated semantics and
+  complicate the parser dispatch arm.
+
+## References
+
+- `crates/gc-parser/src/performer.rs` — OSC 7774 dispatch arm
+- `crates/gc-parser/src/state.rs` — `TerminalState.last_diagnostic` field
+- `shell/ghost-complete.zsh` — `_gc_report_env` (`env_truncated` emission
+  and `_GC_ENV_TRUNCATED_REPORTED` latch), `_gc_install_zle_hook`
+  (`zle_hook_disabled` emission)
+- `crates/gc-pty/src/proxy.rs` — `PrivateOscFilter::PRIVATE_CODES`
+- [ADR-0003](0003-osc7772-buffer-framing.md) — establishes the 777x
+  GC-private OSC namespace, percent-encoding alphabet, and
+  `PrivateOscFilter` stripping mechanism that OSC 7774 extends

--- a/docs/adr/0007-osc7774-runtime-diagnostics.md
+++ b/docs/adr/0007-osc7774-runtime-diagnostics.md
@@ -180,6 +180,8 @@ machine is in place, supporting OSC 7774 is just an entry in the slice
   and `_GC_ENV_TRUNCATED_REPORTED` latch), `_gc_install_zle_hook`
   (`zle_hook_disabled` emission)
 - `crates/gc-pty/src/proxy.rs` — `PrivateOscFilter::PRIVATE_CODES`
-- [ADR-0003](0003-osc7772-buffer-framing.md) — establishes the 777x
-  GC-private OSC namespace, percent-encoding alphabet, and
-  `PrivateOscFilter` stripping mechanism that OSC 7774 extends
+- [ADR-0003](0003-osc7772-buffer-framing.md) — establishes the
+  percent-encoding alphabet that OSC 7774 reuses. The
+  `PrivateOscFilter` stripping mechanism itself was introduced alongside
+  OSC 7773 and is refactored here to handle the multi-code
+  `PRIVATE_CODES` set.

--- a/docs/adr/0007-osc7774-runtime-diagnostics.md
+++ b/docs/adr/0007-osc7774-runtime-diagnostics.md
@@ -50,9 +50,11 @@ and is stripped before any bytes reach the terminal emulator.
 - **`<reason_code>`** — plain ASCII token identifying the failure class.
   Initial set: `env_truncated`, `zle_hook_disabled`.
 - **`<percent_encoded_detail>`** — an additional payload, percent-encoded
-  using `_gc_urlencode_buffer`'s allow-list (`[A-Za-z0-9._~/-% ]`; all
-  other bytes as `%XX` uppercase hex). The encoding rules are identical
-  to those specified for OSC 7772 in ADR 0003.
+  using `_gc_urlencode_buffer`'s allow-list (`[A-Za-z0-9._~/-]` plus the
+  literal space; all other bytes as `%XX` uppercase hex). A literal `%`
+  byte is itself encoded as `%25`, which keeps the encoder round-trip-safe
+  over already-encoded payloads. The encoding rules are identical to
+  those specified for OSC 7772 in ADR 0003.
 
 ### `env_truncated` emission
 
@@ -61,10 +63,11 @@ one variable was dropped due to the per-value cap or the total-budget
 ceiling. The detail field is a **decimal byte count equal to the number
 of bytes successfully emitted** into the OSC 7773 payload — it is the
 final value of the shell's `$used` accumulator (the total size of the
-payload actually emitted), not the number of bytes dropped. A small
-`$used` value therefore signals a per-value-cap rejection of a single
-oversized variable early in the iteration (e.g. a multi-MB `LS_COLORS`)
-rather than total-budget exhaustion after a nearly-full sweep.
+payload actually emitted), not the number of bytes dropped. A `$used`
+value much smaller than `_GC_ENV_TOTAL_BUDGET` suggests a per-value-cap
+rejection cut the sweep short; a value close to the budget indicates
+total-budget exhaustion. The split is not exact — `essentials` are
+emitted first, so even a small `$used` includes those bytes.
 
 The frame is guarded by a one-shot latch (`_GC_ENV_TRUNCATED_REPORTED`)
 so at most one `env_truncated` diagnostic is emitted per shell session,
@@ -92,19 +95,26 @@ receiving the output.
 ### Parser-side consumption
 
 `crates/gc-parser/src/performer.rs::osc_dispatch` matches `b"7774"`,
-concatenates `params[1]` and `params[2]` as `<reason_code>:<detail>`,
-stores the result in `TerminalState.last_diagnostic` (an
-`Option<String>`), and emits a `tracing::warn!` with the full message.
-`last_diagnostic` is overwritten on each received diagnostic; callers
-that need to act on it should drain it promptly.
+parses `params[1]` (reason code) and `params[2]` (detail) into a
+structured `Diagnostic` enum variant (`EnvTruncated`, `ZleHookDisabled`,
+or `Unknown` for codes a stale parser does not recognise), stores it on
+the private `TerminalState::last_diagnostic` field, and emits a
+`tracing::warn!` with the full message. The field is overwritten on
+each received diagnostic; callers drain it via the public
+`TerminalState::take_diagnostic()` accessor and should do so promptly.
 
 ### Filter-side consumption
 
-`PrivateOscFilter::PRIVATE_CODES` in `crates/gc-pty/src/proxy.rs` was
-extended from `[b"7773"]` (single fixed match) to the full set
-`[b"7770", b"7771", b"7772", b"7773", b"7774"]`. The digit-accumulating
-state machine matches on the terminator byte, so adding `b"7774"` to the
-slice is sufficient — no other filter logic changes.
+`PrivateOscFilter` in `crates/gc-pty/src/proxy.rs` previously used a
+static prefix matcher keyed on a single hard-coded code (`OscPrefix {
+matched: usize }` against `CODE = b"7773"`). As part of this ADR's
+footprint, that matcher was replaced with a digit-accumulating state
+machine (`CodeAcc { acc: Vec<u8> }`) that buffers the numeric OSC code
+bytes and matches the accumulator against `PRIVATE_CODES` on the OSC
+terminator byte. `PRIVATE_CODES` is now the full set `[b"7770",
+b"7771", b"7772", b"7773", b"7774"]`. Once the digit-accumulating
+machine is in place, supporting OSC 7774 is just an entry in the slice
+— but the refactor itself is new in this PR, not pre-existing.
 
 ## Consequences
 
@@ -139,9 +149,11 @@ slice is sufficient — no other filter logic changes.
 
 ### Neutral
 
-- The parser-side `last_diagnostic` field is also exposed in the public
-  `TerminalState` struct. Callers that do not use OSC 7774 see `None`
-  and are unaffected.
+- The parser captures the most recent OSC 7774 frame as an
+  `Option<Diagnostic>` and exposes it via `TerminalState::take_diagnostic()`
+  (the underlying field is private). The accessor is currently
+  observation-only — the parser's own tests are the sole in-tree
+  consumer; it is reserved for future proxy-side use.
 
 ## Alternatives considered
 

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -8,14 +8,15 @@
 # OSC 7: current working directory reporting
 
 # Percent-encode a path for use in file:// URIs (RFC 8089).
-# Encodes everything except unreserved chars and '/'.
+# Strict alphabet: only [a-zA-Z0-9._~/-] passes through. ';' MUST be
+# encoded because vte splits OSC params on it (see ADR 0003).
 _gc_urlencode_path() {
     local input="$1" encoded="" i ch hex
     local LC_ALL=C  # force byte-level iteration for correct UTF-8 encoding
     for (( i = 1; i <= ${#input}; i++ )); do
         ch="${input[$i]}"
         case "$ch" in
-            [a-zA-Z0-9._~:@!\$\&\'\(\)\*+,\;=/-])
+            [a-zA-Z0-9._~/-])
                 encoded+="$ch"
                 ;;
             *)

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -146,6 +146,7 @@ _gc_osc7_precmd() {
 # during the deprecation window but logs a one-shot warn! to nudge the
 # user (or distro packager) towards a fresh shell integration.
 _gc_report_buffer() {
+    [[ -n "$GHOST_COMPLETE_ACTIVE" ]] || return
     local encoded
     encoded="$(_gc_urlencode_buffer "$BUFFER")"
     printf '\e]7772;%d;%s\a' "$CURSOR" "$encoded"

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -30,14 +30,16 @@ _gc_urlencode_path() {
 
 # Percent-encode a command-line buffer for OSC 7772 transport.
 #
-# STRICTER alphabet than _gc_urlencode_path: only [a-zA-Z0-9._~/-] and the
-# literal space pass through. Everything else — including ';', '%', '\',
-# all control bytes (0x00-0x1F, 0x7F) and high bytes (0x80-0xFF) — gets
-# `%XX`-encoded. This is non-negotiable: any unencoded ';' would split
-# the OSC parameter list and silently truncate the buffer at the parser;
-# any unencoded BEL (0x07) or ESC+ST (0x1B 0x5C) would terminate the OSC
-# envelope mid-payload; an unencoded ESC could smuggle a nested escape
-# sequence into the parser's state machine. See ADR 0003.
+# Strict alphabet for OSC 7772 transport: [a-zA-Z0-9._~/-] plus literal
+# space. Differs from _gc_urlencode_path only by allowing space (path
+# components rarely need a literal space and percent-encoding is harmless
+# if they do). Everything else — including ';', '%', '\', all control
+# bytes (0x00-0x1F, 0x7F) and high bytes (0x80-0xFF) — gets `%XX`-encoded.
+# This is non-negotiable: any unencoded ';' would split the OSC parameter
+# list and silently truncate the buffer at the parser; any unencoded BEL
+# (0x07) or ESC+ST (0x1B 0x5C) would terminate the OSC envelope mid-
+# payload; an unencoded ESC could smuggle a nested escape sequence into
+# the parser's state machine. See ADR 0003.
 #
 # Do NOT widen the allow-list. If a future use case wants more characters
 # unencoded, weigh it against the cost of re-introducing the original
@@ -63,8 +65,8 @@ _gc_urlencode_buffer() {
 # Shell-side budgets. Below the Rust hard cap (1 MiB) so we never produce
 # a frame the parser will reject silently. Per-entry cap drops individual
 # pathological values (e.g. a multi-MB LS_COLORS) without losing the rest.
-typeset -gri _GC_ENV_TOTAL_BUDGET=524288
-typeset -gri _GC_ENV_PER_VALUE_CAP=16384
+typeset -gi _GC_ENV_TOTAL_BUDGET=524288
+typeset -gi _GC_ENV_PER_VALUE_CAP=16384
 
 _gc_report_env() {
     [[ -n "$GHOST_COMPLETE_ACTIVE" ]] || return
@@ -223,9 +225,10 @@ _gc_install_zle_hook() {
     #   1. No widget registered         → direct-install _gc_report_buffer.
     #   2. Existing plain user widget   → chain over it so $WIDGET is preserved.
     #   3. Existing non-user widget
-    #      (completion:/builtin:/…)     → leave it alone. We can't chain a
-    #      non-user widget safely, and silently clobbering someone else's
-    #      registration is worse than losing our buffer hook.
+    #      (completion:/builtin:/…)     → don't clobber it; emit OSC 7774
+    #      zle_hook_disabled so the proxy can warn. We can't chain a non-user
+    #      widget safely, and silently clobbering someone else's registration
+    #      is worse than losing our buffer hook.
     if (( ! ${+widgets[zle-line-pre-redraw]} )); then
         zle -N zle-line-pre-redraw _gc_report_buffer
     elif [[ "${widgets[zle-line-pre-redraw]}" == user:* ]]; then

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -236,9 +236,16 @@ _gc_install_zle_hook() {
             zle _gc_orig_zle_line_pre_redraw -- "$@"
         }
         zle -N zle-line-pre-redraw _gc_zle_line_pre_redraw
+    else
+        # Non-user widget: chaining is unsafe. Don't clobber, but record a
+        # diagnostic so the proxy can surface a clear warning.
+        local descriptor="${widgets[zle-line-pre-redraw]}"
+        local encoded_desc
+        encoded_desc="$(_gc_urlencode_buffer "$descriptor")"
+        if [[ -n "$GHOST_COMPLETE_ACTIVE" ]]; then
+            printf '\e]7774;zle_hook_disabled;%s\a' "$encoded_desc"
+        fi
     fi
-    # Non-user widget: intentionally no-op. Ghost Complete loses its buffer
-    # hook in this case; that's acceptable degradation.
 }
 
 _gc_install_zle_hook

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -60,26 +60,80 @@ _gc_urlencode_buffer() {
     printf '%s' "$encoded"
 }
 
+# Shell-side budgets. Below the Rust hard cap (1 MiB) so we never produce
+# a frame the parser will reject silently. Per-entry cap drops individual
+# pathological values (e.g. a multi-MB LS_COLORS) without losing the rest.
+typeset -gri _GC_ENV_TOTAL_BUDGET=524288
+typeset -gri _GC_ENV_PER_VALUE_CAP=16384
+
 _gc_report_env() {
     [[ -n "$GHOST_COMPLETE_ACTIVE" ]] || return
 
-    local key meta value encoded payload=""
+    local key meta value encoded entry payload="" truncated=0
+    local -i used=0
 
-    for key in ${(ok)parameters[(R)*export*]}; do
-        meta="${parameters[$key]}"
-        [[ "$meta" == *scalar* ]] || continue
-        [[ -n "$key" && "$key" != [0-9]* && "$key" != *[^a-zA-Z0-9_]* ]] || continue
+    # High-priority groups first so credentials/PATH survive a tight budget.
+    local -a essentials=(PATH HOME USER SHELL PWD OLDPWD LANG TERM \
+        GHOSTTY_RESOURCES_DIR KITTY_WINDOW_ID WEZTERM_UNIX_SOCKET \
+        ALACRITTY_SOCKET ZED_TERM VSCODE_INJECTION ITERM_SESSION_ID)
+    local -a auth_prefixes=(AWS_ GITHUB_ GH_ GOOGLE_ DOCKER_ KUBECONFIG \
+        SSH_AUTH_SOCK XDG_)
 
-        value="${(P)key}"
-        encoded="$(_gc_urlencode_buffer "${key}=${value}")"
-        payload+="${encoded}%00"
+    _gc_env_emit() {
+        local k="$1"
+        # Skip GC-internal vars so we never leak our own state.
+        case "$k" in
+            GHOST_COMPLETE_*|_GC_*) return ;;
+        esac
+        [[ -n "$k" && "$k" != [0-9]* && "$k" != *[^a-zA-Z0-9_]* ]] || return
+        meta="${parameters[$k]}"
+        [[ "$meta" == *scalar* && "$meta" == *export* ]] || return
+        value="${(P)k}"
+        entry="$(_gc_urlencode_buffer "${k}=${value}")"
+        if (( ${#entry} > _GC_ENV_PER_VALUE_CAP )); then
+            truncated=1
+            return
+        fi
+        if (( used + ${#entry} + 3 > _GC_ENV_TOTAL_BUDGET )); then
+            truncated=1
+            return
+        fi
+        payload+="${entry}%00"
+        (( used += ${#entry} + 3 ))
+    }
+
+    local k_seen=""
+    for key in "${essentials[@]}"; do
+        _gc_env_emit "$key"
+        k_seen+="|$key|"
     done
+    local prefix
+    for key in ${(ok)parameters[(R)*export*]}; do
+        for prefix in "${auth_prefixes[@]}"; do
+            [[ "$key" == ${prefix}* ]] || continue
+            [[ "$k_seen" == *"|$key|"* ]] && continue
+            _gc_env_emit "$key"
+            k_seen+="|$key|"
+        done
+    done
+    for key in ${(ok)parameters[(R)*export*]}; do
+        [[ "$k_seen" == *"|$key|"* ]] && continue
+        _gc_env_emit "$key"
+    done
+
+    unset -f _gc_env_emit
 
     if [[ "$payload" == "${_GC_LAST_ENV_PAYLOAD-}" ]]; then
         return
     fi
     typeset -g _GC_LAST_ENV_PAYLOAD="$payload"
     printf '\e]7773;%s\a' "$payload"
+
+    # Truncation diagnostic on OSC 7774. One-shot via _GC_ENV_TRUNCATED_REPORTED.
+    if (( truncated )) && [[ -z "${_GC_ENV_TRUNCATED_REPORTED-}" ]]; then
+        typeset -g _GC_ENV_TRUNCATED_REPORTED=1
+        printf '\e]7774;env_truncated;%d\a' "$used"
+    fi
 }
 
 # True when the host terminal natively parses OSC 133 for its own prompt

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -143,8 +143,9 @@ _gc_report_env() {
 # OSC 633). In those terminals our OSC 7771 fallback is redundant — the
 # terminal already understands the OSC 133 we emit below, and OSC 7771
 # only exists for terminals that mangle OSC 133. Currently covers
-# Ghostty, Zed, and VSCode (the latter only once its shell integration
-# is active, signalled by VSCODE_INJECTION being set).
+# Ghostty, Kitty, WezTerm, Rio, Zed, and VSCode (the latter only once
+# its shell integration is active, signalled by VSCODE_INJECTION being
+# set).
 _gc_native_osc133() {
     [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
     [[ -n "$KITTY_WINDOW_ID" ]] && return 0
@@ -226,9 +227,11 @@ _gc_install_zle_hook() {
     #   2. Existing plain user widget   → chain over it so $WIDGET is preserved.
     #   3. Existing non-user widget
     #      (completion:/builtin:/…)     → don't clobber it; emit OSC 7774
-    #      zle_hook_disabled so the proxy can warn. We can't chain a non-user
-    #      widget safely, and silently clobbering someone else's registration
-    #      is worse than losing our buffer hook.
+    #      zle_hook_disabled (only when $GHOST_COMPLETE_ACTIVE is set, so
+    #      we don't leak the frame to a bare terminal) so the proxy can
+    #      warn. We can't chain a non-user widget safely, and silently
+    #      clobbering someone else's registration is worse than losing
+    #      our buffer hook.
     if (( ! ${+widgets[zle-line-pre-redraw]} )); then
         zle -N zle-line-pre-redraw _gc_report_buffer
     elif [[ "${widgets[zle-line-pre-redraw]}" == user:* ]]; then
@@ -241,7 +244,9 @@ _gc_install_zle_hook() {
         zle -N zle-line-pre-redraw _gc_zle_line_pre_redraw
     else
         # Non-user widget: chaining is unsafe. Don't clobber, but record a
-        # diagnostic so the proxy can surface a clear warning.
+        # diagnostic so the proxy can surface a clear warning. The 7774
+        # emission is gated on $GHOST_COMPLETE_ACTIVE so we don't leak the
+        # frame to a bare terminal when the proxy isn't watching.
         local descriptor="${widgets[zle-line-pre-redraw]}"
         local encoded_desc
         encoded_desc="$(_gc_urlencode_buffer "$descriptor")"

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -91,6 +91,9 @@ _gc_report_env() {
 # is active, signalled by VSCODE_INJECTION being set).
 _gc_native_osc133() {
     [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
+    [[ -n "$KITTY_WINDOW_ID" ]] && return 0
+    [[ -n "$WEZTERM_UNIX_SOCKET" || "$TERM_PROGRAM" == "WezTerm" ]] && return 0
+    [[ "$TERM_PROGRAM" == "rio" ]] && return 0
     [[ -n "$ZED_TERM" ]] && return 0
     [[ -n "$VSCODE_INJECTION" ]] && return 0
     return 1

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -78,6 +78,7 @@ __ghost_complete_init() {
     fi
     local supported=0
     if [[ -n "$KITTY_WINDOW_ID" ]] \
+      || [[ -n "$WEZTERM_UNIX_SOCKET" ]] \
       || [[ -n "$ALACRITTY_SOCKET" ]] \
       || [[ -n "$ZED_TERM" ]] \
       || [[ -n "$VSCODE_IPC_HOOK_CLI" ]]; then


### PR DESCRIPTION
## Summary

Plan #2 of the **0.17 "polish & trust"** milestone — a TDD sweep closing 11
zsh/macOS correctness gaps across OSC framing, terminal detection, command
segmentation, and shell-side diagnostics.

**OSC framing & private-frame stripping**
- Round-trip test pins that the OSC 7 encoder leaves `;` paths intact (`gc-pty`).
- `_gc_urlencode_path` tightened to a strict `[a-zA-Z0-9._~/-]` allow-list.
- `PrivateOscFilter` generalized from a single fixed code to a code-set scan,
  stripping the full GC-private `7770`–`7774` range from terminal-bound bytes.

**Terminal detection & rendering**
- `init.zsh` direct-detection branch aligned with the `gc-terminal` matrix
  (WezTerm via `WEZTERM_UNIX_SOCKET`), pinned by a parity test.
- Kitty / WezTerm / Rio added to the native-OSC-133 fast path in
  `_gc_native_osc133`.

**Command segmentation**
- Command-context segmentation now splits on `Token::Background` (`&`), so a
  token after `&` — e.g. `sleep 1 & git ` — gets its own completion context.

**Shell-side robustness**
- `_gc_report_buffer` gated on `GHOST_COMPLETE_ACTIVE` (no buffer reports when
  the proxy isn't the consumer).
- `_gc_report_env` enforces a 512 KiB total / 16 KiB per-value byte budget with
  priority groups.

**Runtime diagnostics — new OSC 7774**
- Env-snapshot truncation and ZLE-hook-disabled conditions now emit a
  structured, terminal-invisible OSC 7774 frame.
- The parser dispatches `7774` into `TerminalState.last_diagnostic` + a
  `tracing::warn!`.
- Reserved and specified in **ADR-0007**
  (`docs/adr/0007-osc7774-runtime-diagnostics.md`).

11 commits, one per task, built with subagent-driven TDD — every task started
from a test confirmed to fail for the right reason before implementation.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo test --workspace` | 56 test binaries, all `ok`, 0 failures |

## Test Plan

Automated gates above are green. Outstanding **manual smoke** on real
interactive terminals (not yet run — requires a human at a real Ghostty +
iTerm2):

- [ ] Proxied shell in **Ghostty** *and* **iTerm2**:
  `cd /tmp && mkdir -p 'foo;bar' && cd 'foo;bar'` → path completions resolve
  inside the semicolon directory (proxy CWD not truncated at `;`)
- [ ] `sleep 1 & git ` → git subcommand suggestions appear for the token
  after `&`
- [ ] No stray `]7770`–`]7774` OSC text or garbage glyphs in the terminal or
  scrollback during the above
