### PR TITLE
Overlay rendering polish: one DECSET 2026 frame per overlay update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
  "dirs",
  "gc-config",
  "gc-overlay",
+ "gc-parser",
  "gc-pty",
  "gc-suggest",
  "gc-terminal",

--- a/crates/gc-overlay/Cargo.toml
+++ b/crates/gc-overlay/Cargo.toml
@@ -21,3 +21,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 [[bench]]
 name = "feedback_render"
 harness = false
+
+[[bench]]
+name = "popup_render"
+harness = false

--- a/crates/gc-overlay/benches/popup_render.rs
+++ b/crates/gc-overlay/benches/popup_render.rs
@@ -1,0 +1,354 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use gc_overlay::{
+    clear_detail_box, clear_popup_unframed, render_detail_box, render_popup, render_popup_unframed,
+    with_overlay_update_frame, DetailLayout, DetailPosition, FeedbackKind, OverlayState,
+    PopupLayout, PopupTheme,
+};
+use gc_suggest::{Suggestion, SuggestionKind, SuggestionSource};
+use gc_terminal::TerminalProfile;
+use std::hint::black_box;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_suggestion(text: &str, desc: Option<&str>, kind: SuggestionKind) -> Suggestion {
+    Suggestion {
+        text: text.to_string(),
+        description: desc.map(String::from),
+        kind,
+        source: SuggestionSource::Spec,
+        ..Default::default()
+    }
+}
+
+fn make_suggestions(n: usize) -> Vec<Suggestion> {
+    (0..n)
+        .map(|i| {
+            make_suggestion(
+                &format!("suggestion-{i:04}"),
+                Some("A description for benchmark item"),
+                SuggestionKind::Subcommand,
+            )
+        })
+        .collect()
+}
+
+fn bordered_theme() -> PopupTheme {
+    PopupTheme {
+        borders: true,
+        ..PopupTheme::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// bench_popup_render
+// Framed render_popup with representative suggestion counts x 2 profiles
+// x 2 border variants.
+// ---------------------------------------------------------------------------
+
+fn bench_popup_render(c: &mut Criterion) {
+    let ghostty = TerminalProfile::for_ghostty();
+    let iterm2 = TerminalProfile::for_iterm2();
+    let state = OverlayState::new();
+
+    let profiles: &[(&str, &TerminalProfile)] = &[("ghostty", &ghostty), ("iterm2", &iterm2)];
+    let counts = [10usize, 100, 500];
+
+    let mut group = c.benchmark_group("bench_popup_render");
+
+    for &count in &counts {
+        let suggestions = make_suggestions(count);
+
+        for (profile_name, profile) in profiles {
+            // Unbordered
+            group.bench_with_input(
+                BenchmarkId::new(format!("{profile_name}/unbordered"), count),
+                &suggestions,
+                |b, sugs| {
+                    b.iter(|| {
+                        let mut buf = Vec::with_capacity(4096);
+                        let layout = render_popup(
+                            &mut buf,
+                            black_box(sugs),
+                            black_box(&state),
+                            black_box(10u16),
+                            black_box(0u16),
+                            black_box(40u16),
+                            black_box(120u16),
+                            black_box(10usize),
+                            black_box(20u16),
+                            black_box(60u16),
+                            black_box(&PopupTheme::default()),
+                            black_box(0u16),
+                            black_box(FeedbackKind::None),
+                            black_box(profile),
+                        );
+                        black_box(buf);
+                        black_box(layout);
+                    });
+                },
+            );
+
+            // Bordered
+            group.bench_with_input(
+                BenchmarkId::new(format!("{profile_name}/bordered"), count),
+                &suggestions,
+                |b, sugs| {
+                    let theme = bordered_theme();
+                    b.iter(|| {
+                        let mut buf = Vec::with_capacity(4096);
+                        let layout = render_popup(
+                            &mut buf,
+                            black_box(sugs),
+                            black_box(&state),
+                            black_box(10u16),
+                            black_box(0u16),
+                            black_box(40u16),
+                            black_box(120u16),
+                            black_box(10usize),
+                            black_box(20u16),
+                            black_box(60u16),
+                            black_box(&theme),
+                            black_box(0u16),
+                            black_box(FeedbackKind::None),
+                            black_box(profile),
+                        );
+                        black_box(buf);
+                        black_box(layout);
+                    });
+                },
+            );
+        }
+    }
+
+    // Feedback-only (loading indicator, no suggestions)
+    for (profile_name, profile) in profiles {
+        group.bench_function(format!("{profile_name}/feedback_only_loading"), |b| {
+            b.iter(|| {
+                let mut buf = Vec::with_capacity(256);
+                let layout = render_popup(
+                    &mut buf,
+                    black_box(&[]),
+                    black_box(&state),
+                    black_box(10u16),
+                    black_box(0u16),
+                    black_box(40u16),
+                    black_box(120u16),
+                    black_box(10usize),
+                    black_box(20u16),
+                    black_box(60u16),
+                    black_box(&PopupTheme::default()),
+                    black_box(0u16),
+                    black_box(FeedbackKind::Loading { frame: 3 }),
+                    black_box(profile),
+                );
+                black_box(buf);
+                black_box(layout);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// bench_detail_render
+// render_detail_box with short / wrapped(long) / CJK / ANSI-containing
+// descriptions.
+// ---------------------------------------------------------------------------
+
+fn bench_detail_render(c: &mut Criterion) {
+    // A non-trivial layout that exercises real content rendering.
+    let layout = DetailLayout {
+        start_row: 6,
+        start_col: 62,
+        width: 40,
+        height: 8,
+        position: DetailPosition::SideRight,
+    };
+    let theme = PopupTheme::default();
+    let bordered = bordered_theme();
+
+    let short_desc = "Switch branches or restore working tree files.";
+    let long_desc = "Switches branches or restores working tree files. This is a \
+        very long description that will need to be word-wrapped across multiple \
+        lines in the detail box. It exercises the wrap_description path.";
+    let cjk_desc = "日本語の説明文です。これはテストです。Unicode幅の計算が正しく動作するかを確認するための文字列。";
+    let ansi_desc = "\x1b[2JThis description contains ANSI escape sequences \
+        like \x1b[31mred text\x1b[0m that must be sanitized before rendering.";
+
+    let mut group = c.benchmark_group("bench_detail_render");
+
+    group.bench_function("short_unbordered", |b| {
+        b.iter(|| {
+            let mut buf = Vec::with_capacity(512);
+            render_detail_box(
+                &mut buf,
+                black_box(&layout),
+                black_box(short_desc),
+                black_box(&theme),
+            );
+            black_box(buf);
+        });
+    });
+
+    group.bench_function("long_wrapped_unbordered", |b| {
+        b.iter(|| {
+            let mut buf = Vec::with_capacity(1024);
+            render_detail_box(
+                &mut buf,
+                black_box(&layout),
+                black_box(long_desc),
+                black_box(&theme),
+            );
+            black_box(buf);
+        });
+    });
+
+    group.bench_function("cjk_unbordered", |b| {
+        b.iter(|| {
+            let mut buf = Vec::with_capacity(1024);
+            render_detail_box(
+                &mut buf,
+                black_box(&layout),
+                black_box(cjk_desc),
+                black_box(&theme),
+            );
+            black_box(buf);
+        });
+    });
+
+    group.bench_function("ansi_sanitized_unbordered", |b| {
+        b.iter(|| {
+            let mut buf = Vec::with_capacity(512);
+            render_detail_box(
+                &mut buf,
+                black_box(&layout),
+                black_box(ansi_desc),
+                black_box(&theme),
+            );
+            black_box(buf);
+        });
+    });
+
+    // Bordered variant
+    let bordered_layout = DetailLayout {
+        start_row: 6,
+        start_col: 62,
+        width: 40,
+        height: 10,
+        position: DetailPosition::SideRight,
+    };
+
+    group.bench_function("long_wrapped_bordered", |b| {
+        b.iter(|| {
+            let mut buf = Vec::with_capacity(1024);
+            render_detail_box(
+                &mut buf,
+                black_box(&bordered_layout),
+                black_box(long_desc),
+                black_box(&bordered),
+            );
+            black_box(buf);
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// bench_full_update
+// A full overlay update: clear old popup + clear old detail + render new
+// popup + render new detail, all staged into one buffer inside
+// with_overlay_update_frame. Uses unframed primitives inside one frame.
+// ---------------------------------------------------------------------------
+
+fn bench_full_update(c: &mut Criterion) {
+    let ghostty = TerminalProfile::for_ghostty();
+    let iterm2 = TerminalProfile::for_iterm2();
+    let state = OverlayState::new();
+    let theme = PopupTheme::default();
+    let suggestions = make_suggestions(50);
+
+    let profiles: &[(&str, &TerminalProfile)] = &[("ghostty", &ghostty), ("iterm2", &iterm2)];
+
+    // Prior layout to clear
+    let prior_popup = PopupLayout {
+        start_row: 6,
+        start_col: 0,
+        width: 60,
+        height: 10,
+        scroll_deficit: 0,
+    };
+    let prior_detail = DetailLayout {
+        start_row: 6,
+        start_col: 62,
+        width: 40,
+        height: 8,
+        position: DetailPosition::SideRight,
+    };
+
+    let description = "Switches branches or restores working tree files. A longer description \
+        that exercises word wrapping in the detail box render path.";
+
+    let mut group = c.benchmark_group("bench_full_update");
+
+    for (profile_name, profile) in profiles {
+        group.bench_function(format!("{profile_name}/50_suggestions"), |b| {
+            b.iter(|| {
+                let mut buf = Vec::with_capacity(8192);
+                with_overlay_update_frame(&mut buf, black_box(profile), |buf| {
+                    // Clear prior surfaces
+                    clear_popup_unframed(buf, black_box(&prior_popup));
+                    clear_detail_box(buf, black_box(&prior_detail));
+
+                    // Render new popup (unframed — we own the outer frame)
+                    let new_layout = render_popup_unframed(
+                        buf,
+                        black_box(&suggestions),
+                        black_box(&state),
+                        black_box(10u16),
+                        black_box(0u16),
+                        black_box(40u16),
+                        black_box(120u16),
+                        black_box(10usize),
+                        black_box(20u16),
+                        black_box(60u16),
+                        black_box(&theme),
+                        black_box(0u16),
+                        black_box(FeedbackKind::Loading { frame: 1 }),
+                    );
+
+                    // Render new detail box (already unframed)
+                    let detail_layout = DetailLayout {
+                        start_row: new_layout.start_row,
+                        start_col: new_layout.start_col + new_layout.width + 1,
+                        width: 40,
+                        height: 8,
+                        position: DetailPosition::SideRight,
+                    };
+                    render_detail_box(
+                        buf,
+                        black_box(&detail_layout),
+                        black_box(description),
+                        black_box(&theme),
+                    );
+
+                    black_box(new_layout);
+                });
+                black_box(buf);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_popup_render,
+    bench_detail_render,
+    bench_full_update
+);
+criterion_main!(benches);

--- a/crates/gc-overlay/benches/popup_render.rs
+++ b/crates/gc-overlay/benches/popup_render.rs
@@ -51,8 +51,16 @@ fn bench_popup_render(c: &mut Criterion) {
     let ghostty = TerminalProfile::for_ghostty();
     let iterm2 = TerminalProfile::for_iterm2();
     let state = OverlayState::new();
+    // Themes are hoisted out of every `b.iter` closure: `PopupTheme::default()`
+    // allocates ~8 `Vec<u8>` fields, and charging that to the timed region
+    // would skew the measurement toward theme construction over render work.
+    let default_theme = PopupTheme::default();
+    let bordered = bordered_theme();
 
     let profiles: &[(&str, &TerminalProfile)] = &[("ghostty", &ghostty), ("iterm2", &iterm2)];
+    // 10 exercises the sub-max_visible fast path; 100/500 confirm render
+    // cost is O(max_visible), not O(n), once the list exceeds the visible
+    // window (compute_layout only measures the visible slice).
     let counts = [10usize, 100, 500];
 
     let mut group = c.benchmark_group("bench_popup_render");
@@ -79,7 +87,7 @@ fn bench_popup_render(c: &mut Criterion) {
                             black_box(10usize),
                             black_box(20u16),
                             black_box(60u16),
-                            black_box(&PopupTheme::default()),
+                            black_box(&default_theme),
                             black_box(0u16),
                             black_box(FeedbackKind::None),
                             black_box(profile),
@@ -95,7 +103,6 @@ fn bench_popup_render(c: &mut Criterion) {
                 BenchmarkId::new(format!("{profile_name}/bordered"), count),
                 &suggestions,
                 |b, sugs| {
-                    let theme = bordered_theme();
                     b.iter(|| {
                         let mut buf = Vec::with_capacity(4096);
                         let layout = render_popup(
@@ -109,7 +116,7 @@ fn bench_popup_render(c: &mut Criterion) {
                             black_box(10usize),
                             black_box(20u16),
                             black_box(60u16),
-                            black_box(&theme),
+                            black_box(&bordered),
                             black_box(0u16),
                             black_box(FeedbackKind::None),
                             black_box(profile),
@@ -138,7 +145,7 @@ fn bench_popup_render(c: &mut Criterion) {
                     black_box(10usize),
                     black_box(20u16),
                     black_box(60u16),
-                    black_box(&PopupTheme::default()),
+                    black_box(&default_theme),
                     black_box(0u16),
                     black_box(FeedbackKind::Loading { frame: 3 }),
                     black_box(profile),
@@ -175,7 +182,10 @@ fn bench_detail_render(c: &mut Criterion) {
         very long description that will need to be word-wrapped across multiple \
         lines in the detail box. It exercises the wrap_description path.";
     let cjk_desc = "日本語の説明文です。これはテストです。Unicode幅の計算が正しく動作するかを確認するための文字列。";
-    let ansi_desc = "\x1b[2JThis description contains ANSI escape sequences \
+    // Benign SGR sequences only (bold/red/reset) — exercises the same
+    // `sanitize_display_text` strip path without a screen-clearing escape
+    // (e.g. CSI 2J) sitting in the source fixture.
+    let ansi_desc = "\x1b[1mThis description contains ANSI escape sequences \
         like \x1b[31mred text\x1b[0m that must be sanitized before rendering.";
 
     let mut group = c.benchmark_group("bench_detail_render");

--- a/crates/gc-overlay/src/detail.rs
+++ b/crates/gc-overlay/src/detail.rs
@@ -6,12 +6,11 @@
 //! cascade.
 //!
 //! Detail bytes are appended to the same render buffer as the main popup, so
-//! pre-render-buffer terminals receive one coalesced flush. On terminals using
-//! DECSET 2026 synchronized rendering, `clear_popup`/`render_popup` currently
-//! own their sync frames; `clear_detail_box`/`render_detail_box` emit no sync
-//! markers of their own. Callers should keep detail clear/render calls in the
-//! same buffer flush as popup updates, or add an explicit outer sync frame if
-//! both surfaces need to share one synchronized-rendering window.
+//! pre-render-buffer terminals receive one coalesced flush. Detail-box
+//! functions emit raw bytes only. The CALLER owns the synchronized-output
+//! frame via `gc_overlay::with_overlay_update_frame`, so the entire overlay
+//! update (popup + detail) lands inside one balanced DECSET 2026 pair on
+//! Synchronized terminals.
 
 use std::io::Write;
 

--- a/crates/gc-overlay/src/lib.rs
+++ b/crates/gc-overlay/src/lib.rs
@@ -9,6 +9,7 @@ pub mod detail;
 pub mod frame;
 pub(crate) mod layout;
 mod render;
+pub mod sync_frame;
 pub mod types;
 pub(crate) mod util;
 
@@ -21,6 +22,7 @@ pub use render::{
     clear_popup, parse_style, popup_additional_scroll_deficit, render_indicator_row, render_popup,
     FeedbackKind, PopupTheme,
 };
+pub use sync_frame::with_overlay_update_frame;
 pub use types::{
     OverlayState, PopupLayout, DEFAULT_MAX_POPUP_WIDTH, DEFAULT_MAX_VISIBLE,
     DEFAULT_MIN_POPUP_WIDTH,

--- a/crates/gc-overlay/src/lib.rs
+++ b/crates/gc-overlay/src/lib.rs
@@ -19,8 +19,8 @@ pub use detail::{
 };
 pub use frame::{ContentRow, PopupFrame, PopupRow, ScrollbarCell, SpanStyle, StyledSpan};
 pub use render::{
-    clear_popup, parse_style, popup_additional_scroll_deficit, render_indicator_row, render_popup,
-    FeedbackKind, PopupTheme,
+    clear_popup, clear_popup_unframed, parse_style, popup_additional_scroll_deficit,
+    render_indicator_row, render_popup, render_popup_unframed, FeedbackKind, PopupTheme,
 };
 pub use sync_frame::with_overlay_update_frame;
 pub use types::{

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -99,8 +99,8 @@ pub fn popup_additional_scroll_deficit(
     // render the popup at row 1 over prior scrollback. Discard it instead
     // and treat this render as fresh — anchored to cursor_row, scrolling
     // only the room actually needed below. Same guard mirrored in
-    // `render_popup` and `render_feedback_only_popup`; keep all three in
-    // sync.
+    // `render_popup_unframed` and `render_feedback_only_popup_unframed`;
+    // keep all three in sync.
     let effective_prior = if prior_deficit >= cursor_row {
         0
     } else {

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -246,6 +246,16 @@ pub fn render_popup(
 /// Callers that own a surrounding `with_overlay_update_frame` can call this
 /// directly to fold multiple overlay operations into a single atomic frame.
 /// The public `render_popup` is the framed convenience wrapper.
+///
+/// # Atomicity contract
+///
+/// This function emits NO DECSET 2026 markers. On
+/// `RenderStrategy::Synchronized` terminals, calling it without a surrounding
+/// `with_overlay_update_frame` silently loses atomicity and may flicker as
+/// partial paints reach the screen. Callers MUST either (a) call the framed
+/// wrapper `render_popup` instead, or (b) invoke this from inside a
+/// `with_overlay_update_frame` body. The `_unframed` suffix marks the
+/// type-by-convention contract; there is no compile-time enforcement.
 #[allow(clippy::too_many_arguments)]
 pub fn render_popup_unframed(
     buf: &mut Vec<u8>,
@@ -274,6 +284,9 @@ pub fn render_popup_unframed(
 
     // Suppress rendering when terminal is too narrow — must check BEFORE any
     // terminal state mutation (scrolling, cursor save) to avoid corruption.
+    // Sync markers, if any, are emitted by the caller
+    // (`with_overlay_update_frame`), which rolls back the speculative
+    // `begin_sync` when this early return leaves the body buffer untouched.
     if screen_cols < min_width {
         return PopupLayout {
             start_row: 0,
@@ -802,6 +815,16 @@ pub fn clear_popup(buf: &mut Vec<u8>, layout: &PopupLayout, profile: &TerminalPr
 /// Callers that own a surrounding `with_overlay_update_frame` can call this
 /// directly to fold multiple overlay operations into a single atomic frame.
 /// The public `clear_popup` is the framed convenience wrapper.
+///
+/// # Atomicity contract
+///
+/// This function emits NO DECSET 2026 markers. On
+/// `RenderStrategy::Synchronized` terminals, calling it without a surrounding
+/// `with_overlay_update_frame` silently loses atomicity and may flicker as
+/// partial paints reach the screen. Callers MUST either (a) call the framed
+/// wrapper `clear_popup` instead, or (b) invoke this from inside a
+/// `with_overlay_update_frame` body. The `_unframed` suffix marks the
+/// type-by-convention contract; there is no compile-time enforcement.
 pub fn clear_popup_unframed(buf: &mut Vec<u8>, layout: &PopupLayout) {
     if layout.height == 0 || layout.width == 0 {
         return;

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -217,26 +217,9 @@ pub fn render_popup(
     feedback: FeedbackKind,
     profile: &TerminalProfile,
 ) -> PopupLayout {
-    // Fast-exit paths emit ZERO bytes — check before entering the sync frame.
-    if suggestions.is_empty() && !feedback.reserves_row() {
-        return PopupLayout {
-            start_row: 0,
-            start_col: 0,
-            width: 0,
-            height: 0,
-            scroll_deficit: prior_deficit,
-        };
-    }
-    if screen_cols < min_width {
-        return PopupLayout {
-            start_row: 0,
-            start_col: 0,
-            width: 0,
-            height: 0,
-            scroll_deficit: prior_deficit,
-        };
-    }
-
+    // Pure wrapper: all early-exit logic lives in `render_popup_unframed`.
+    // `with_overlay_update_frame` already short-circuits a no-op body to
+    // zero bytes, so an early-exit unframed render emits nothing here too.
     let mut layout = None;
     crate::sync_frame::with_overlay_update_frame(buf, profile, |buf| {
         layout = Some(render_popup_unframed(
@@ -807,9 +790,8 @@ fn truncate_to_display_cols(text: &str, max_cols: usize) -> (String, usize) {
 /// single `with_overlay_update_frame` call so the whole clear is one atomic
 /// synchronized frame on `RenderStrategy::Synchronized` terminals.
 pub fn clear_popup(buf: &mut Vec<u8>, layout: &PopupLayout, profile: &TerminalProfile) {
-    if layout.height == 0 || layout.width == 0 {
-        return;
-    }
+    // Pure wrapper: the zero-size guard lives in `clear_popup_unframed`.
+    // `with_overlay_update_frame` short-circuits a no-op body to zero bytes.
     crate::sync_frame::with_overlay_update_frame(buf, profile, |buf| {
         clear_popup_unframed(buf, layout);
     });

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -196,6 +196,10 @@ pub fn parse_style(style_str: &str) -> Result<Vec<u8>> {
 /// renders, possibly across dismiss/re-trigger cycles until a CPR sync or
 /// resize invalidates it. It prevents re-scrolling by accounting for viewport
 /// shifts that the parser doesn't know about.
+///
+/// This is the framed public wrapper: it wraps `render_popup_unframed` in a
+/// single `with_overlay_update_frame` call so the whole update is one atomic
+/// synchronized frame on `RenderStrategy::Synchronized` terminals.
 #[allow(clippy::too_many_arguments)]
 pub fn render_popup(
     buf: &mut Vec<u8>,
@@ -213,6 +217,68 @@ pub fn render_popup(
     feedback: FeedbackKind,
     profile: &TerminalProfile,
 ) -> PopupLayout {
+    // Fast-exit paths emit ZERO bytes — check before entering the sync frame.
+    if suggestions.is_empty() && !feedback.reserves_row() {
+        return PopupLayout {
+            start_row: 0,
+            start_col: 0,
+            width: 0,
+            height: 0,
+            scroll_deficit: prior_deficit,
+        };
+    }
+    if screen_cols < min_width {
+        return PopupLayout {
+            start_row: 0,
+            start_col: 0,
+            width: 0,
+            height: 0,
+            scroll_deficit: prior_deficit,
+        };
+    }
+
+    let mut layout = None;
+    crate::sync_frame::with_overlay_update_frame(buf, profile, |buf| {
+        layout = Some(render_popup_unframed(
+            buf,
+            suggestions,
+            state,
+            cursor_row,
+            cursor_col,
+            screen_rows,
+            screen_cols,
+            max_visible,
+            min_width,
+            max_width,
+            theme,
+            prior_deficit,
+            feedback,
+        ));
+    });
+    layout.expect("with_overlay_update_frame body always runs exactly once")
+}
+
+/// Byte-staging body of `render_popup` without sync-frame markers.
+///
+/// Callers that own a surrounding `with_overlay_update_frame` can call this
+/// directly to fold multiple overlay operations into a single atomic frame.
+/// The public `render_popup` is the framed convenience wrapper.
+#[allow(clippy::too_many_arguments)]
+pub fn render_popup_unframed(
+    buf: &mut Vec<u8>,
+    suggestions: &[Suggestion],
+    state: &OverlayState,
+    cursor_row: u16,
+    cursor_col: u16,
+    screen_rows: u16,
+    screen_cols: u16,
+    max_visible: usize,
+    min_width: u16,
+    max_width: u16,
+    theme: &PopupTheme,
+    prior_deficit: u16,
+    feedback: FeedbackKind,
+) -> PopupLayout {
     if suggestions.is_empty() && !feedback.reserves_row() {
         return PopupLayout {
             start_row: 0,
@@ -224,7 +290,7 @@ pub fn render_popup(
     }
 
     // Suppress rendering when terminal is too narrow — must check BEFORE any
-    // terminal state mutation (sync, scrolling, cursor save) to avoid corruption.
+    // terminal state mutation (scrolling, cursor save) to avoid corruption.
     if screen_cols < min_width {
         return PopupLayout {
             start_row: 0,
@@ -236,7 +302,7 @@ pub fn render_popup(
     }
 
     if suggestions.is_empty() {
-        return render_feedback_only_popup(
+        return render_feedback_only_popup_unframed(
             buf,
             cursor_row,
             cursor_col,
@@ -247,7 +313,6 @@ pub fn render_popup(
             theme,
             prior_deficit,
             feedback,
-            profile,
         );
     }
 
@@ -296,14 +361,6 @@ pub fn render_popup(
     let total_deficit = effective_prior.saturating_add(new_deficit);
     let final_cursor_row = cursor_row.saturating_sub(total_deficit);
 
-    let use_sync = matches!(
-        profile.render_strategy(),
-        gc_terminal::RenderStrategy::Synchronized
-    );
-    if use_sync {
-        ansi::begin_sync(buf);
-    }
-
     // Scroll viewport if we need more room
     if new_deficit > 0 {
         // Move to last viewport row so newlines cause actual scrolls
@@ -333,9 +390,6 @@ pub fn render_popup(
 
     if layout.height == 0 {
         ansi::restore_cursor(buf);
-        if use_sync {
-            ansi::end_sync(buf);
-        }
         return PopupLayout {
             scroll_deficit: total_deficit,
             ..layout
@@ -529,9 +583,6 @@ pub fn render_popup(
     }
 
     ansi::restore_cursor(buf);
-    if use_sync {
-        ansi::end_sync(buf);
-    }
 
     PopupLayout {
         height: layout.height + loading_extra,
@@ -541,7 +592,7 @@ pub fn render_popup(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn render_feedback_only_popup(
+fn render_feedback_only_popup_unframed(
     buf: &mut Vec<u8>,
     cursor_row: u16,
     cursor_col: u16,
@@ -552,13 +603,12 @@ fn render_feedback_only_popup(
     theme: &PopupTheme,
     prior_deficit: u16,
     feedback: FeedbackKind,
-    profile: &TerminalProfile,
 ) -> PopupLayout {
     let border_pad: u16 = if theme.borders { 2 } else { 0 };
     let effective_max_w = max_width.min(screen_cols).max(min_width);
     let width = min_width.min(effective_max_w);
     let base_height = 1 + border_pad;
-    // Mirror the discard logic in `render_popup`: when prior_deficit >=
+    // Mirror the discard logic in `render_popup_unframed`: when prior_deficit >=
     // cursor_row the cached value is stale and would pin the indicator at
     // row 1 even after clamping. Drop it and recompute fresh.
     let effective_prior = if prior_deficit >= cursor_row {
@@ -578,14 +628,7 @@ fn render_feedback_only_popup(
         cursor_col
     };
     let content_width = width.saturating_sub(border_pad);
-    let use_sync = matches!(
-        profile.render_strategy(),
-        gc_terminal::RenderStrategy::Synchronized
-    );
 
-    if use_sync {
-        ansi::begin_sync(buf);
-    }
     if new_deficit > 0 {
         ansi::move_to(buf, screen_rows - 1, 0);
         for _ in 0..new_deficit {
@@ -639,9 +682,6 @@ fn render_feedback_only_popup(
     }
 
     ansi::restore_cursor(buf);
-    if use_sync {
-        ansi::end_sync(buf);
-    }
 
     PopupLayout {
         start_row,
@@ -762,17 +802,27 @@ fn truncate_to_display_cols(text: &str, max_cols: usize) -> (String, usize) {
 }
 
 /// Clear the popup area by overwriting with spaces.
+///
+/// This is the framed public wrapper: it wraps `clear_popup_unframed` in a
+/// single `with_overlay_update_frame` call so the whole clear is one atomic
+/// synchronized frame on `RenderStrategy::Synchronized` terminals.
 pub fn clear_popup(buf: &mut Vec<u8>, layout: &PopupLayout, profile: &TerminalProfile) {
     if layout.height == 0 || layout.width == 0 {
         return;
     }
+    crate::sync_frame::with_overlay_update_frame(buf, profile, |buf| {
+        clear_popup_unframed(buf, layout);
+    });
+}
 
-    let use_sync = matches!(
-        profile.render_strategy(),
-        gc_terminal::RenderStrategy::Synchronized
-    );
-    if use_sync {
-        ansi::begin_sync(buf);
+/// Byte-staging body of `clear_popup` without sync-frame markers.
+///
+/// Callers that own a surrounding `with_overlay_update_frame` can call this
+/// directly to fold multiple overlay operations into a single atomic frame.
+/// The public `clear_popup` is the framed convenience wrapper.
+pub fn clear_popup_unframed(buf: &mut Vec<u8>, layout: &PopupLayout) {
+    if layout.height == 0 || layout.width == 0 {
+        return;
     }
     ansi::save_cursor(buf);
 
@@ -785,9 +835,6 @@ pub fn clear_popup(buf: &mut Vec<u8>, layout: &PopupLayout, profile: &TerminalPr
     }
 
     ansi::restore_cursor(buf);
-    if use_sync {
-        ansi::end_sync(buf);
-    }
 }
 
 /// Strip control characters (including ESC) from text to prevent ANSI injection

--- a/crates/gc-overlay/src/sync_frame.rs
+++ b/crates/gc-overlay/src/sync_frame.rs
@@ -17,6 +17,9 @@ where
     F: FnOnce(&mut Vec<u8>),
 {
     let sync = matches!(profile.render_strategy(), RenderStrategy::Synchronized);
+    // Captured before `begin_sync` so a no-op-body rollback (`truncate(pre)`)
+    // also drops the speculative `begin_sync`; `body_pre` (after it) is the
+    // baseline for detecting whether the body wrote anything.
     let pre = buf.len();
     if sync {
         ansi::begin_sync(buf);

--- a/crates/gc-overlay/src/sync_frame.rs
+++ b/crates/gc-overlay/src/sync_frame.rs
@@ -1,0 +1,87 @@
+//! Caller-owned synchronized-output frame.
+//!
+//! Wraps an overlay update closure with exactly ONE balanced
+//! `begin_sync`/`end_sync` pair on `RenderStrategy::Synchronized`. On
+//! `RenderStrategy::PreRenderBuffer` no markers are emitted; the caller's
+//! single coalesced write is its own atomicity guarantee.
+//!
+//! Empty-render short-circuit: if the closure leaves `buf` unchanged
+//! (`buf.len()` matches the pre-frame length), no sync markers are emitted
+//! — saves the 16-byte cost of `\x1b[?2026h\x1b[?2026l` on no-op renders.
+
+use crate::ansi;
+use gc_terminal::{RenderStrategy, TerminalProfile};
+
+pub fn with_overlay_update_frame<F>(buf: &mut Vec<u8>, profile: &TerminalProfile, body: F)
+where
+    F: FnOnce(&mut Vec<u8>),
+{
+    let sync = matches!(profile.render_strategy(), RenderStrategy::Synchronized);
+    let pre = buf.len();
+    if sync {
+        ansi::begin_sync(buf);
+    }
+    let body_pre = buf.len();
+    body(buf);
+    if sync {
+        if buf.len() == body_pre {
+            // No-op body — roll back the begin_sync to avoid emitting
+            // a useless 16-byte no-op frame.
+            buf.truncate(pre);
+        } else {
+            ansi::end_sync(buf);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gc_terminal::TerminalProfile;
+
+    #[test]
+    fn synchronized_profile_wraps_in_decset_2026() {
+        let mut buf = Vec::new();
+        with_overlay_update_frame(&mut buf, &TerminalProfile::for_ghostty(), |b| {
+            b.extend_from_slice(b"BODY");
+        });
+        assert_eq!(buf, b"\x1b[?2026hBODY\x1b[?2026l");
+    }
+
+    #[test]
+    fn pre_render_profile_emits_no_sync_markers() {
+        let mut buf = Vec::new();
+        with_overlay_update_frame(&mut buf, &TerminalProfile::for_iterm2(), |b| {
+            b.extend_from_slice(b"BODY");
+        });
+        assert_eq!(buf, b"BODY");
+    }
+
+    #[test]
+    fn empty_body_emits_no_bytes_on_synchronized() {
+        let mut buf = Vec::new();
+        with_overlay_update_frame(&mut buf, &TerminalProfile::for_ghostty(), |_b| {});
+        assert!(
+            buf.is_empty(),
+            "no-op body must emit zero bytes; got {:?}",
+            buf
+        );
+    }
+
+    #[test]
+    fn nested_calls_emit_only_one_outer_frame_pair() {
+        // If a caller accidentally nests (anti-pattern), each frame is
+        // independently balanced. Test guards against the prior bug where
+        // popup helpers AND caller both emit sync.
+        let mut buf = Vec::new();
+        with_overlay_update_frame(&mut buf, &TerminalProfile::for_ghostty(), |b| {
+            with_overlay_update_frame(b, &TerminalProfile::for_ghostty(), |bb| {
+                bb.extend_from_slice(b"INNER");
+            });
+        });
+        assert_eq!(buf, b"\x1b[?2026h\x1b[?2026hINNER\x1b[?2026l\x1b[?2026l");
+        // 2 begin + 2 end is correct for nested usage; we just rely on
+        // callers NOT to nest. The unframed primitives in Task 3 are how
+        // we avoid nesting in practice.
+    }
+}

--- a/crates/gc-overlay/src/sync_frame.rs
+++ b/crates/gc-overlay/src/sync_frame.rs
@@ -12,14 +12,51 @@
 use crate::ansi;
 use gc_terminal::{RenderStrategy, TerminalProfile};
 
+/// Wrap an overlay update closure in exactly one balanced DECSET 2026 frame.
+///
+/// Use this to own the outer synchronized-output frame for one overlay tick —
+/// the whole popup + detail box update lands inside a single
+/// `begin_sync`/`end_sync` pair on `RenderStrategy::Synchronized` terminals,
+/// preventing the user from seeing partial paints. On
+/// `RenderStrategy::PreRenderBuffer` no markers are emitted; the caller's
+/// single coalesced `write()` is the atomicity guarantee.
+///
+/// # Invocation contract
+///
+/// `body` is called exactly once. `FnOnce` guarantees AT MOST one call; this
+/// function additionally guarantees AT LEAST one — callers (e.g.
+/// `render_popup`) rely on this to populate `Option<PopupLayout>` captures
+/// inside the closure. Any future refactor that conditionally skips `body`
+/// must update those callers.
+///
+/// # No-op short-circuit
+///
+/// If `body` leaves `buf` unchanged (its post-call length equals the
+/// pre-`begin_sync` length), the speculatively-written `begin_sync` is rolled
+/// back so the call emits zero bytes — saves the 16-byte cost of
+/// `\x1b[?2026h\x1b[?2026l` on no-op renders.
+///
+/// # Do NOT nest
+///
+/// Calling `with_overlay_update_frame` from inside another
+/// `with_overlay_update_frame` body is an anti-pattern: each level emits its
+/// own balanced pair, producing nested markers (see
+/// `nested_calls_emit_independent_frame_pairs` for the exact bytes). To fold
+/// multiple overlay operations into ONE frame, call the `*_unframed`
+/// primitives — `render_popup_unframed`, `clear_popup_unframed`,
+/// `render_detail_box`, `clear_detail_box` — inside the body instead of their
+/// framed wrappers (`render_popup`, `clear_popup`).
 pub fn with_overlay_update_frame<F>(buf: &mut Vec<u8>, profile: &TerminalProfile, body: F)
 where
     F: FnOnce(&mut Vec<u8>),
 {
     let sync = matches!(profile.render_strategy(), RenderStrategy::Synchronized);
-    // Captured before `begin_sync` so a no-op-body rollback (`truncate(pre)`)
-    // also drops the speculative `begin_sync`; `body_pre` (after it) is the
-    // baseline for detecting whether the body wrote anything.
+    // On Synchronized profiles, `pre` snapshots the buffer length BEFORE the
+    // speculative `begin_sync` so a no-op-body rollback (`truncate(pre)`)
+    // drops both the body bytes and the speculative marker. `body_pre` (after
+    // the marker) is the baseline for detecting whether the body wrote
+    // anything. On PreRenderBuffer profiles no marker is emitted, so
+    // `pre == body_pre` and the rollback branch never runs.
     let pre = buf.len();
     if sync {
         ansi::begin_sync(buf);
@@ -72,10 +109,13 @@ mod tests {
     }
 
     #[test]
-    fn nested_calls_emit_only_one_outer_frame_pair() {
-        // If a caller accidentally nests (anti-pattern), each frame is
-        // independently balanced. Test guards against the prior bug where
-        // popup helpers AND caller both emit sync.
+    fn nested_calls_emit_independent_frame_pairs() {
+        // Nesting is an anti-pattern: each `with_overlay_update_frame` level
+        // emits its own balanced `begin_sync`/`end_sync` pair without any
+        // deduplication. Callers must avoid nesting by using the `*_unframed`
+        // primitives inside the outer frame body. This test pins the current
+        // behavior so a regression that breaks the balance — or, conversely,
+        // a refactor that secretly starts deduping — is caught.
         let mut buf = Vec::new();
         with_overlay_update_frame(&mut buf, &TerminalProfile::for_ghostty(), |b| {
             with_overlay_update_frame(b, &TerminalProfile::for_ghostty(), |bb| {
@@ -83,8 +123,5 @@ mod tests {
             });
         });
         assert_eq!(buf, b"\x1b[?2026h\x1b[?2026hINNER\x1b[?2026l\x1b[?2026l");
-        // 2 begin + 2 end is correct for nested usage; we just rely on
-        // callers NOT to nest. The unframed primitives in Task 3 are how
-        // we avoid nesting in practice.
     }
 }

--- a/crates/gc-parser/Cargo.toml
+++ b/crates/gc-parser/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 authors.workspace = true
 publish = false
 
+[features]
+test-utils = []
+
 [dependencies]
 vte = "0.15"
 unicode-width = "0.2.2"

--- a/crates/gc-parser/src/lib.rs
+++ b/crates/gc-parser/src/lib.rs
@@ -8,6 +8,71 @@ mod state;
 
 pub use state::{CprOwner, CprToken, Diagnostic, TerminalState};
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils {
+    /// Build an OSC 7772 envelope for testing: percent-encode the buffer
+    /// with the same allow-list as `shell/ghost-complete.zsh`
+    /// (`[A-Za-z0-9._~/-]` plus space).
+    pub fn build_osc7772_envelope(buffer: &str, cursor: usize) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(b"\x1b]7772;");
+        out.extend_from_slice(cursor.to_string().as_bytes());
+        out.push(b';');
+        for byte in buffer.bytes() {
+            let allowed = matches!(byte,
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9'
+                | b'.' | b'_' | b'~' | b'/' | b'-' | b' '
+            );
+            if allowed {
+                out.push(byte);
+            } else {
+                out.extend_from_slice(format!("%{:02X}", byte).as_bytes());
+            }
+        }
+        out.push(0x07);
+        out
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_simple_buffer_space_passes_through() {
+            // "git " with cursor=4: space is in the allow-list, passes literally
+            let result = build_osc7772_envelope("git ", 4);
+            assert_eq!(result, b"\x1b]7772;4;git \x07");
+        }
+
+        #[test]
+        fn test_semicolon_is_percent_encoded() {
+            // semicolons are OSC param delimiters — must be encoded
+            let result = build_osc7772_envelope(";", 1);
+            assert_eq!(result, b"\x1b]7772;1;%3B\x07");
+        }
+
+        #[test]
+        fn test_esc_bel_percent_are_encoded() {
+            // ESC (0x1B), BEL (0x07), and '%' (0x25) must all be percent-encoded
+            let result = build_osc7772_envelope("\x1b", 1);
+            assert_eq!(result, b"\x1b]7772;1;%1B\x07");
+
+            let result2 = build_osc7772_envelope("\x07", 1);
+            assert_eq!(result2, b"\x1b]7772;1;%07\x07");
+
+            let result3 = build_osc7772_envelope("%", 1);
+            assert_eq!(result3, b"\x1b]7772;1;%25\x07");
+        }
+
+        #[test]
+        fn test_utf8_bytes_percent_encoded() {
+            // UTF-8 multi-byte: "中" = 0xE4 0xB8 0xAD — each byte encoded
+            let result = build_osc7772_envelope("中", 1);
+            assert_eq!(result, b"\x1b]7772;1;%E4%B8%AD\x07");
+        }
+    }
+}
+
 /// Wraps `vte::Parser` and `TerminalState` into a single unit.
 ///
 /// Feed terminal output bytes through [`process_bytes`](Self::process_bytes)

--- a/crates/gc-parser/src/lib.rs
+++ b/crates/gc-parser/src/lib.rs
@@ -70,6 +70,57 @@ pub mod test_utils {
             let result = build_osc7772_envelope("中", 1);
             assert_eq!(result, b"\x1b]7772;1;%E4%B8%AD\x07");
         }
+
+        /// Round-trip: feed the helper's output through `TerminalParser` and
+        /// assert the decoded `(command_buffer, buffer_cursor)` matches the
+        /// originals. Guards against an encoder regression (wrong allow-list
+        /// char, missed percent-encoding for a control byte) silently
+        /// producing envelopes the production decoder rejects — a class of
+        /// bug otherwise visible only as opaque "popup did not render"
+        /// PTY-smoke failures. Mirrors the parallel `build_osc7772` helper
+        /// exercised by `tests/osc7772_proptest.rs`.
+        #[test]
+        fn roundtrip_ascii_only() {
+            let buffer = "git status";
+            let cursor = buffer.chars().count();
+            let envelope = build_osc7772_envelope(buffer, cursor);
+
+            let mut parser = crate::TerminalParser::new(24, 80);
+            parser.process_bytes(&envelope);
+
+            assert_eq!(parser.state().command_buffer(), Some(buffer));
+            assert_eq!(parser.state().buffer_cursor(), cursor);
+        }
+
+        #[test]
+        fn roundtrip_with_percent_encoded_semicolon() {
+            // Semicolon is the OSC param delimiter — encoder must emit `%3B`
+            // and the decoder must reverse it.
+            let buffer = "echo a;b";
+            let cursor = buffer.chars().count();
+            let envelope = build_osc7772_envelope(buffer, cursor);
+
+            let mut parser = crate::TerminalParser::new(24, 80);
+            parser.process_bytes(&envelope);
+
+            assert_eq!(parser.state().command_buffer(), Some(buffer));
+            assert_eq!(parser.state().buffer_cursor(), cursor);
+        }
+
+        #[test]
+        fn roundtrip_with_utf8_multibyte() {
+            // "中" is three bytes (E4 B8 AD), all percent-encoded on the
+            // wire, and counts as a single character for cursor positioning.
+            let buffer = "echo 中";
+            let cursor = buffer.chars().count();
+            let envelope = build_osc7772_envelope(buffer, cursor);
+
+            let mut parser = crate::TerminalParser::new(24, 80);
+            parser.process_bytes(&envelope);
+
+            assert_eq!(parser.state().command_buffer(), Some(buffer));
+            assert_eq!(parser.state().buffer_cursor(), cursor);
+        }
     }
 }
 

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -286,4 +286,75 @@ mod tests {
 
         assert_eq!(handler.lock().unwrap().render_block_ms(), 150);
     }
+
+    /// Drives the full hot-reload seam end-to-end: an on-disk config.toml,
+    /// the real `notify::RecommendedWatcher` (kind filter + 200ms debounce +
+    /// `GhostConfig::load`), and the handler update. The pure-Rust test
+    /// above (`render_block_ms_propagates_on_config_reload`) only exercises
+    /// `apply_config_reload`; if the event-kind filter or `file_name` match
+    /// silently drops a `Modify` event for an in-place rewrite, the
+    /// single-field reload never reaches `update_config` in production —
+    /// this test catches that regression.
+    ///
+    /// Timeout is 5s to tolerate slow CI; the notify backend on macOS is
+    /// fsevents and typically delivers events within ~100ms.
+    #[test]
+    fn render_block_ms_propagates_through_file_watcher() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+
+        rt.block_on(async {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let config_path = dir.path().join("config.toml");
+
+            // Seed with a starting value so the second write is an in-place
+            // Modify (not a Create) — exercises the EventKind::Modify branch
+            // of the kind filter.
+            std::fs::write(&config_path, "[popup]\nrender_block_ms = 90\n").expect("seed config");
+
+            let handler = Arc::new(Mutex::new(
+                InputHandler::new_with_embedded(
+                    &[],
+                    gc_terminal::TerminalProfile::for_ghostty(),
+                    false,
+                )
+                .expect("handler builds"),
+            ));
+            // Sanity: default render_block_ms before the watcher fires.
+            assert_eq!(handler.lock().unwrap().render_block_ms(), 80);
+
+            let watcher_handle = spawn_config_watcher(config_path.clone(), Arc::clone(&handler))
+                .expect("watcher spawns");
+
+            // The 200ms debounce treats events as "recent" if last_reload
+            // was within the window. Wait past it before the meaningful
+            // write to guarantee this edit is not coalesced with a startup
+            // event (notify sometimes emits a creation/touch event during
+            // watcher registration).
+            tokio::time::sleep(Duration::from_millis(300)).await;
+
+            // Trigger the reload: rewrite with the target value.
+            std::fs::write(&config_path, "[popup]\nrender_block_ms = 150\n")
+                .expect("rewrite config");
+
+            // Poll the handler for up to 5s for the new value to land.
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut observed = handler.lock().unwrap().render_block_ms();
+            while observed != 150 && Instant::now() < deadline {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                observed = handler.lock().unwrap().render_block_ms();
+            }
+
+            watcher_handle.shutdown();
+
+            assert_eq!(
+                observed, 150,
+                "watcher did not propagate render_block_ms within 5s; \
+                 the notify event-kind filter or file_name match likely \
+                 dropped the Modify event"
+            );
+        });
+    }
 }

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -181,6 +181,7 @@ pub fn spawn_config_watcher(
                     config.popup.description_box_max_width,
                     config.popup.description_box_lines,
                     config.popup.description_box_debounce_ms,
+                    config.popup.render_block_ms as u64,
                 );
                 (cleanup, h.overlay_write_ticket())
             };

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -128,80 +128,79 @@ pub fn spawn_config_watcher(
                 }
             };
 
-            // Resolve theme
-            let resolved_theme = match config.theme.resolve() {
-                Ok(t) => t,
-                Err(e) => {
-                    tracing::warn!("config reload failed (theme preset): {e}");
-                    continue;
+            match apply_config_reload(&handler, &config) {
+                Ok(()) => {
+                    tracing::info!("config reloaded successfully");
+                    tracing::debug!(
+                        "note: changes to delay_ms, max_results, providers, spec_dirs, \
+                         and [experimental] require a restart to take effect"
+                    );
                 }
-            };
-
-            let theme = match build_popup_theme(
-                &resolved_theme,
-                config.popup.borders,
-                config.popup.spinner,
-                config.popup.show_provider_errors,
-            ) {
-                Ok(t) => t,
                 Err(e) => {
-                    tracing::warn!("config reload failed (theme styles): {e}");
-                    continue;
-                }
-            };
-
-            // Resolve keybindings
-            let keybindings = match Keybindings::from_config(&config.keybindings) {
-                Ok(kb) => kb,
-                Err(e) => {
-                    tracing::warn!("config reload failed (keybindings): {e}");
-                    continue;
-                }
-            };
-
-            // Apply to handler
-            let (cleanup, cleanup_ticket) = {
-                let mut h = match handler.lock() {
-                    Ok(h) => h,
-                    Err(e) => {
-                        tracing::warn!("config reload skipped (handler lock poisoned): {e}");
-                        continue;
-                    }
-                };
-                let cleanup = h.update_config(
-                    theme,
-                    keybindings,
-                    &config.trigger.auto_chars,
-                    config.popup.max_visible,
-                    config.popup.feedback_dismiss_ms,
-                    config.trigger.auto_trigger,
-                    config.popup.min_width,
-                    config.popup.max_width,
-                    config.popup.description_box,
-                    config.popup.description_box_max_width,
-                    config.popup.description_box_lines,
-                    config.popup.description_box_debounce_ms,
-                    config.popup.render_block_ms as u64,
-                );
-                (cleanup, h.overlay_write_ticket())
-            };
-            if !cleanup.is_empty() {
-                if let Err(e) =
-                    crate::proxy::write_overlay_if_current(&handler, cleanup_ticket, &cleanup)
-                {
-                    tracing::debug!("config reload cleanup write/flush failed: {e}");
+                    tracing::warn!("config reload failed: {e}");
                 }
             }
-
-            tracing::info!("config reloaded successfully");
-            tracing::debug!(
-                "note: changes to delay_ms, max_results, providers, spec_dirs, \
-                 and [experimental] require a restart to take effect"
-            );
         }
     });
 
     Ok(ConfigWatcherHandle { shutdown, join })
+}
+
+/// Apply a freshly-loaded [`GhostConfig`] to the live handler.
+///
+/// This is the seam exercised by an actual hot-reload: it resolves the theme
+/// and keybindings, forwards every runtime-configurable field through
+/// [`InputHandler::update_config`], and writes any cleanup bytes the handler
+/// staged. Extracted from the file-watcher loop so it is callable (and
+/// testable) without driving `notify` events.
+///
+/// Returns `Err` on theme/keybinding resolution failure or a poisoned handler
+/// lock; the caller keeps the previous config and never crashes.
+fn apply_config_reload(handler: &Arc<Mutex<InputHandler>>, config: &GhostConfig) -> Result<()> {
+    let resolved_theme = config
+        .theme
+        .resolve()
+        .map_err(|e| anyhow::anyhow!("theme preset: {e}"))?;
+
+    let theme = build_popup_theme(
+        &resolved_theme,
+        config.popup.borders,
+        config.popup.spinner,
+        config.popup.show_provider_errors,
+    )
+    .map_err(|e| anyhow::anyhow!("theme styles: {e}"))?;
+
+    let keybindings = Keybindings::from_config(&config.keybindings)
+        .map_err(|e| anyhow::anyhow!("keybindings: {e}"))?;
+
+    let (cleanup, cleanup_ticket) = {
+        let mut h = handler
+            .lock()
+            .map_err(|e| anyhow::anyhow!("handler lock poisoned: {e}"))?;
+        let cleanup = h.update_config(
+            theme,
+            keybindings,
+            &config.trigger.auto_chars,
+            config.popup.max_visible,
+            config.popup.feedback_dismiss_ms,
+            config.trigger.auto_trigger,
+            config.popup.min_width,
+            config.popup.max_width,
+            config.popup.description_box,
+            config.popup.description_box_max_width,
+            config.popup.description_box_lines,
+            config.popup.description_box_debounce_ms,
+            config.popup.render_block_ms as u64,
+        );
+        (cleanup, h.overlay_write_ticket())
+    };
+    if !cleanup.is_empty() {
+        if let Err(e) = crate::proxy::write_overlay_if_current(handler, cleanup_ticket, &cleanup) {
+            tracing::debug!("config reload cleanup write/flush failed: {e}");
+        }
+    }
+
+    Ok(())
 }
 
 /// Build a `PopupTheme` from a [`gc_config::ResolvedTheme`] (preset merged
@@ -257,5 +256,34 @@ mod tests {
         let result = build_popup_theme(&resolved, true, true, false);
         assert!(result.is_ok());
         assert!(result.unwrap().borders);
+    }
+
+    /// A live config reload must carry `popup.render_block_ms` all the way
+    /// through `apply_config_reload` into the handler. Exercises the real
+    /// `GhostConfig -> config_watch -> InputHandler` seam — not a direct
+    /// `update_config` call — so the test fails if `apply_config_reload`
+    /// ever stops forwarding the field.
+    #[test]
+    fn render_block_ms_propagates_on_config_reload() {
+        let handler = Arc::new(Mutex::new(
+            InputHandler::new_with_embedded(
+                &[],
+                gc_terminal::TerminalProfile::for_ghostty(),
+                false,
+            )
+            .expect("handler builds"),
+        ));
+        assert_eq!(
+            handler.lock().unwrap().render_block_ms(),
+            80,
+            "default render_block_ms should be 80"
+        );
+
+        let mut config = GhostConfig::default();
+        config.popup.render_block_ms = 150;
+
+        apply_config_reload(&handler, &config).expect("config reload applies");
+
+        assert_eq!(handler.lock().unwrap().render_block_ms(), 150);
     }
 }

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -4916,27 +4916,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn render_block_ms_propagates_on_config_reload() {
-        let mut handler = make_handler().with_render_block_ms(80);
-        handler.update_config(
-            PopupTheme::default(),
-            Keybindings::default(),
-            &[' ', '/'],
-            10,
-            1200,
-            true,
-            DEFAULT_MIN_POPUP_WIDTH,
-            DEFAULT_MAX_POPUP_WIDTH,
-            DescriptionBoxMode::Off,
-            60,
-            5,
-            80,
-            150,
-        );
-        assert_eq!(handler.render_block_ms(), 150);
-    }
-
     // --- auto_trigger tests ---
 
     #[test]

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -591,6 +591,11 @@ impl InputHandler {
         self
     }
 
+    /// Return the current render-block budget in milliseconds.
+    pub fn render_block_ms(&self) -> u64 {
+        self.render_block_ms
+    }
+
     /// Set popup min/max width bounds (display columns). Stored on the
     /// handler and read on every render; further clamping against the live
     /// `screen_cols` happens inside `compute_layout`.
@@ -755,6 +760,7 @@ impl InputHandler {
         detail_box_max_width: u16,
         detail_box_lines: u16,
         detail_box_debounce_ms: u16,
+        render_block_ms: u64,
     ) -> Vec<u8> {
         let mut cleanup = Vec::new();
         let mut cleanup_scope: Option<CleanupScope> = None;
@@ -823,6 +829,7 @@ impl InputHandler {
         self.detail_box_max_width = detail_box_max_width;
         self.detail_box_lines = detail_box_lines;
         self.detail_box_debounce_ms = detail_box_debounce_ms as u64;
+        self.render_block_ms = render_block_ms;
 
         cleanup
     }
@@ -4618,6 +4625,7 @@ mod tests {
             60,
             5,
             80,
+            80,
         );
 
         assert_eq!(handler.theme.selected_on, vec![0x1B, b'[', b'1', b'm']);
@@ -4650,6 +4658,7 @@ mod tests {
             60,
             5,
             80,
+            80,
         );
 
         assert_eq!(handler.keybindings, new_kb);
@@ -4671,6 +4680,7 @@ mod tests {
             DescriptionBoxMode::Off,
             60,
             5,
+            80,
             80,
         );
 
@@ -4694,6 +4704,7 @@ mod tests {
             60,
             5,
             80,
+            80,
         );
 
         assert_eq!(handler.trigger_chars, vec!['@', '#', '!']);
@@ -4716,6 +4727,7 @@ mod tests {
             90,
             7,
             0,
+            80,
         );
 
         assert_eq!(handler.min_popup_width, 35);
@@ -4760,6 +4772,7 @@ mod tests {
             30,
             3,
             0,
+            80,
         );
 
         assert!(
@@ -4816,6 +4829,7 @@ mod tests {
             60,
             5,
             80,
+            80,
         );
 
         let output = String::from_utf8_lossy(&cleanup);
@@ -4862,6 +4876,7 @@ mod tests {
             60,
             5,
             80,
+            80,
         );
 
         let output = String::from_utf8_lossy(&cleanup);
@@ -4899,6 +4914,27 @@ mod tests {
             dismiss_output.contains("\x1b[6;1H"),
             "main popup must remain clearable after detail-only cleanup: {dismiss_output:?}"
         );
+    }
+
+    #[test]
+    fn render_block_ms_propagates_on_config_reload() {
+        let mut handler = make_handler().with_render_block_ms(80);
+        handler.update_config(
+            PopupTheme::default(),
+            Keybindings::default(),
+            &[' ', '/'],
+            10,
+            1200,
+            true,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            DescriptionBoxMode::Off,
+            60,
+            5,
+            80,
+            150,
+        );
+        assert_eq!(handler.render_block_ms(), 150);
     }
 
     // --- auto_trigger tests ---
@@ -4954,6 +4990,7 @@ mod tests {
             60,
             5,
             80,
+            80,
         );
 
         assert!(!handler.auto_trigger_enabled());
@@ -4981,6 +5018,7 @@ mod tests {
             DescriptionBoxMode::Off,
             60,
             5,
+            80,
             80,
         );
 
@@ -5016,6 +5054,7 @@ mod tests {
             60,
             5,
             80,
+            80,
         );
 
         assert!(
@@ -5050,6 +5089,7 @@ mod tests {
             DescriptionBoxMode::Off,
             60,
             5,
+            80,
             80,
         );
 
@@ -7220,6 +7260,7 @@ mod tests {
             DescriptionBoxMode::Side,
             60,
             5,
+            80,
             80,
         );
 

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -774,6 +774,12 @@ impl InputHandler {
             if self.visible {
                 if let Some(layout) = self.last_layout.clone() {
                     self.bump_output_epoch();
+                    // TODO(phase-N-follow-up): route through
+                    // with_overlay_update_frame so the popup-clear and the
+                    // subsequent detail-clear land inside ONE balanced DECSET
+                    // 2026 pair on Synchronized terminals (see PR #138 "Out
+                    // of scope" — render_at was scoped to do this; the
+                    // config-cleanup path was deliberately deferred).
                     clear_popup(&mut cleanup, &layout, &self.terminal_profile);
                     if let Some(ref det) = self.last_detail_layout {
                         clear_detail_box(&mut cleanup, det);
@@ -2766,6 +2772,11 @@ impl InputHandler {
         if let Some(layout) = self.last_layout.clone() {
             let mut buf = Vec::new();
             self.bump_output_epoch();
+            // TODO(phase-N-follow-up): wrap clear_popup_unframed +
+            // clear_detail_box in with_overlay_update_frame so the entire
+            // teardown lands inside ONE balanced DECSET 2026 pair on
+            // Synchronized terminals (see PR #138 "Out of scope" — render_at
+            // was scoped to do this; teardown_popup was deliberately deferred).
             clear_popup(&mut buf, &layout, &self.terminal_profile);
             if let Some(ref det) = detail_layout {
                 clear_detail_box(&mut buf, det);
@@ -7374,5 +7385,69 @@ mod tests {
             "no-op render must emit zero bytes; got {} bytes",
             stdout.len()
         );
+    }
+
+    #[test]
+    fn render_at_emits_one_sync_frame_when_only_clear_runs() {
+        // Boundary case: last_layout=Some(non-zero) AND suggestions=vec![] —
+        // the popup was visible last frame but the user has typed a query that
+        // filtered out all matches. clear_popup_unframed writes bytes (DECSC
+        // \x1b7 + spaces) but render_popup_unframed early-exits because
+        // suggestions.is_empty() and feedback is None. The frame helper must
+        // still emit exactly one balanced begin_sync/end_sync pair around the
+        // clear bytes — a future re-order of the clear/render calls could
+        // regress this and only fail in live use.
+        let mut handler = make_handler();
+        handler.terminal_profile = TerminalProfile::for_ghostty();
+        handler.last_layout = Some(PopupLayout {
+            start_row: 5,
+            start_col: 0,
+            width: 20,
+            height: 1,
+            scroll_deficit: 0,
+        });
+        // suggestions stays empty (default); feedback stays Idle (None).
+        let mut stdout = Vec::<u8>::new();
+
+        handler.render_at(&mut stdout, 10, 0, 24, 80);
+
+        let begin_count = stdout.windows(8).filter(|w| *w == b"\x1b[?2026h").count();
+        let end_count = stdout.windows(8).filter(|w| *w == b"\x1b[?2026l").count();
+        assert_eq!(
+            begin_count, 1,
+            "expected exactly one begin_sync; got {begin_count}"
+        );
+        assert_eq!(
+            end_count, 1,
+            "expected exactly one end_sync; got {end_count}"
+        );
+
+        // The clear bytes (DECSC \x1b7 emitted by clear_popup_unframed) must
+        // sit inside the sync window.
+        let begin_pos = stdout.windows(8).position(|w| w == b"\x1b[?2026h").unwrap();
+        let end_pos = stdout.windows(8).position(|w| w == b"\x1b[?2026l").unwrap();
+        let decsc_pos = stdout
+            .windows(2)
+            .position(|w| w == b"\x1b7")
+            .expect("clear_popup_unframed must emit DECSC \\x1b7");
+        assert!(
+            decsc_pos > begin_pos && decsc_pos < end_pos,
+            "clear bytes must be inside the sync window \
+             (begin={begin_pos}, decsc={decsc_pos}, end={end_pos})"
+        );
+    }
+
+    // Phase N follow-up stub — the production teardown_popup path is
+    // intentionally not wrapped in with_overlay_update_frame yet (see PR #138
+    // "Out of scope" section). When the follow-up phase routes teardown_popup
+    // through the frame helper, remove this `#[ignore]` and tighten the body
+    // to match render_at_emits_exactly_one_sync_frame_on_synchronized_profile.
+    #[test]
+    #[ignore = "Phase N follow-up: teardown_popup not yet wrapped in with_overlay_update_frame"]
+    fn teardown_popup_emits_one_balanced_sync_pair_around_popup_and_detail() {
+        // When implemented: set last_layout and last_detail_layout to
+        // Some(non-zero), call teardown_popup, assert exactly one begin_sync /
+        // end_sync pair AND that BOTH the popup-clear and the detail-clear
+        // bytes sit between them.
     }
 }

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -12,8 +12,8 @@ use gc_overlay::types::{
 };
 use gc_overlay::{
     clear_detail_box, clear_popup, compute_detail_layout, description_overflows_main_popup,
-    popup_additional_scroll_deficit, render_detail_box, render_indicator_row, render_popup,
-    DetailLayout, FeedbackKind, PopupTheme,
+    popup_additional_scroll_deficit, render_detail_box, render_indicator_row, DetailLayout,
+    FeedbackKind, PopupTheme,
 };
 use gc_parser::TerminalParser;
 use gc_suggest::{SpecCacheSweep, Suggestion, SuggestionEngine};
@@ -2292,11 +2292,8 @@ impl InputHandler {
         screen_rows: u16,
         screen_cols: u16,
     ) {
-        // For PreRenderBuffer strategy, we must combine clear + render into a
-        // single buffer and emit one write() call for flicker-free atomicity.
-        // For Synchronized strategy, DECSET 2026 markers handle this at the
-        // terminal level so separate writes are fine.
-        let mut buf = Vec::new();
+        // `bump_output_epoch` stays OUTSIDE the frame — exactly one bump per
+        // render_at call regardless of strategy.
         self.bump_output_epoch();
 
         let feedback = self.current_feedback_kind();
@@ -2316,17 +2313,28 @@ impl InputHandler {
             && !matches!(&feedback, FeedbackKind::None)
             && self.overlay_scroll_deficit > 0;
 
+        // Stage every overlay byte into inner_buf first.  All calls here are
+        // normal method calls on &mut self — no borrow-checker issue.  The
+        // resulting bytes are then handed to with_overlay_update_frame so the
+        // entire update is enclosed in exactly ONE balanced DECSET 2026 pair
+        // on Synchronized terminals.  On PreRenderBuffer terminals the frame
+        // helper is a no-op and the single write_all below provides atomicity.
+        let mut inner_buf = Vec::with_capacity(2048);
+
+        // 1. Clear prior popup if no scroll is needed.
         let can_clear_old = additional_scroll == 0 && !feedback_only_repaint_after_scroll;
         if can_clear_old {
             if let Some(ref layout) = self.last_layout {
-                clear_popup(&mut buf, layout, &self.terminal_profile);
+                gc_overlay::clear_popup_unframed(&mut inner_buf, layout);
             }
             // Clear the previous detail box in lockstep so it can't survive a
             // popup repaint as a ghost rectangle.
             if let Some(ref det) = self.last_detail_layout {
-                clear_detail_box(&mut buf, det);
+                clear_detail_box(&mut inner_buf, det);
             }
         }
+
+        // 2. Compute the post-scroll position of any old detail layout.
         let scrolled_old_detail_layout = if additional_scroll > 0 {
             self.last_detail_layout
                 .as_ref()
@@ -2335,8 +2343,9 @@ impl InputHandler {
             None
         };
 
-        let layout = render_popup(
-            &mut buf,
+        // 3. Render new popup (unframed — no sync markers).
+        let layout = gc_overlay::render_popup_unframed(
+            &mut inner_buf,
             &self.suggestions,
             &self.overlay,
             cursor_row,
@@ -2349,24 +2358,35 @@ impl InputHandler {
             &self.theme,
             self.overlay_scroll_deficit,
             feedback,
-            &self.terminal_profile,
         );
 
-        // Detail-box pass: only renders when the feature is on, the main
-        // popup is non-empty, and there's a selected suggestion with a
-        // description.
+        // 4. Detail-box pass (render_detail_box is already unframed).
         let new_detail_layout =
-            self.maybe_render_detail(&mut buf, &layout, screen_rows, screen_cols);
+            self.maybe_render_detail(&mut inner_buf, &layout, screen_rows, screen_cols);
+
+        // 5. Clear scrolled-out portions of old detail (unframed).
         if let Some(ref old_detail) = scrolled_old_detail_layout {
             let mut covers = vec![OverlayRect::from_popup(&layout)];
             if let Some(ref new_detail) = new_detail_layout {
                 covers.push(OverlayRect::from_detail(new_detail));
             }
-            clear_detail_box_uncovered_by(&mut buf, old_detail, &covers);
+            clear_detail_box_uncovered_by(&mut inner_buf, old_detail, &covers);
         }
 
-        let _ = stdout.write_all(&buf);
-        let _ = stdout.flush();
+        // Wrap the entire update in ONE sync frame.  On Synchronized profiles
+        // this emits exactly one begin_sync / end_sync pair around all the
+        // bytes staged above.  On PreRenderBuffer profiles the helper is a
+        // transparent pass-through.  If inner_buf is empty (no-op render) the
+        // helper short-circuits and buf stays empty — no 16-byte no-op pair.
+        let mut buf = Vec::with_capacity(inner_buf.len() + 16);
+        gc_overlay::with_overlay_update_frame(&mut buf, &self.terminal_profile, |b| {
+            b.extend_from_slice(&inner_buf);
+        });
+
+        if !buf.is_empty() {
+            let _ = stdout.write_all(&buf);
+            let _ = stdout.flush();
+        }
         self.overlay_render_generation = self.overlay_render_generation.wrapping_add(1);
         self.pending_overlay_cleanup = None;
         self.pending_overlay_render = Some(PendingOverlayRender {
@@ -7263,6 +7283,96 @@ mod tests {
         assert!(
             handler.last_detail_layout.is_none(),
             "detail layout must be released after the cleanup write is acknowledged",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Task 4: one DECSET 2026 frame per overlay update
+    // ------------------------------------------------------------------
+
+    /// Returns the byte position of a known detail-box content marker within
+    /// `buf`, or panics with a message if not found.
+    fn find_detail_marker(buf: &[u8], marker: &[u8]) -> usize {
+        buf.windows(marker.len())
+            .position(|w| w == marker)
+            .unwrap_or_else(|| {
+                panic!(
+                    "detail marker {:?} not found in buf (len={})",
+                    String::from_utf8_lossy(marker),
+                    buf.len()
+                )
+            })
+    }
+
+    #[test]
+    fn render_at_emits_exactly_one_sync_frame_on_synchronized_profile() {
+        // Ghostty → Synchronized → DECSET 2026 frames expected.
+        // Long description so the detail box is actually rendered.
+        let description =
+            "DETAIL_MARKER alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu";
+        let mut handler = make_selected_handler(command_suggestion("checkout", Some(description)))
+            .with_popup_widths(20, 40)
+            .with_description_box(DescriptionBoxMode::Side, 60, 5, 0);
+        // make_handler() already uses for_ghostty() (Synchronized), but be explicit.
+        handler.terminal_profile = TerminalProfile::for_ghostty();
+        let mut stdout = Vec::<u8>::new();
+
+        handler.render_at(&mut stdout, 10, 0, 24, 120);
+
+        let begin_count = stdout.windows(8).filter(|w| *w == b"\x1b[?2026h").count();
+        let end_count = stdout.windows(8).filter(|w| *w == b"\x1b[?2026l").count();
+        assert_eq!(
+            begin_count, 1,
+            "expected exactly one begin_sync; got {begin_count}"
+        );
+        assert_eq!(
+            end_count, 1,
+            "expected exactly one end_sync; got {end_count}"
+        );
+
+        // The detail-box bytes must be INSIDE the sync window.
+        let begin_pos = stdout.windows(8).position(|w| w == b"\x1b[?2026h").unwrap();
+        let end_pos = stdout.windows(8).position(|w| w == b"\x1b[?2026l").unwrap();
+        let detail_pos = find_detail_marker(&stdout, b"DETAIL_MARKER");
+        assert!(
+            detail_pos > begin_pos && detail_pos < end_pos,
+            "detail bytes must be inside the sync window \
+             (begin={begin_pos}, detail={detail_pos}, end={end_pos})"
+        );
+    }
+
+    #[test]
+    fn render_at_pre_render_buffer_emits_no_sync_markers() {
+        // iTerm2 → PreRenderBuffer → no DECSET 2026 markers.
+        let mut handler = make_visible_handler(numbered_suggestions(5));
+        handler.terminal_profile = TerminalProfile::for_iterm2();
+        let mut stdout = Vec::<u8>::new();
+
+        handler.render_at(&mut stdout, 10, 0, 24, 80);
+
+        assert!(
+            !stdout.windows(8).any(|w| w == b"\x1b[?2026h"),
+            "PreRenderBuffer profile must not emit begin_sync"
+        );
+        assert!(
+            !stdout.windows(8).any(|w| w == b"\x1b[?2026l"),
+            "PreRenderBuffer profile must not emit end_sync"
+        );
+    }
+
+    #[test]
+    fn render_at_noop_renders_emit_no_bytes() {
+        // Empty suggestions + no feedback → no-op render → zero bytes.
+        let mut handler = make_handler();
+        // make_handler() uses Ghostty (Synchronized) — sync markers would appear if not no-op.
+        let mut stdout = Vec::<u8>::new();
+
+        handler.render_at(&mut stdout, 10, 0, 24, 80);
+
+        assert!(
+            stdout.is_empty(),
+            "no-op render must emit zero bytes; got {} bytes",
+            stdout.len()
         );
     }
 }

--- a/crates/ghost-complete/Cargo.toml
+++ b/crates/ghost-complete/Cargo.toml
@@ -50,3 +50,5 @@ portable-pty = "0.9"
 tempfile = "3"
 # Enables the `TerminalProfile::for_*()` fixture constructors for tests only.
 gc-terminal = { path = "../gc-terminal", features = ["test-utils"] }
+# Enables `gc_parser::test_utils::build_osc7772_envelope` for smoke tests.
+gc-parser = { path = "../gc-parser", features = ["test-utils"] }

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -1,8 +1,31 @@
 mod harness;
 
+use gc_parser::test_utils::build_osc7772_envelope;
 use harness::GhostProcess;
 use std::thread;
 use std::time::Duration;
+
+/// Convert an OSC 7772 envelope (raw bytes) into a `printf`-compatible shell
+/// command string. Each byte that is not a printable ASCII non-quote character
+/// is emitted as a `\xHH` octal-style escape that `/bin/sh`'s `printf`
+/// interprets via `%b` format or just passed as octal `\OOO`. We use `\NNN`
+/// octal escapes since POSIX `printf` with `%b` and `\xHH` is not universal;
+/// octal `\NNN` (3-digit, leading zero) is universally supported.
+///
+/// The envelope is wrapped in `printf '...'` so the shell emits the bytes to
+/// its stdout (which gc-parser sees as PTY output), and a `; read <gate>`
+/// suffix keeps the shell parked so it cannot race the popup render.
+fn osc_printf_cmd(envelope: &[u8], gate: &str) -> String {
+    let mut escaped = String::new();
+    for &b in envelope {
+        match b {
+            b'\'' => escaped.push_str("\\'"),
+            0x20..=0x7e => escaped.push(b as char), // printable ASCII (not quote)
+            _ => escaped.push_str(&format!("\\{:03o}", b)),
+        }
+    }
+    format!("printf '{}'; read {}", escaped, gate)
+}
 
 /// DECSC. Emitted by both `render_popup` and `clear_popup`; presence after a
 /// clean baseline indicates popup activity (not uniquely a fresh render).
@@ -192,24 +215,24 @@ fn test_multiple_commands() {
 
 /// End-to-end popup smoke test.
 ///
-/// Verifies the entire UX pipeline: OSC 7770 buffer-report (from simulated
+/// Verifies the entire UX pipeline: OSC 7772 buffer-report (from simulated
 /// shell integration) -> auto-trigger -> popup renders with git-spec
 /// subcommand text -> ESC dismisses the popup.
 ///
 /// Architecture notes:
 /// - The harness wraps `/bin/sh` (no shell integration). Without shell
-///   integration, the shell will NOT emit OSC 7770 buffer-report sequences,
+///   integration, the shell will NOT emit OSC 7772 buffer-report sequences,
 ///   so the parser's `command_buffer` stays empty, and `handler.trigger()`
 ///   would dismiss immediately (see gc-pty/src/handler.rs: `if
 ///   buffer.is_empty() { return; }`).
 /// - To simulate shell integration without installing it, we have the
-///   inner shell print OSC 7770 itself: `printf '\033]7770;4;git \007'`.
-///   The shell executes printf, emits the raw ANSI bytes to its stdout,
-///   which flow through gc-parser's VT state machine and set
-///   `command_buffer = "git "` with cursor = 4. This also sets
-///   `buffer_dirty = true`, which Task B (stdout -> terminal loop) notices
-///   and uses to fire `trigger()` automatically.
-/// - No manual Ctrl+/ is needed — the auto-trigger path from OSC 7770 is
+///   inner shell print OSC 7772 itself via `printf`. The shell executes
+///   printf, emits the raw ANSI bytes to its stdout, which flow through
+///   gc-parser's VT state machine and set `command_buffer = "git "` with
+///   cursor = 4. This also sets `buffer_dirty = true`, which Task B
+///   (stdout -> terminal loop) notices and uses to fire `trigger()`
+///   automatically.
+/// - No manual Ctrl+/ is needed — the auto-trigger path from OSC 7772 is
 ///   exactly what real shell integration does on every keystroke.
 ///
 /// Assumptions:
@@ -235,9 +258,12 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
     // Mark the pre-trigger offset — popup render bytes must appear after.
     let mark_before_trigger = proc.output_len();
 
-    // OSC ]7770;<cursor>;<buffer>BEL — the `read` keeps the shell from
-    // emitting a new prompt that would tear down the popup mid-test.
-    proc.send_line(r"printf '\033]7770;4;git \007'; read _ghost_popup_hold");
+    // OSC 7772 envelope — the `read` keeps the shell from emitting a new
+    // prompt that would tear down the popup mid-test.
+    proc.send_line(&osc_printf_cmd(
+        &build_osc7772_envelope("git ", 4),
+        "_ghost_popup_hold",
+    ));
 
     assert_no_popup_render_after(&proc, mark_before_trigger, "git OSC injection");
 
@@ -253,7 +279,7 @@ fn test_popup_renders_and_dismisses_on_git_trigger() {
         let snapshot = proc.output_snapshot();
         let since_redraw = &snapshot[mark_before_redraw..];
         panic!(
-            "Popup did not render within 5s after display advanced post-OSC 7770.\n\
+            "Popup did not render within 5s after display advanced post-OSC 7772.\n\
              Bytes since redraw mark ({} bytes, lossy UTF-8):\n{:?}",
             since_redraw.len(),
             String::from_utf8_lossy(since_redraw),
@@ -325,7 +351,10 @@ fn test_popup_is_cleared_before_later_shell_output() {
     proc.expect_output("smoke_prompt_repaint_marker");
 
     let mark_before_trigger = proc.output_len();
-    proc.send_line(r"printf '\033]7770;4;git \007'; read _gc_smoke_gate");
+    proc.send_line(&osc_printf_cmd(
+        &build_osc7772_envelope("git ", 4),
+        "_gc_smoke_gate",
+    ));
 
     assert_no_popup_render_after(&proc, mark_before_trigger, "prompt-repaint cleanup setup");
     let mark_before_redraw = advance_display(&mut proc);
@@ -394,11 +423,13 @@ fn test_popup_defers_until_display_after_osc_only_pty_read() {
 
     let mark_before_osc = proc.output_len();
 
-    // `printf` interprets the `\033`/`\007` backslash escapes into ESC/BEL,
-    // which is what frames the OSC sequence; `read` then parks the shell so
-    // it cannot emit follow-up display bytes that would resolve the defer on
-    // their own.
-    proc.send_line(r"printf '\033]7770;4;git \007'; read _gc_defer_gate");
+    // `printf` interprets the octal escapes into ESC/BEL, which is what
+    // frames the OSC 7772 sequence; `read` then parks the shell so it cannot
+    // emit follow-up display bytes that would resolve the defer on their own.
+    proc.send_line(&osc_printf_cmd(
+        &build_osc7772_envelope("git ", 4),
+        "_gc_defer_gate",
+    ));
 
     assert_no_popup_render_after(&proc, mark_before_osc, "OSC-only PTY read defer");
 
@@ -436,12 +467,15 @@ fn test_popup_renders_for_osc_with_inline_display_byte() {
 
     let mark_before_trigger = proc.output_len();
 
-    // OSC + printable byte in a single `printf` payload. The shell emits both
-    // before parking on `read`, so the popup must eventually render without
-    // any external `advance_display` nudge. Same-batch coalescing into one
-    // PTY read is not asserted here — kernel chunking can split the bytes
-    // across reads and the proxy's deferred path is allowed to resolve it.
-    proc.send_line(r"printf '\033]7770;4;git \007X'; read _gc_inline_gate");
+    // OSC 7772 envelope + printable byte in a single `printf` payload. The
+    // shell emits both before parking on `read`, so the popup must eventually
+    // render without any external `advance_display` nudge. Same-batch
+    // coalescing into one PTY read is not asserted here — kernel chunking can
+    // split the bytes across reads and the proxy's deferred path is allowed
+    // to resolve it.
+    let mut envelope_with_display = build_osc7772_envelope("git ", 4);
+    envelope_with_display.push(b'X');
+    proc.send_line(&osc_printf_cmd(&envelope_with_display, "_gc_inline_gate"));
 
     let popup_rendered = proc.wait_for_bytes_after(
         POPUP_RENDER_MARKER,

--- a/crates/ghost-complete/tests/smoke.rs
+++ b/crates/ghost-complete/tests/smoke.rs
@@ -6,11 +6,16 @@ use std::thread;
 use std::time::Duration;
 
 /// Convert an OSC 7772 envelope (raw bytes) into a `printf`-compatible shell
-/// command string. Each byte that is not a printable ASCII non-quote character
-/// is emitted as a `\xHH` octal-style escape that `/bin/sh`'s `printf`
-/// interprets via `%b` format or just passed as octal `\OOO`. We use `\NNN`
-/// octal escapes since POSIX `printf` with `%b` and `\xHH` is not universal;
-/// octal `\NNN` (3-digit, leading zero) is universally supported.
+/// command string. Each non-printable byte is emitted as an octal `\NNN`
+/// escape (3-digit, leading zero) that `/bin/sh`'s `printf` interprets — we
+/// use octal `\NNN` rather than `\xHH` because hex escapes in `printf` are
+/// not universally supported, whereas octal `\NNN` is POSIX-portable.
+///
+/// `%` (0x25) is emitted as `%%`: the envelope payload is percent-encoded, so
+/// any buffer char outside the allow-list arrives as `%XX`. A literal `%` in
+/// `printf`'s format string starts a conversion specifier and would truncate
+/// the OSC frame, so it must be doubled. `'` is backslash-escaped so it does
+/// not close the single-quoted format argument.
 ///
 /// The envelope is wrapped in `printf '...'` so the shell emits the bytes to
 /// its stdout (which gc-parser sees as PTY output), and a `; read <gate>`
@@ -20,11 +25,42 @@ fn osc_printf_cmd(envelope: &[u8], gate: &str) -> String {
     for &b in envelope {
         match b {
             b'\'' => escaped.push_str("\\'"),
-            0x20..=0x7e => escaped.push(b as char), // printable ASCII (not quote)
+            b'%' => escaped.push_str("%%"), // literal % — printf format escape
+            0x20..=0x7e => escaped.push(b as char), // printable ASCII (not quote/percent)
             _ => escaped.push_str(&format!("\\{:03o}", b)),
         }
     }
     format!("printf '{}'; read {}", escaped, gate)
+}
+
+/// A percent-encoded byte in the envelope payload (`%XX`) must be doubled to
+/// `%%XX` in the `printf` format string. A bare `%` starts a printf
+/// conversion specifier and would truncate the OSC frame at that point — see
+/// the commit that introduced this escape. A buffer containing `;` encodes to
+/// `%3B` via the OSC 7772 allow-list, exercising the percent path.
+#[test]
+fn osc_printf_cmd_doubles_percent_in_format_string() {
+    let envelope = build_osc7772_envelope("a;b", 3);
+    // Sanity: the envelope itself carries exactly one single-percent escape.
+    assert_eq!(
+        envelope.iter().filter(|&&b| b == b'%').count(),
+        1,
+        "envelope should percent-encode ';' as exactly one %3B: {:?}",
+        String::from_utf8_lossy(&envelope),
+    );
+
+    let cmd = osc_printf_cmd(&envelope, "_gate");
+    assert!(
+        cmd.contains("%%3B"),
+        "printf format must double the percent (%%3B), got: {cmd:?}",
+    );
+    // Every `%` in the format must be part of a `%%` pair: stripping all
+    // `%%` pairs must leave zero stray `%`. A bare `%3B` (the bug) leaves one.
+    let stray_percents = cmd.replace("%%", "").matches('%').count();
+    assert_eq!(
+        stray_percents, 0,
+        "printf format must not leave a bare single percent, got: {cmd:?}",
+    );
 }
 
 /// DECSC. Emitted by both `render_popup` and `clear_popup`; presence after a


### PR DESCRIPTION
## Summary

Phase 6 of the 0.17 polish-and-trust milestone. Moves DECSET 2026 (synchronized-output) frame ownership from the low-level popup helpers to the caller, so a complete overlay update is one atomic frame.

- **One sync frame per overlay update.** `InputHandler::render_at` was emitting `[?2026h] clear [?2026l] [?2026h] render [?2026l]` with detail-box bytes entirely outside any frame. New `gc_overlay::with_overlay_update_frame` wraps the whole update (popup clear + detail clear + popup render + detail render + scrolled-detail cleanup) in exactly one balanced `\x1b[?2026h…\x1b[?2026l` pair on Synchronized terminals, zero markers on PreRenderBuffer, and zero bytes on a no-op render.
- **Popup primitives split into framed/unframed pairs.** Public `render_popup`/`clear_popup` stay as thin back-compat wrappers; `render_at` routes through the new `*_unframed` internals inside its caller-owned frame.
- **`render_block_ms` is now genuinely hot-reloadable.** It was documented and shown in the TUI editor as live-reloadable but never wired through `update_config`; now it is, with a regression test that exercises the real `config.toml → config_watch → InputHandler` reload path.
- **PTY popup smoke moved from legacy OSC 7770 to OSC 7772**, via a shared `build_osc7772_envelope` helper (new `gc-parser` `test-utils` feature). Parser-level OSC 7770 tests are untouched.
- **Criterion benches** for the full popup + detail render paths (`crates/gc-overlay/benches/popup_render.rs`).

13 commits; each task spec- and quality-reviewed, plus a final whole-branch review.

## Coordination

Phase 2 (zsh-macos-correctness) also touches `gc-parser`. This branch's only `gc-parser` change is strictly additive — a new `test-utils` feature line in `Cargo.toml` and a new `test_utils` module in `lib.rs`, no existing lines modified — so the merge with Phase 2 should be conflict-free. Land/rebase whichever PR is second to confirm.

## Out of scope (follow-up)

The dismiss/teardown and config-cleanup paths still emit multi-frame output on Synchronized terminals — the framing refactor was deliberately scoped to `render_at`. A future phase should route `teardown_popup` and the `update_config` cleanup through `with_overlay_update_frame` for parity.

## Test plan

- [x] `cargo test --workspace` — green, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo bench -p gc-overlay --bench popup_render` — all 3 groups run
- [ ] Manual smoke on macOS: trigger a popup in Ghostty (Synchronized) and iTerm2 (PreRenderBuffer), verify no flicker and that the detail box renders in the same frame; edit `render_block_ms` in `config.toml` while the proxy runs and confirm the next trigger reflects the new value.