### PR TITLE
fix(pty): defer initial PTY resize to recover from startup TIOCGWINSZ race (Linux/Wayland)

### DIFF
--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -109,6 +109,18 @@ pub struct PopupConfig {
     /// later). Clamped to `[0, 300]` during normalization. Default: 80 ms,
     /// chosen to stay below the human perception threshold for "instant".
     pub render_block_ms: u16,
+    /// Number of trailing spaces between the kind icon and suggestion text.
+    /// Layout reserves `1 + icon + gutter_padding` columns; default `1`
+    /// preserves the historical `" K "` rendering. Clamped to `[0, 8]`.
+    pub gutter_padding: u8,
+    /// When `true`, the popup always renders at `max_width` (clamped to the
+    /// terminal) regardless of the longest visible suggestion. When `false`
+    /// (default), width fits content within `[min_width, max_width]`.
+    pub fixed_width: bool,
+    /// String appended to suggestion text or description when it overflows
+    /// the row's column budget. Empty string (default) preserves silent
+    /// truncation. A typical setting is `"…"` (1 column).
+    pub truncation_indicator: String,
 }
 
 impl Default for PopupConfig {
@@ -120,6 +132,9 @@ impl Default for PopupConfig {
             spinner: true,
             show_provider_errors: false,
             render_block_ms: 80,
+            gutter_padding: 1,
+            fixed_width: false,
+            truncation_indicator: String::new(),
         }
     }
 }
@@ -501,6 +516,7 @@ const MAX_RESULTS_UPPER: usize = 10_000;
 const MAX_RESULTS_DEFAULT: usize = 50;
 const RENDER_BLOCK_MS_UPPER: u16 = 300;
 const FEEDBACK_DISMISS_MS_UPPER: u16 = 10_000;
+const GUTTER_PADDING_UPPER: u8 = 8;
 
 impl GhostConfig {
     /// Clamp config values to sane bounds, logging warnings when clamping.
@@ -556,6 +572,32 @@ impl GhostConfig {
                 FEEDBACK_DISMISS_MS_UPPER,
             );
             self.popup.feedback_dismiss_ms = FEEDBACK_DISMISS_MS_UPPER;
+        }
+        if self.popup.gutter_padding > GUTTER_PADDING_UPPER {
+            tracing::warn!(
+                "popup.gutter_padding={} exceeds maximum {}, clamping",
+                self.popup.gutter_padding,
+                GUTTER_PADDING_UPPER,
+            );
+            self.popup.gutter_padding = GUTTER_PADDING_UPPER;
+        }
+        // Truncation indicator: warn (do not clamp) when it is suspiciously
+        // long. Per-row truncation budget varies with popup width / gutter /
+        // description length, so clamping at config time would be too
+        // aggressive — but a multi-character indicator is almost certainly a
+        // misconfiguration. Char count is a safe upper bound: every non-empty
+        // grapheme contributes at least 1 column. Common indicators are
+        // `…` (1 char) and `...` (3 chars); we warn at 5+.
+        const TRUNCATION_INDICATOR_CHAR_WARN: usize = 4;
+        let indicator_chars = self.popup.truncation_indicator.chars().count();
+        if indicator_chars > TRUNCATION_INDICATOR_CHAR_WARN {
+            tracing::warn!(
+                "popup.truncation_indicator={:?} is {} chars long; values wider than \
+                 the per-row text budget fall back to silent truncation. Consider \
+                 \"…\" (1 col) or \"...\" (3 cols).",
+                self.popup.truncation_indicator,
+                indicator_chars,
+            );
         }
         // Spec cache sanity. Only apply when eviction is enabled —
         // a config with idle_ttl_secs=0 means the user opted out and

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -149,6 +149,12 @@ pub struct SuggestConfig {
     /// stalled generator does not keep the loading indicator spinning
     /// indefinitely. Default: 5000 ms.
     pub generator_timeout_ms: u64,
+    /// When `true`, spec-declared flags are emitted only after the user
+    /// types `-` (the `Context::FlagPrefix` arm). In `Context::SpecArg`
+    /// the `options` candidates are suppressed, leaving subcommands,
+    /// argument values, and filesystem results to dominate the popup
+    /// until the user explicitly asks for flags. Default: `true`.
+    pub flags_require_dash: bool,
     pub providers: ProvidersConfig,
     pub spec_cache: SpecCacheConfig,
 }
@@ -159,6 +165,7 @@ impl Default for SuggestConfig {
             max_results: 50,
             max_history_results: 5,
             generator_timeout_ms: 5000,
+            flags_require_dash: true,
             providers: ProvidersConfig::default(),
             spec_cache: SpecCacheConfig::default(),
         }

--- a/crates/gc-overlay/src/frame.rs
+++ b/crates/gc-overlay/src/frame.rs
@@ -15,7 +15,7 @@
 
 use gc_suggest::Suggestion;
 
-use crate::layout::{DESC_GAP_COLS, GUTTER_COLS, TRAILING_PAD_COLS};
+use crate::layout::{DEFAULT_GUTTER_COLS as GUTTER_COLS, DESC_GAP_COLS, TRAILING_PAD_COLS};
 use crate::render::{kind_icon, sanitize_display_text, translate_match_indices};
 use crate::types::{OverlayState, PopupLayout};
 use crate::util::display_text;

--- a/crates/gc-overlay/src/layout.rs
+++ b/crates/gc-overlay/src/layout.rs
@@ -4,13 +4,16 @@ use unicode_width::UnicodeWidthStr;
 use crate::types::PopupLayout;
 use crate::util::display_text;
 
-/// Display-column width of the gutter area (" K ") in a popup row.
-///
-/// Nerd Font PUA codepoints used for kind icons (e.g. \u{F120}) report
-/// `UnicodeWidthChar::width == 1` but render as 2 columns in Nerd Font
-/// terminals. We use 4 (space + 2-col icon + space) to prevent off-by-one
-/// overflow in width calculations.
-pub(crate) const GUTTER_COLS: usize = 4;
+/// Display-column width of the leading space + kind icon, before any
+/// trailing padding. Nerd Font PUA codepoints used for kind icons
+/// (e.g. \u{F120}) report `UnicodeWidthChar::width == 1` but render as 2
+/// columns in Nerd Font terminals — we reserve 2 here to prevent
+/// off-by-one overflow in width calculations.
+pub(crate) const ICON_BASE_COLS: usize = 3;
+
+/// Default gutter width when no `PopupTheme` is supplied (tests, fallbacks).
+/// Matches `gutter_padding = 1` — the historical `" K "` rendering.
+pub(crate) const DEFAULT_GUTTER_COLS: usize = ICON_BASE_COLS + 1;
 
 /// Display-column width of the gap rendered between suggestion text and its
 /// inline description. Two spaces: wide enough to be visually distinct from
@@ -36,6 +39,8 @@ pub fn compute_layout(
     min_width: u16,
     max_width: u16,
     borders: bool,
+    gutter_cols: usize,
+    fixed_width: bool,
 ) -> PopupLayout {
     // Suppress rendering entirely when the terminal is too narrow for the
     // minimum popup width — rendering off-screen corrupts terminal state.
@@ -52,25 +57,26 @@ pub fn compute_layout(
     let visible_count = suggestions.len().min(max_visible);
     let border_pad: u16 = if borders { 2 } else { 0 };
 
-    // Compute width from visible suggestions (content only, no border)
-    let content_width = suggestions
-        .iter()
-        .skip(scroll_offset)
-        .take(max_visible)
-        .map(item_display_width)
-        .max()
-        .unwrap_or(min_width.saturating_sub(border_pad) as usize);
     // Defense-in-depth: ensure the clamp upper bound is never below min_width.
     // The early return at the top of this function guards the common path
     // (screen_cols < min_width), but any future caller that bypasses it — or a
     // future refactor that lets max_width shrink below min_width — would
     // otherwise hit `clamp(min, max)` with min > max, which is an unconditional
     // panic in std. `.max(min_width)` collapses the degenerate bound into a
-    // no-op clamp that returns min_width. Phase 1 CRIT-2 fix claimed this
-    // guard was added to compute_layout but only added the early return in
-    // render_popup — this line closes the gap.
+    // no-op clamp that returns min_width.
     let effective_max_w = max_width.min(screen_cols).max(min_width);
-    let width = (content_width as u16 + border_pad).clamp(min_width, effective_max_w);
+    let width = if fixed_width {
+        effective_max_w
+    } else {
+        let content_width = suggestions
+            .iter()
+            .skip(scroll_offset)
+            .take(max_visible)
+            .map(|s| item_display_width(s, gutter_cols))
+            .max()
+            .unwrap_or(min_width.saturating_sub(border_pad) as usize);
+        (content_width as u16 + border_pad).clamp(min_width, effective_max_w)
+    };
 
     // Height includes border rows when enabled
     let height = (visible_count as u16) + border_pad;
@@ -96,9 +102,9 @@ pub fn compute_layout(
 }
 
 /// Calculate display width for a single suggestion line.
-/// Format: " K text  description " where K is kind char.
-fn item_display_width(suggestion: &Suggestion) -> usize {
-    // gutter = GUTTER_COLS, then text, then optional "  desc", then trailing space
+/// Format: " K<padding>text  description " where K is the kind icon and
+/// `<padding>` is `gutter_cols - ICON_BASE_COLS` trailing spaces.
+fn item_display_width(suggestion: &Suggestion, gutter_cols: usize) -> usize {
     let (dt, _) = display_text(suggestion);
     let text_len = UnicodeWidthStr::width(dt);
     let desc_len = suggestion
@@ -106,7 +112,7 @@ fn item_display_width(suggestion: &Suggestion) -> usize {
         .as_ref()
         .map(|d| UnicodeWidthStr::width(d.as_str()) + DESC_GAP_COLS)
         .unwrap_or(0);
-    GUTTER_COLS + text_len + desc_len + TRAILING_PAD_COLS
+    gutter_cols + text_len + desc_len + TRAILING_PAD_COLS
 }
 
 #[cfg(test)]
@@ -146,6 +152,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         assert_eq!(layout.scroll_deficit, 0);
         assert_eq!(layout.start_row, 6);
@@ -166,6 +174,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         // Layout always places below — start_row = cursor_row + 1
         assert_eq!(layout.start_row, 23);
@@ -186,6 +196,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         assert!(layout.start_col + layout.width <= 80);
     }
@@ -204,6 +216,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         assert_eq!(layout.start_row, 1);
         assert_eq!(layout.start_col, 0);
@@ -223,6 +237,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         assert!(layout.width >= DEFAULT_MIN_POPUP_WIDTH);
     }
@@ -242,6 +258,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         assert!(layout.width <= DEFAULT_MAX_POPUP_WIDTH);
     }
@@ -261,6 +279,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         assert_eq!(layout.height, DEFAULT_MAX_VISIBLE as u16 + 2); // +2 for borders
     }
@@ -280,6 +300,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         assert_eq!(layout.height, 7); // 5 content + 2 borders
     }
@@ -292,25 +314,25 @@ mod tests {
         // based on "file.txt" (8 chars), not the full 25-byte path.
         let deep = make_path("src/deeply/nested/file.txt", SuggestionKind::FilePath, None);
         let shallow = make_path("file.txt", SuggestionKind::FilePath, None);
-        assert_eq!(item_display_width(&deep), item_display_width(&shallow));
+        assert_eq!(item_display_width(&deep, DEFAULT_GUTTER_COLS), item_display_width(&shallow, DEFAULT_GUTTER_COLS));
     }
 
     #[test]
     fn test_directory_width_uses_basename() {
         // "path/to/mydir/" as Directory — display should be "mydir/" (6 chars).
         let deep = make_path("path/to/mydir/", SuggestionKind::Directory, None);
-        // GUTTER_COLS(4) + "mydir/"(6) + trailing(1) = 11
+        // DEFAULT_GUTTER_COLS(4) + "mydir/"(6) + trailing(1) = 11
         assert_eq!(
-            item_display_width(&deep),
-            GUTTER_COLS + 6 + TRAILING_PAD_COLS
+            item_display_width(&deep, DEFAULT_GUTTER_COLS),
+            DEFAULT_GUTTER_COLS + 6 + TRAILING_PAD_COLS
         );
     }
 
     #[test]
     fn test_filepath_no_slash_unchanged() {
         let s = make_path("Cargo.toml", SuggestionKind::FilePath, None);
-        // GUTTER_COLS(4) + "Cargo.toml"(10) + trailing(1) = 15
-        assert_eq!(item_display_width(&s), GUTTER_COLS + 10 + TRAILING_PAD_COLS);
+        // DEFAULT_GUTTER_COLS(4) + "Cargo.toml"(10) + trailing(1) = 15
+        assert_eq!(item_display_width(&s, DEFAULT_GUTTER_COLS), DEFAULT_GUTTER_COLS + 10 + TRAILING_PAD_COLS);
     }
 
     // --- Bug B5: non-ASCII char counting ---
@@ -319,18 +341,18 @@ mod tests {
     fn test_non_ascii_text_width() {
         // 3 CJK characters = 6 terminal columns (2 each via unicode-width)
         let s = make("\u{65E5}\u{672C}\u{8A9E}", None);
-        // GUTTER_COLS(4) + text(6 cols) + trailing(1) = 11
-        assert_eq!(item_display_width(&s), GUTTER_COLS + 6 + TRAILING_PAD_COLS);
+        // DEFAULT_GUTTER_COLS(4) + text(6 cols) + trailing(1) = 11
+        assert_eq!(item_display_width(&s, DEFAULT_GUTTER_COLS), DEFAULT_GUTTER_COLS + 6 + TRAILING_PAD_COLS);
     }
 
     #[test]
     fn test_non_ascii_description_width() {
         // 3 accented chars = 3 terminal columns (1 each, not fullwidth)
         let s = make("cmd", Some("\u{00E9}\u{00E8}\u{00EA}"));
-        // GUTTER_COLS(4) + "cmd"(3) + gap(2) + desc(3 cols) + trailing(1) = 13
+        // DEFAULT_GUTTER_COLS(4) + "cmd"(3) + gap(2) + desc(3 cols) + trailing(1) = 13
         assert_eq!(
-            item_display_width(&s),
-            GUTTER_COLS + 3 + DESC_GAP_COLS + 3 + TRAILING_PAD_COLS
+            item_display_width(&s, DEFAULT_GUTTER_COLS),
+            DEFAULT_GUTTER_COLS + 3 + DESC_GAP_COLS + 3 + TRAILING_PAD_COLS
         );
     }
 
@@ -351,6 +373,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         // Popup suppressed: zero-size layout prevents off-screen rendering
         assert_eq!(layout.width, 0);
@@ -372,6 +396,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         assert_eq!(layout.width, 0);
         assert_eq!(layout.height, 0);
@@ -392,6 +418,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            DEFAULT_GUTTER_COLS,
+            false,
         );
         assert!(layout.width > 0);
         assert!(layout.height > 0);
@@ -406,17 +434,17 @@ mod tests {
             SuggestionKind::FilePath,
             None,
         );
-        // GUTTER_COLS(4) + basename(12 cols) + trailing(1) = 17
-        assert_eq!(item_display_width(&s), GUTTER_COLS + 12 + TRAILING_PAD_COLS);
+        // DEFAULT_GUTTER_COLS(4) + basename(12 cols) + trailing(1) = 17
+        assert_eq!(item_display_width(&s, DEFAULT_GUTTER_COLS), DEFAULT_GUTTER_COLS + 12 + TRAILING_PAD_COLS);
     }
 
     #[test]
     fn test_gutter_cols_accounts_for_nerd_font_width() {
-        // GUTTER_COLS must be 4 to account for Nerd Font PUA icons rendering
+        // DEFAULT_GUTTER_COLS must be 4 to account for Nerd Font PUA icons rendering
         // as 2 columns: space(1) + icon(2) + space(1) = 4
-        assert_eq!(GUTTER_COLS, 4);
+        assert_eq!(DEFAULT_GUTTER_COLS, 4);
         // Simple command: gutter(4) + "ls"(2) + trailing(1) = 7
         let s = make("ls", None);
-        assert_eq!(item_display_width(&s), GUTTER_COLS + 2 + TRAILING_PAD_COLS);
+        assert_eq!(item_display_width(&s, DEFAULT_GUTTER_COLS), DEFAULT_GUTTER_COLS + 2 + TRAILING_PAD_COLS);
     }
 }

--- a/crates/gc-overlay/src/render.rs
+++ b/crates/gc-overlay/src/render.rs
@@ -24,6 +24,16 @@ pub struct PopupTheme {
     pub borders: bool,
     pub spinner: bool,
     pub show_provider_errors: bool,
+    /// Trailing spaces emitted after the kind icon. Total gutter width is
+    /// `1 + 2 + gutter_padding` columns (leading space + 2-col Nerd Font
+    /// icon + padding). Default `1` preserves historical `" K "` rendering.
+    pub gutter_padding: u8,
+    /// When `true`, layout always uses `max_width`; when `false`, width fits
+    /// the longest visible suggestion within `[min_width, max_width]`.
+    pub fixed_width: bool,
+    /// Appended to suggestion text or description when it would overflow the
+    /// row. Empty disables the indicator (silent truncation).
+    pub truncation_indicator: String,
 }
 
 impl Default for PopupTheme {
@@ -43,7 +53,45 @@ impl Default for PopupTheme {
             borders: false,
             spinner: true,
             show_provider_errors: false,
+            gutter_padding: 1,
+            fixed_width: false,
+            truncation_indicator: String::new(),
         }
+    }
+}
+
+impl PopupTheme {
+    /// Total gutter width in display columns: leading space + 2-col icon
+    /// + trailing padding. The icon column count assumes Nerd Font PUA
+    /// codepoints; matches the reasoning behind the historical `GUTTER_COLS`
+    /// constant in `layout.rs`.
+    pub fn gutter_cols(&self) -> usize {
+        layout::ICON_BASE_COLS + self.gutter_padding as usize
+    }
+
+    /// Display-column width of the configured truncation indicator. Returns
+    /// `0` when the indicator is empty (silent truncation).
+    pub fn truncation_indicator_cols(&self) -> usize {
+        display_cols(&self.truncation_indicator)
+    }
+}
+
+/// Decide whether a row needs to append the truncation indicator and the
+/// remaining body budget. `total_cols_fn` is only invoked when the indicator
+/// is non-empty and fits — keeping the default config (empty indicator) free
+/// of the per-row width scan over `text`.
+fn truncation_budget(
+    total_cols_fn: impl FnOnce() -> usize,
+    max_cols: usize,
+    indicator_cols: usize,
+) -> (usize, bool) {
+    if indicator_cols == 0 || indicator_cols >= max_cols {
+        return (max_cols, false);
+    }
+    if total_cols_fn() > max_cols {
+        (max_cols - indicator_cols, true)
+    } else {
+        (max_cols, false)
     }
 }
 
@@ -329,6 +377,8 @@ pub fn render_popup(
         min_width,
         max_width,
         theme.borders,
+        theme.gutter_cols(),
+        theme.fixed_width,
     );
 
     if layout.height == 0 {
@@ -556,7 +606,16 @@ fn render_feedback_only_popup(
 ) -> PopupLayout {
     let border_pad: u16 = if theme.borders { 2 } else { 0 };
     let effective_max_w = max_width.min(screen_cols).max(min_width);
-    let width = min_width.min(effective_max_w);
+    // Honor `fixed_width` here too: without this, the popup would render at
+    // `min_width` for the Loading/Empty/Error indicator and then jump to
+    // `max_width` the moment results merge in via `render_popup`. Users who
+    // opt into fixed_width are doing so for visual stability — that goal
+    // requires the same width across both code paths.
+    let width = if theme.fixed_width {
+        effective_max_w
+    } else {
+        min_width.min(effective_max_w)
+    };
     let base_height = 1 + border_pad;
     // Mirror the discard logic in `render_popup`: when prior_deficit >=
     // cursor_row the cached value is stale and would pin the indicator at
@@ -816,9 +875,10 @@ pub(crate) fn kind_icon(kind: SuggestionKind) -> char {
 
 /// Write the leading gutter (`" K "`) for a suggestion row. Always occupies
 /// `layout::GUTTER_COLS` display columns.
-fn write_gutter(buf: &mut Vec<u8>, kind: SuggestionKind) {
+fn write_gutter(buf: &mut Vec<u8>, kind: SuggestionKind, theme: &PopupTheme) {
     let kind_char = kind_icon(kind);
-    let _ = write!(buf, " {kind_char} ");
+    let _ = write!(buf, " {kind_char}");
+    write_padding(buf, theme.gutter_padding as usize);
 }
 
 /// Re-enable the row's base text style after an `ansi::reset` inside
@@ -917,11 +977,22 @@ fn write_highlighted_text(
     is_selected: bool,
     theme: &PopupTheme,
 ) -> usize {
+    // If the full text overflows the budget AND the configured truncation
+    // indicator fits, reserve indicator columns up front and emit the
+    // indicator after the truncated body. Empty indicator preserves the
+    // historical silent-truncation behavior.
+    let indicator_cols = theme.truncation_indicator_cols();
+    let (body_budget, will_truncate_with_indicator) = truncation_budget(
+        || display_cols(display_text),
+        max_text_chars,
+        indicator_cols,
+    );
+
     let mut in_highlight = false;
     let mut cols_written: usize = 0;
     for (char_idx, ch) in display_text.chars().enumerate() {
         let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
-        if cols_written + ch_width > max_text_chars {
+        if cols_written + ch_width > body_budget {
             break;
         }
         let should_highlight = !theme.match_highlight_on.is_empty()
@@ -942,6 +1013,10 @@ fn write_highlighted_text(
     if in_highlight {
         ansi::reset(buf);
         restore_base_style(buf, is_selected, theme);
+    }
+    if will_truncate_with_indicator {
+        let _ = write!(buf, "{}", theme.truncation_indicator);
+        cols_written += indicator_cols;
     }
     cols_written
 }
@@ -977,18 +1052,18 @@ fn write_description(
         ansi::reset(buf);
         buf.extend_from_slice(&theme.description_on);
     }
-    // Truncate description by display columns, not char count
-    let mut desc_cols: usize = 0;
-    let mut truncated = String::new();
-    for ch in desc.chars() {
-        let w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
-        if desc_cols + w > max_desc_cols {
-            break;
-        }
-        truncated.push(ch);
-        desc_cols += w;
-    }
+    // Truncate description by display columns, not char count. If truncation
+    // is needed and the configured indicator fits, reserve room for it and
+    // append after the truncated body.
+    let indicator_cols = theme.truncation_indicator_cols();
+    let (body_budget, will_truncate_with_indicator) =
+        truncation_budget(|| display_cols(&desc), max_desc_cols, indicator_cols);
+    let (truncated, mut desc_cols) = truncate_to_display_cols(&desc, body_budget);
     let _ = write!(buf, "{truncated}");
+    if will_truncate_with_indicator {
+        let _ = write!(buf, "{}", theme.truncation_indicator);
+        desc_cols += indicator_cols;
+    }
     if !is_selected {
         ansi::reset(buf);
         if !theme.item_text_on.is_empty() {
@@ -1010,10 +1085,11 @@ fn format_item(
     is_selected: bool,
     theme: &PopupTheme,
 ) {
-    write_gutter(buf, s.kind);
+    write_gutter(buf, s.kind, theme);
 
+    let gutter_cols = theme.gutter_cols();
     let total_width = width as usize;
-    let max_text_chars = total_width.saturating_sub(crate::layout::GUTTER_COLS);
+    let max_text_chars = total_width.saturating_sub(gutter_cols);
 
     // For filesystem entries, show just the last path component (the user
     // already typed the prefix, so repeating it wastes popup space).
@@ -1041,7 +1117,7 @@ fn format_item(
         theme,
     );
 
-    let gutter_text_len = crate::layout::GUTTER_COLS + cols_written;
+    let gutter_text_len = gutter_cols + cols_written;
     write_description(
         buf,
         s.description.as_deref(),
@@ -2569,6 +2645,67 @@ mod tests {
     }
 
     #[test]
+    fn test_feedback_only_popup_honors_fixed_width() {
+        // Regression: when a user opts into popup.fixed_width, the
+        // feedback-only path used to render at min_width, causing the popup
+        // to "jump" from min_width to max_width the moment results arrived.
+        // Both paths must use max_width when fixed_width is true.
+        let theme = PopupTheme {
+            fixed_width: true,
+            ..PopupTheme::default()
+        };
+        let state = OverlayState::new();
+
+        let mut feedback_buf = Vec::new();
+        let feedback_layout = render_popup(
+            &mut feedback_buf,
+            &[],
+            &state,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            &theme,
+            0,
+            FeedbackKind::Empty,
+            &ghostty_profile(),
+        );
+
+        let suggestions = make_suggestions();
+        let mut results_buf = Vec::new();
+        let results_layout = render_popup(
+            &mut results_buf,
+            &suggestions,
+            &state,
+            5,
+            0,
+            24,
+            80,
+            DEFAULT_MAX_VISIBLE,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            &theme,
+            0,
+            FeedbackKind::None,
+            &ghostty_profile(),
+        );
+
+        assert_eq!(
+            feedback_layout.width, results_layout.width,
+            "fixed_width must produce identical widths for feedback-only and \
+             results popups; got feedback={} results={}",
+            feedback_layout.width, results_layout.width,
+        );
+        assert_eq!(
+            feedback_layout.width, DEFAULT_MAX_POPUP_WIDTH,
+            "fixed_width should pin to max_width"
+        );
+    }
+
+    #[test]
     fn test_feedback_empty_and_error_labels() {
         let mut empty_buf = Vec::new();
         let state = OverlayState::new();
@@ -2807,6 +2944,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             false, // no borders
+            layout::DEFAULT_GUTTER_COLS,
+            false,
         );
         let bordered = layout::compute_layout(
             &suggestions,
@@ -2819,6 +2958,8 @@ mod tests {
             DEFAULT_MIN_POPUP_WIDTH,
             DEFAULT_MAX_POPUP_WIDTH,
             true,
+            layout::DEFAULT_GUTTER_COLS,
+            false,
         );
         assert_eq!(
             bordered.width - layout.width,

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -149,12 +149,7 @@ pub fn spawn_config_watcher(
                 }
             };
 
-            let theme = match build_popup_theme(
-                &resolved_theme,
-                config.popup.borders,
-                config.popup.spinner,
-                config.popup.show_provider_errors,
-            ) {
+            let theme = match build_popup_theme(&resolved_theme, &config.popup) {
                 Ok(t) => t,
                 Err(e) => {
                     tracing::warn!("config reload failed (theme styles): {e}");
@@ -210,9 +205,7 @@ pub fn spawn_config_watcher(
 /// with user overrides), parsing each style string.
 fn build_popup_theme(
     resolved: &gc_config::ResolvedTheme,
-    borders: bool,
-    spinner: bool,
-    show_provider_errors: bool,
+    popup: &gc_config::PopupConfig,
 ) -> Result<PopupTheme> {
     Ok(PopupTheme {
         selected_on: parse_style(&resolved.selected)
@@ -233,9 +226,12 @@ fn build_popup_theme(
             .map_err(|e| anyhow::anyhow!("invalid theme.scrollbar: {e}"))?,
         border_on: parse_style(&resolved.border)
             .map_err(|e| anyhow::anyhow!("invalid theme.border: {e}"))?,
-        borders,
-        spinner,
-        show_provider_errors,
+        borders: popup.borders,
+        spinner: popup.spinner,
+        show_provider_errors: popup.show_provider_errors,
+        gutter_padding: popup.gutter_padding,
+        fixed_width: popup.fixed_width,
+        truncation_indicator: popup.truncation_indicator.clone(),
     })
 }
 
@@ -256,7 +252,13 @@ mod tests {
             feedback_empty: "dim".into(),
             feedback_error: "dim fg:#f38ba8".into(),
         };
-        let result = build_popup_theme(&resolved, true, true, false);
+        let popup = gc_config::PopupConfig {
+            borders: true,
+            spinner: true,
+            show_provider_errors: false,
+            ..gc_config::PopupConfig::default()
+        };
+        let result = build_popup_theme(&resolved, &popup);
         assert!(result.is_ok());
         assert!(result.unwrap().borders);
     }

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -455,6 +455,7 @@ impl InputHandler {
         git: bool,
         js_runtime: bool,
         generator_timeout_ms: u64,
+        flags_require_dash: bool,
     ) -> Self {
         // During builder phase the Arc has exactly one reference, so try_unwrap succeeds.
         // Can't use .expect() directly because SuggestionEngine doesn't derive Debug;
@@ -471,6 +472,7 @@ impl InputHandler {
                 specs,
                 git,
                 js_runtime,
+                flags_require_dash,
             );
         Self {
             engine: Arc::new(engine),

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -3804,6 +3804,9 @@ mod tests {
             borders: true,
             spinner: true,
             show_provider_errors: false,
+            gutter_padding: 1,
+            fixed_width: false,
+            truncation_indicator: String::new(),
         };
 
         handler.update_config(

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -806,6 +806,24 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
     // Drop the sender we cloned from — we only need the ones in the tasks
     drop(shutdown_tx);
 
+    // Deferred initial resize. Some outer terminals (observed: Ghostty on
+    // Linux/Wayland) don't have their final window size reported via
+    // TIOCGWINSZ at the instant spawn_shell() called get_terminal_size(),
+    // so the inner PTY is created with stale dimensions and the inner
+    // shell's $COLUMNS is wrong until the first real SIGWINCH. That
+    // shows up as a misaligned first prompt: right-aligned RPROMPT
+    // segments land off-screen, PROMPT_SP fires because zsh's internal
+    // cursor-column tracking disagrees with the real terminal width,
+    // and zooming "fixes" it only because the zoom triggers SIGWINCH.
+    // Re-querying once shortly after startup catches the race; if the
+    // initial size was already correct, the second resize_pty with the
+    // same dimensions is a no-op.
+    let (initial_resize_tx, mut initial_resize_rx) = mpsc::channel::<()>(1);
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let _ = initial_resize_tx.send(()).await;
+    });
+
     // Task C: Signal handling
     let mut sigwinch =
         signal(SignalKind::window_change()).context("failed to register SIGWINCH handler")?;
@@ -874,6 +892,39 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                     }
                     Err(e) => {
                         tracing::warn!("failed to get terminal size for resize: {}", e);
+                    }
+                }
+            }
+            _ = initial_resize_rx.recv() => {
+                // Defensive re-resize after startup — see channel setup above.
+                // Body intentionally narrower than the SIGWINCH branch: at
+                // startup no popup is visible yet, so the overlay-cleanup
+                // path is unnecessary; we only need to propagate the
+                // (possibly corrected) outer size to the inner PTY and the
+                // parser. The channel is single-shot, so this branch fires
+                // at most once per proxy lifetime.
+                match get_terminal_size() {
+                    Ok(size) => {
+                        if let Err(e) = resize_pty(master.as_ref(), size) {
+                            tracing::warn!("failed deferred initial resize: {}", e);
+                        } else {
+                            match parser.lock() {
+                                Ok(mut p) => {
+                                    p.state_mut().update_dimensions(size.rows, size.cols);
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "parser mutex poisoned on deferred initial resize: {e}"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "failed to query terminal size for deferred initial resize: {}",
+                            e
+                        );
                     }
                 }
             }

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -196,6 +196,9 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
         borders: config.popup.borders,
         spinner: config.popup.spinner,
         show_provider_errors: config.popup.show_provider_errors,
+        gutter_padding: config.popup.gutter_padding,
+        fixed_width: config.popup.fixed_width,
+        truncation_indicator: config.popup.truncation_indicator.clone(),
     };
 
     // Initialize suggestion handler with config

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -217,6 +217,7 @@ pub async fn run_proxy(shell: &str, args: &[String], config: &GhostConfig) -> Re
                 config.suggest.providers.git,
                 config.suggest.providers.js_runtime,
                 config.suggest.generator_timeout_ms,
+                config.suggest.flags_require_dash,
             ),
     ));
 
@@ -1753,7 +1754,7 @@ mod tests {
     fn proxy_resolution_test_handler(resolution: &SpecDirResolution) -> InputHandler {
         input_handler_for_resolution(resolution, TerminalProfile::for_ghostty())
             .expect("handler")
-            .with_suggest_config(20, false, 0, false, true, false, false, 100)
+            .with_suggest_config(20, false, 0, false, true, false, false, 100, false)
     }
 
     fn trigger_texts(handler: &mut InputHandler, buffer: &str) -> Vec<String> {

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -275,6 +275,10 @@ pub struct SuggestionEngine {
     /// `js_runtime` were missing — they're dropped from the generator
     /// pool. Mirrors `ProvidersConfig::js_runtime` from `gc-config`.
     providers_js_runtime: bool,
+    /// When `true`, `Context::SpecArg` suppresses spec-declared flags;
+    /// they reach the popup only via `Context::FlagPrefix` (after the
+    /// user types `-`). Mirrors `SuggestConfig::flags_require_dash`.
+    flags_require_dash: bool,
 }
 
 impl SuggestionEngine {
@@ -317,6 +321,7 @@ impl SuggestionEngine {
             providers_specs: true,
             providers_git: true,
             providers_js_runtime: true,
+            flags_require_dash: true,
         })
     }
 
@@ -330,6 +335,7 @@ impl SuggestionEngine {
         specs: bool,
         git: bool,
         js_runtime: bool,
+        flags_require_dash: bool,
     ) -> Self {
         self.max_results = max_results;
         self.max_history_results = max_history_results;
@@ -338,6 +344,7 @@ impl SuggestionEngine {
         self.providers_specs = specs;
         self.providers_git = git;
         self.providers_js_runtime = js_runtime;
+        self.flags_require_dash = flags_require_dash;
         // Reload history only if enabled
         if max_history_results > 0 {
             self.history_provider = HistoryProvider::load(DEFAULT_MAX_HISTORY_ENTRIES);
@@ -371,6 +378,7 @@ impl SuggestionEngine {
             providers_specs: true,
             providers_git: true,
             providers_js_runtime: true,
+            flags_require_dash: true,
         }
     }
 
@@ -1205,7 +1213,9 @@ impl SuggestionEngine {
 
         if !suppress_commands {
             candidates.extend(subcommands);
-            candidates.extend(options);
+            if !self.flags_require_dash {
+                candidates.extend(options);
+            }
         }
 
         // Static `args.suggestions` are values for an arg position, not commands —
@@ -1991,6 +2001,44 @@ mod tests {
     }
 
     #[test]
+    fn flags_require_dash_default_hides_flags_in_spec_arg() {
+        // Default `flags_require_dash = true`: empty current_word in SpecArg
+        // context yields subcommands but no flags from the spec's `options`.
+        let engine = make_engine();
+        let ctx = make_ctx(Some("git"), vec![], "", 1);
+        let results = engine
+            .suggest_sync(&ctx, Path::new("/tmp"), "git ")
+            .unwrap();
+        assert!(
+            !results
+                .suggestions
+                .iter()
+                .any(|s| s.kind == SuggestionKind::Flag),
+            "flags must not appear in SpecArg when flags_require_dash=true: {:?}",
+            results.suggestions,
+        );
+    }
+
+    #[test]
+    fn flags_require_dash_disabled_emits_flags_in_spec_arg() {
+        // Opt-out: with flags_require_dash=false the SpecArg arm still extends
+        // candidates with the spec's flags, matching pre-existing behavior.
+        let engine = make_engine().with_suggest_config(50, true, 5, true, true, true, false, false);
+        let ctx = make_ctx(Some("git"), vec![], "", 1);
+        let results = engine
+            .suggest_sync(&ctx, Path::new("/tmp"), "git ")
+            .unwrap();
+        assert!(
+            results
+                .suggestions
+                .iter()
+                .any(|s| s.kind == SuggestionKind::Flag),
+            "flags must appear in SpecArg when flags_require_dash=false: {:?}",
+            results.suggestions,
+        );
+    }
+
+    #[test]
     fn test_git_checkout_with_flag_prefix_still_shows_flags() {
         // FlagPrefix context dispatches to suggest_flag_prefix which returns
         // spec-declared flags and subcommands only — no filesystem, no git
@@ -2458,7 +2506,7 @@ mod tests {
         let history = HistoryProvider::from_entries(vec![]);
         let commands = CommandsProvider::from_list(vec!["git".into(), "ls".into()]);
         let engine = SuggestionEngine::with_providers(spec_store, history, commands)
-            .with_suggest_config(50, false, 5, true, true, true, true);
+            .with_suggest_config(50, false, 5, true, true, true, true, false);
 
         let ctx = make_ctx(None, vec![], "gi", 0);
         let results = engine.suggest_sync(&ctx, Path::new("/tmp"), "gi").unwrap();

--- a/crates/gc-suggest/src/frecency.rs
+++ b/crates/gc-suggest/src/frecency.rs
@@ -560,6 +560,36 @@ impl FrecencyDb {
         }
     }
 
+    /// Record many keys under a single lock acquisition. Intentionally
+    /// skips the per-record `SAVE_EVERY` snapshot trigger — callers are
+    /// expected to call [`Self::flush`] at the end. Used by the bulk
+    /// `import-history` path; the per-keystroke runtime path stays on
+    /// [`Self::record`] so its incremental persistence is preserved.
+    pub fn record_many<S, I>(&self, keys: I)
+    where
+        S: AsRef<str>,
+        I: IntoIterator<Item = S>,
+    {
+        let now = now_secs();
+        let mut inner = self.lock_inner();
+        let mut count: u32 = 0;
+        for key in keys {
+            let entry =
+                inner
+                    .entries
+                    .entry(key.as_ref().to_string())
+                    .or_insert(FrecencyEntry {
+                        stored_score: 0.0,
+                        reference_secs: now,
+                    });
+            let actual = entry.actual_score(now);
+            entry.stored_score = (actual + 1.0).min(MAX_STORED_SCORE);
+            entry.reference_secs = now;
+            count = count.saturating_add(1);
+        }
+        inner.dirty_count = inner.dirty_count.saturating_add(count);
+    }
+
     /// Flush any unsaved records to disk. Call on proxy shutdown.
     pub fn flush(&self) {
         let snapshot = {

--- a/crates/gc-suggest/src/history.rs
+++ b/crates/gc-suggest/src/history.rs
@@ -10,7 +10,7 @@ use gc_buffer::CommandContext;
 use crate::provider::Provider;
 use crate::types::{Suggestion, SuggestionKind, SuggestionSource};
 
-pub(crate) const DEFAULT_MAX_HISTORY_ENTRIES: usize = 10_000;
+pub const DEFAULT_MAX_HISTORY_ENTRIES: usize = 10_000;
 
 /// Above this file size, [`read_tail`] reads only the last ~2 MiB rather
 /// than slurping the whole file. 2 MiB is roughly 20–30k history entries on

--- a/crates/gc-suggest/src/history.rs
+++ b/crates/gc-suggest/src/history.rs
@@ -136,7 +136,11 @@ impl HistoryProvider {
         }
     }
 
-    fn read_history_from(path: &Path, max_entries: usize) -> Result<Vec<String>> {
+    /// Read and parse `path` (zsh extended or plain history format) into
+    /// its deduplicated command list, oldest-to-newest. Capped at
+    /// `max_entries`. Used by the runtime [`HistoryProvider`] and by
+    /// `ghost-complete import-history`.
+    pub fn read_history_from(path: &Path, max_entries: usize) -> Result<Vec<String>> {
         let raw = read_tail(path)?;
         // Strict per-line UTF-8: any line that isn't valid UTF-8 is dropped
         // with a debug log instead of being silently corrupted by U+FFFD

--- a/crates/gc-suggest/src/specs.rs
+++ b/crates/gc-suggest/src/specs.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, RwLock};
+#[cfg(target_os = "macos")]
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};

--- a/crates/gc-suggest/tests/js_dispatch.rs
+++ b/crates/gc-suggest/tests/js_dispatch.rs
@@ -524,7 +524,7 @@ async fn custom_unsupported_host_api_logs_diagnostic() {
 async fn custom_kill_switch_disables_dispatch() {
     let source = "async () => [{ name: 'should-not-run' }]";
     let gen = custom_generator(source);
-    let engine = make_engine().with_suggest_config(50, true, 5, true, true, true, false);
+    let engine = make_engine().with_suggest_config(50, true, 5, true, true, true, false, false);
     let ctx = make_ctx("phase5-test", Vec::new(), "");
     let results = engine
         .run_generators(&[gen], &ctx, Path::new("/tmp"), 5_000)

--- a/crates/gc-suggest/tests/js_post_process_dispatch.rs
+++ b/crates/gc-suggest/tests/js_post_process_dispatch.rs
@@ -120,7 +120,7 @@ fn fixture_engine() -> SuggestionEngine {
 }
 
 fn engine_with_js_disabled() -> SuggestionEngine {
-    make_engine().with_suggest_config(50, true, 5, true, true, true, false)
+    make_engine().with_suggest_config(50, true, 5, true, true, true, false, false)
 }
 
 /// Convenience: build a `post_process` generator wrapping a fixed `script`

--- a/crates/ghost-complete/src/import_history.rs
+++ b/crates/ghost-complete/src/import_history.rs
@@ -1,0 +1,235 @@
+//! `ghost-complete import-history` — seed the frecency database from a
+//! zsh history file so commonly-used commands rank highly from day one.
+//!
+//! For each history line we tokenize on whitespace, split the line into
+//! pipeline segments (`|`, `&&`, `||`, `;`), and for each segment record:
+//! - One `Command`-position frecency hit on the head token (e.g. `git`).
+//! - One `Subcommand`-position frecency hit on the next non-flag,
+//!   non-path-looking token (e.g. `push` after `git`). When the second
+//!   token starts with `-/.~$=` we skip it — those buckets are
+//!   command-specific and would just clutter the frecency JSON.
+//!
+//! Multi-line history entries are merged by [`HistoryProvider::read_history_from`]
+//! before we see them.
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+use gc_suggest::frecency::{frecency_key, FrecencyDb};
+use gc_suggest::history::HistoryProvider;
+use gc_suggest::types::SuggestionKind;
+
+const PIPELINE_SEPARATORS: &[&str] = &["|", "&&", "||", ";"];
+
+/// Mirror of `gc_suggest::history::DEFAULT_MAX_HISTORY_ENTRIES` (which is
+/// `pub(crate)` over there). Keeping a local constant avoids broadening
+/// the gc-suggest API surface for a one-off importer cap default.
+const DEFAULT_MAX_HISTORY_ENTRIES: usize = 10_000;
+
+pub fn run_import_history(
+    path_override: Option<&str>,
+    max_entries: Option<usize>,
+    dry_run: bool,
+) -> Result<()> {
+    let history_path = resolve_history_path(path_override)?;
+    let cap = max_entries.unwrap_or(DEFAULT_MAX_HISTORY_ENTRIES);
+
+    println!("Reading {} (cap: {} entries)…", history_path.display(), cap);
+    let entries = HistoryProvider::read_history_from(&history_path, cap)
+        .with_context(|| format!("failed to read history at {}", history_path.display()))?;
+    println!("  Found {} unique entries.", entries.len());
+
+    let recordings = build_recordings(&entries);
+    println!(
+        "  Generated {} frecency records ({} commands, {} subcommands).",
+        recordings.len(),
+        recordings
+            .iter()
+            .filter(|r| r.kind == SuggestionKind::Command)
+            .count(),
+        recordings
+            .iter()
+            .filter(|r| r.kind == SuggestionKind::Subcommand)
+            .count(),
+    );
+
+    if dry_run {
+        println!("\n[dry-run] Skipping write. First 10 records:");
+        for r in recordings.iter().take(10) {
+            println!("  {r}");
+        }
+        return Ok(());
+    }
+
+    let db = FrecencyDb::load();
+    for r in &recordings {
+        db.record(&frecency_key(r.command.as_deref(), r.kind, &r.text));
+    }
+    db.flush();
+
+    println!(
+        "\n\x1b[32m\u{2713}\x1b[0m  Imported {} records into the frecency store.",
+        recordings.len()
+    );
+    println!(
+        "  Tip: open a new shell to attach to a fresh proxy that loads the updated scores."
+    );
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Recording {
+    command: Option<String>,
+    kind: SuggestionKind,
+    text: String,
+}
+
+impl std::fmt::Display for Recording {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (&self.command, self.kind) {
+            (None, SuggestionKind::Command) => write!(f, "cmd  {}", self.text),
+            (Some(c), SuggestionKind::Subcommand) => write!(f, "sub  {} {}", c, self.text),
+            _ => write!(f, "{:?} {:?} {}", self.command, self.kind, self.text),
+        }
+    }
+}
+
+fn build_recordings(entries: &[String]) -> Vec<Recording> {
+    let mut out = Vec::new();
+    for line in entries {
+        for segment in split_pipeline(line) {
+            let mut tokens = segment.split_whitespace();
+            let Some(cmd) = tokens.next() else {
+                continue;
+            };
+            if !is_plausible_command(cmd) {
+                continue;
+            }
+            out.push(Recording {
+                command: None,
+                kind: SuggestionKind::Command,
+                text: cmd.to_string(),
+            });
+            if let Some(sub) = tokens.find(|t| !t.is_empty()) {
+                if is_plausible_subcommand(sub) {
+                    out.push(Recording {
+                        command: Some(cmd.to_string()),
+                        kind: SuggestionKind::Subcommand,
+                        text: sub.to_string(),
+                    });
+                }
+            }
+        }
+    }
+    out
+}
+
+fn split_pipeline(line: &str) -> Vec<&str> {
+    let mut segments = vec![line];
+    for sep in PIPELINE_SEPARATORS {
+        segments = segments
+            .into_iter()
+            .flat_map(|s| s.split(sep))
+            .collect();
+    }
+    segments
+        .into_iter()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn is_plausible_command(token: &str) -> bool {
+    let first = token.chars().next().unwrap_or('\0');
+    !matches!(first, '-' | '/' | '.' | '~' | '$' | '=' | '\\' | '(')
+        && !token.contains('=')
+}
+
+fn is_plausible_subcommand(token: &str) -> bool {
+    let first = token.chars().next().unwrap_or('\0');
+    !matches!(first, '-' | '/' | '.' | '~' | '$' | '=' | '\\')
+}
+
+fn resolve_history_path(override_: Option<&str>) -> Result<PathBuf> {
+    if let Some(p) = override_ {
+        return Ok(PathBuf::from(p));
+    }
+    if let Ok(p) = std::env::var("HISTFILE") {
+        if !p.is_empty() {
+            return Ok(PathBuf::from(p));
+        }
+    }
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".zsh_history"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(s: &str) -> String {
+        s.to_string()
+    }
+
+    #[test]
+    fn build_recordings_emits_command_and_subcommand_pairs() {
+        let entries = vec![entry("git push origin main"), entry("cargo build")];
+        let recordings = build_recordings(&entries);
+        let pairs: Vec<(Option<&str>, SuggestionKind, &str)> = recordings
+            .iter()
+            .map(|r| (r.command.as_deref(), r.kind, r.text.as_str()))
+            .collect();
+        assert!(pairs.contains(&(None, SuggestionKind::Command, "git")));
+        assert!(pairs.contains(&(Some("git"), SuggestionKind::Subcommand, "push")));
+        assert!(pairs.contains(&(None, SuggestionKind::Command, "cargo")));
+        assert!(pairs.contains(&(Some("cargo"), SuggestionKind::Subcommand, "build")));
+    }
+
+    #[test]
+    fn build_recordings_splits_pipelines() {
+        let entries = vec![entry("cat /tmp/log | grep error && echo done")];
+        let recordings = build_recordings(&entries);
+        let cmds: Vec<&str> = recordings
+            .iter()
+            .filter(|r| r.kind == SuggestionKind::Command)
+            .map(|r| r.text.as_str())
+            .collect();
+        assert!(cmds.contains(&"cat"));
+        assert!(cmds.contains(&"grep"));
+        assert!(cmds.contains(&"echo"));
+    }
+
+    #[test]
+    fn build_recordings_skips_path_like_subcommand_tokens() {
+        let entries = vec![entry("ls /usr/local/bin")];
+        let recordings = build_recordings(&entries);
+        assert!(recordings
+            .iter()
+            .any(|r| r.kind == SuggestionKind::Command && r.text == "ls"));
+        assert!(!recordings
+            .iter()
+            .any(|r| r.kind == SuggestionKind::Subcommand));
+    }
+
+    #[test]
+    fn build_recordings_skips_assignment_lines() {
+        // VAR=value commands aren't useful frecency seeds.
+        let entries = vec![entry("FOO=bar")];
+        let recordings = build_recordings(&entries);
+        assert!(recordings.is_empty());
+    }
+
+    #[test]
+    fn build_recordings_skips_dash_subcommands() {
+        // First non-cmd token is a flag — no subcommand bucket should be recorded.
+        let entries = vec![entry("ls -la")];
+        let recordings = build_recordings(&entries);
+        assert_eq!(
+            recordings
+                .iter()
+                .filter(|r| r.kind == SuggestionKind::Subcommand)
+                .count(),
+            0
+        );
+    }
+}

--- a/crates/ghost-complete/src/import_history.rs
+++ b/crates/ghost-complete/src/import_history.rs
@@ -16,15 +16,13 @@ use anyhow::{Context, Result};
 use std::path::PathBuf;
 
 use gc_suggest::frecency::{frecency_key, FrecencyDb};
-use gc_suggest::history::HistoryProvider;
+use gc_suggest::history::{HistoryProvider, DEFAULT_MAX_HISTORY_ENTRIES};
 use gc_suggest::types::SuggestionKind;
 
-const PIPELINE_SEPARATORS: &[&str] = &["|", "&&", "||", ";"];
-
-/// Mirror of `gc_suggest::history::DEFAULT_MAX_HISTORY_ENTRIES` (which is
-/// `pub(crate)` over there). Keeping a local constant avoids broadening
-/// the gc-suggest API surface for a one-off importer cap default.
-const DEFAULT_MAX_HISTORY_ENTRIES: usize = 10_000;
+// `||` and `&&` precede `|` so a literal `||` is split as one boundary
+// rather than two empty `|` splits (which the empty-segment filter would
+// then silently swallow).
+const PIPELINE_SEPARATORS: &[&str] = &["||", "&&", "|", ";"];
 
 pub fn run_import_history(
     path_override: Option<&str>,
@@ -40,31 +38,38 @@ pub fn run_import_history(
     println!("  Found {} unique entries.", entries.len());
 
     let recordings = build_recordings(&entries);
+    let cmd_count = recordings
+        .iter()
+        .filter(|r| r.kind == SuggestionKind::Command)
+        .count();
+    let sub_count = recordings.len() - cmd_count;
     println!(
         "  Generated {} frecency records ({} commands, {} subcommands).",
         recordings.len(),
-        recordings
-            .iter()
-            .filter(|r| r.kind == SuggestionKind::Command)
-            .count(),
-        recordings
-            .iter()
-            .filter(|r| r.kind == SuggestionKind::Subcommand)
-            .count(),
+        cmd_count,
+        sub_count,
     );
 
     if dry_run {
         println!("\n[dry-run] Skipping write. First 10 records:");
         for r in recordings.iter().take(10) {
-            println!("  {r}");
+            match r.kind {
+                SuggestionKind::Command => println!("  cmd  {}", r.text),
+                SuggestionKind::Subcommand => {
+                    println!("  sub  {} {}", r.command.as_deref().unwrap_or("?"), r.text)
+                }
+                _ => println!("  {}  {}", r.kind.key_tag(), r.text),
+            }
         }
         return Ok(());
     }
 
     let db = FrecencyDb::load();
-    for r in &recordings {
-        db.record(&frecency_key(r.command.as_deref(), r.kind, &r.text));
-    }
+    db.record_many(
+        recordings
+            .iter()
+            .map(|r| frecency_key(r.command.as_deref(), r.kind, &r.text)),
+    );
     db.flush();
 
     println!(
@@ -84,16 +89,6 @@ struct Recording {
     text: String,
 }
 
-impl std::fmt::Display for Recording {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match (&self.command, self.kind) {
-            (None, SuggestionKind::Command) => write!(f, "cmd  {}", self.text),
-            (Some(c), SuggestionKind::Subcommand) => write!(f, "sub  {} {}", c, self.text),
-            _ => write!(f, "{:?} {:?} {}", self.command, self.kind, self.text),
-        }
-    }
-}
-
 fn build_recordings(entries: &[String]) -> Vec<Recording> {
     let mut out = Vec::new();
     for line in entries {
@@ -105,15 +100,17 @@ fn build_recordings(entries: &[String]) -> Vec<Recording> {
             if !is_plausible_command(cmd) {
                 continue;
             }
+            let cmd_owned = cmd.to_string();
+            let next = tokens.next();
             out.push(Recording {
                 command: None,
                 kind: SuggestionKind::Command,
-                text: cmd.to_string(),
+                text: cmd_owned.clone(),
             });
-            if let Some(sub) = tokens.find(|t| !t.is_empty()) {
+            if let Some(sub) = next {
                 if is_plausible_subcommand(sub) {
                     out.push(Recording {
-                        command: Some(cmd.to_string()),
+                        command: Some(cmd_owned),
                         kind: SuggestionKind::Subcommand,
                         text: sub.to_string(),
                     });

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -43,6 +43,7 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # max_results = 50
 # max_history_results = 5
 # generator_timeout_ms = 5000  # Per-invocation timeout (ms) for async script/git generators
+# flags_require_dash = true  # Set false to mix spec flags into argument suggestions before user types '-'
 
 # [suggest.providers]
 # commands = true

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -38,6 +38,9 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # feedback_dismiss_ms = 1200  # Empty/error feedback auto-dismiss delay; 0 disables
 # spinner = true  # Animate async Loading feedback in wide popups
 # show_provider_errors = false  # Set true to show provider names in error feedback
+# gutter_padding = 1  # Trailing spaces between the kind icon and suggestion text (0–8)
+# fixed_width = false  # When true, popup always renders at max width (60 cols) instead of fitting content
+# truncation_indicator = \"\"  # Appended to clipped text/description; e.g. \"…\" (1 col) or \"...\" (3 cols)
 
 # [suggest]
 # max_results = 50

--- a/crates/ghost-complete/src/main.rs
+++ b/crates/ghost-complete/src/main.rs
@@ -1,5 +1,6 @@
 mod config_cmd;
 mod doctor;
+mod import_history;
 mod install;
 mod sanitize;
 mod status;
@@ -22,7 +23,7 @@ use tracing_subscriber::EnvFilter;
         ")"
     ),
     about = "Terminal-native autocomplete engine",
-    after_help = "COMMANDS:\n  install          Install shell integration (zsh)\n  uninstall        Remove shell integration\n  validate-specs   Validate completion spec files\n  status           Show loaded specs and JS compatibility\n  config           Show resolved configuration\n  config edit      Open interactive config editor\n  doctor           Run health checks\n\nSHELL SUPPORT:\n  zsh   Full support (auto-installed into ~/.zshrc)"
+    after_help = "COMMANDS:\n  install          Install shell integration (zsh)\n  uninstall        Remove shell integration\n  validate-specs   Validate completion spec files\n  status           Show loaded specs and JS compatibility\n  config           Show resolved configuration\n  config edit      Open interactive config editor\n  doctor           Run health checks\n  import-history   Seed frecency scores from $HISTFILE / ~/.zsh_history\n\nSHELL SUPPORT:\n  zsh   Full support (auto-installed into ~/.zshrc)"
 )]
 struct Cli {
     /// Path to config file
@@ -123,6 +124,36 @@ fn parse_baseline_flag(shell_args: &[String]) -> Result<Option<std::path::PathBu
     Ok(out)
 }
 
+/// Generic counterpart to [`parse_baseline_flag`]: extract a `--<name> VALUE`
+/// or `--<name>=VALUE` flag from `args`. Returns the last occurrence so
+/// `--from a --from b` resolves to `b`. Errors on a bare `--<name>` with
+/// no value or one followed by another flag.
+fn parse_value_flag(args: &[String], name: &str) -> Result<Option<String>> {
+    let with_eq = format!("{name}=");
+    let mut out: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        let a = &args[i];
+        if a == name {
+            match args.get(i + 1) {
+                Some(v) if !v.starts_with('-') => {
+                    out = Some(v.clone());
+                    i += 2;
+                    continue;
+                }
+                _ => anyhow::bail!("{name} requires a value"),
+            }
+        } else if let Some(rest) = a.strip_prefix(&with_eq) {
+            if rest.is_empty() {
+                anyhow::bail!("{name} requires a value");
+            }
+            out = Some(rest.to_string());
+        }
+        i += 1;
+    }
+    Ok(out)
+}
+
 fn init_tracing(level: &str, log_file: Option<&str>) -> Result<()> {
     // Prefer `RUST_LOG` (standard ecosystem env var) when set; fall back to
     // the `--log-level` flag value otherwise. This matches how every other
@@ -197,6 +228,20 @@ fn main() -> Result<()> {
         Some("doctor") => {
             init_tracing(&cli.log_level, cli.log_file.as_deref())?;
             return doctor::run_doctor(cli.config.as_deref());
+        }
+        Some("import-history") => {
+            init_tracing(&cli.log_level, cli.log_file.as_deref())?;
+            let dry_run = cli.shell_args.iter().any(|s| s == "--dry-run");
+            let path_override = parse_value_flag(&cli.shell_args, "--from")?;
+            let max_entries = parse_value_flag(&cli.shell_args, "--max")?
+                .map(|s| s.parse::<usize>())
+                .transpose()
+                .context("--max requires a non-negative integer")?;
+            return import_history::run_import_history(
+                path_override.as_deref(),
+                max_entries,
+                dry_run,
+            );
         }
         _ => {}
     }

--- a/crates/ghost-complete/src/main.rs
+++ b/crates/ghost-complete/src/main.rs
@@ -91,43 +91,19 @@ where
 }
 
 /// Parse `--baseline <path>` (or `--baseline=PATH`) out of the trailing
-/// arg list `shell_args`. Accepts the GNU-style `--baseline=` form as a
-/// convenience alias.
-///
-/// A bare `--baseline` with no following value — or a `--baseline` whose
-/// next token starts with `-` (another flag) — is a user error, not a
-/// silent fallback to the embedded baseline. The latter behaviour would
-/// mask typos like `ghost-complete status --baseline --json`.
+/// arg list `shell_args`. A bare `--baseline` with no following value —
+/// or a `--baseline` whose next token starts with `-` — is a user
+/// error, not a silent fallback to the embedded baseline; the latter
+/// would mask typos like `ghost-complete status --baseline --json`.
 fn parse_baseline_flag(shell_args: &[String]) -> Result<Option<std::path::PathBuf>> {
-    let mut out: Option<std::path::PathBuf> = None;
-    let mut i = 0;
-    while i < shell_args.len() {
-        let a = &shell_args[i];
-        if a == "--baseline" {
-            let next = shell_args.get(i + 1);
-            match next {
-                Some(v) if !v.starts_with('-') => {
-                    out = Some(std::path::PathBuf::from(v));
-                    i += 2;
-                    continue;
-                }
-                _ => anyhow::bail!("--baseline requires a path argument"),
-            }
-        } else if let Some(rest) = a.strip_prefix("--baseline=") {
-            if rest.is_empty() {
-                anyhow::bail!("--baseline requires a path argument");
-            }
-            out = Some(std::path::PathBuf::from(rest));
-        }
-        i += 1;
-    }
-    Ok(out)
+    parse_value_flag(shell_args, "--baseline")
+        .map_err(|_| anyhow::anyhow!("--baseline requires a path argument"))
+        .map(|opt| opt.map(std::path::PathBuf::from))
 }
 
-/// Generic counterpart to [`parse_baseline_flag`]: extract a `--<name> VALUE`
-/// or `--<name>=VALUE` flag from `args`. Returns the last occurrence so
-/// `--from a --from b` resolves to `b`. Errors on a bare `--<name>` with
-/// no value or one followed by another flag.
+/// Extract a `--<name> VALUE` or `--<name>=VALUE` flag from `args`.
+/// Returns the last occurrence so `--from a --from b` resolves to `b`.
+/// Errors on a bare `--<name>` with no value or one followed by another flag.
 fn parse_value_flag(args: &[String], name: &str) -> Result<Option<String>> {
     let with_eq = format!("{name}=");
     let mut out: Option<String> = None;

--- a/crates/ghost-complete/src/tui/editor.rs
+++ b/crates/ghost-complete/src/tui/editor.rs
@@ -264,6 +264,17 @@ fn commit_toml_update(app: &mut App, field_key: String, new_toml: String) {
                 );
                 return;
             }
+            if normalized.popup.gutter_padding != new_config.popup.gutter_padding {
+                set_error(
+                    app,
+                    &field_key,
+                    format!(
+                        "value {} out of range: would be clamped to {}",
+                        new_config.popup.gutter_padding, normalized.popup.gutter_padding
+                    ),
+                );
+                return;
+            }
 
             app.raw_toml = new_toml;
             app.config = new_config;

--- a/crates/ghost-complete/src/tui/fields.rs
+++ b/crates/ghost-complete/src/tui/fields.rs
@@ -129,6 +129,30 @@ pub fn all_fields() -> Vec<FieldMeta> {
             reload: ReloadBehavior::Live,
             help: "Show provider names in error feedback",
         },
+        FieldMeta {
+            section: "popup",
+            key: "gutter_padding",
+            field_type: FieldType::Usize,
+            default: "1",
+            reload: ReloadBehavior::Live,
+            help: "Trailing spaces between the kind icon and suggestion text (0-8)",
+        },
+        FieldMeta {
+            section: "popup",
+            key: "fixed_width",
+            field_type: FieldType::Bool,
+            default: "false",
+            reload: ReloadBehavior::Live,
+            help: "Always render at max width (60 cols) instead of fitting content",
+        },
+        FieldMeta {
+            section: "popup",
+            key: "truncation_indicator",
+            field_type: FieldType::String,
+            default: "",
+            reload: ReloadBehavior::Live,
+            help: "Appended when text/description overflows; e.g. \"…\" (1 col) or \"...\" (3 cols)",
+        },
         // suggest
         FieldMeta {
             section: "suggest",

--- a/crates/ghost-complete/src/tui/fields.rs
+++ b/crates/ghost-complete/src/tui/fields.rs
@@ -154,6 +154,14 @@ pub fn all_fields() -> Vec<FieldMeta> {
             reload: ReloadBehavior::RequiresRestart,
             help: "Timeout in ms for async script generators",
         },
+        FieldMeta {
+            section: "suggest",
+            key: "flags_require_dash",
+            field_type: FieldType::Bool,
+            default: "true",
+            reload: ReloadBehavior::RequiresRestart,
+            help: "Show spec flags only after typing '-' (false = mix flags into argument suggestions)",
+        },
         // suggest.providers
         FieldMeta {
             section: "suggest.providers",

--- a/scripts/dev-reinstall.sh
+++ b/scripts/dev-reinstall.sh
@@ -51,4 +51,17 @@ step "Reinstalling shell integration"
 ghost-complete install
 
 step "Opening config editor"
-exec ghost-complete config edit
+ghost-complete config edit
+
+cat <<'NOTE'
+
+[3m===========================================================================[0m
+[1;33mHeads up:[0m the running ghost-complete PTY proxy in your current shell is
+the OLD binary — proxies are spawned at shell startup and do not hot-reload
+their own code (only config.toml). To exercise the new binary:
+
+  • Open a new terminal, OR
+  • In this shell run:  pkill ghost-complete && exec zsh
+
+[3m===========================================================================[0m
+NOTE

--- a/scripts/dev-reinstall.sh
+++ b/scripts/dev-reinstall.sh
@@ -4,7 +4,11 @@
 # Steps:
 #   1. ghost-complete uninstall   (remove shell integration block from ~/.zshrc)
 #   2. cargo uninstall ghost-complete   (drop the cargo-managed binary)
-#   3. cargo install --path crates/ghost-complete --locked
+#   3. cargo install --path crates/ghost-complete --locked --force
+#      (--force handles the case where step 2 was a no-op because the
+#      installed binary was placed by some other path — e.g. a manual
+#      `cp` into $CARGO_HOME/bin — and cargo therefore has no record
+#      of it to uninstall.)
 #   4. ghost-complete install   (re-write shell integration)
 #   5. ghost-complete config edit   (open the TUI editor)
 #
@@ -38,7 +42,7 @@ step "Uninstalling cargo binary"
 cargo uninstall ghost-complete 2>/dev/null || warn "cargo had no ghost-complete to uninstall; continuing"
 
 step "Building and installing from $(pwd)"
-if ! cargo install --path crates/ghost-complete --locked; then
+if ! cargo install --path crates/ghost-complete --locked --force; then
     printf '\n\033[1;31m[fail]\033[0m cargo install failed; aborting before shell-integration step.\n' >&2
     exit 1
 fi

--- a/scripts/dev-reinstall.sh
+++ b/scripts/dev-reinstall.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# scripts/dev-reinstall.sh — local dev convenience: rebuild, swap binary, edit config.
+#
+# Steps:
+#   1. ghost-complete uninstall   (remove shell integration block from ~/.zshrc)
+#   2. cargo uninstall ghost-complete   (drop the cargo-managed binary)
+#   3. cargo install --path crates/ghost-complete --locked
+#   4. ghost-complete install   (re-write shell integration)
+#   5. ghost-complete config edit   (open the TUI editor)
+#
+# Steps 1-2 are best-effort — the script does not fail if there is nothing
+# to uninstall (fresh checkout, first run). The cargo install step IS
+# fatal: if the rebuild fails we don't want to leave the user with no
+# binary on PATH.
+
+set -u
+set -o pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+step() {
+    printf '\n\033[1;36m==>\033[0m \033[1m%s\033[0m\n' "$*"
+}
+
+warn() {
+    printf '\033[1;33m[warn]\033[0m %s\n' "$*" >&2
+}
+
+step "Removing shell integration"
+if command -v ghost-complete >/dev/null 2>&1; then
+    ghost-complete uninstall || warn "ghost-complete uninstall reported a non-zero exit; continuing"
+else
+    warn "ghost-complete not on PATH; skipping shell-integration uninstall"
+fi
+
+step "Uninstalling cargo binary"
+cargo uninstall ghost-complete 2>/dev/null || warn "cargo had no ghost-complete to uninstall; continuing"
+
+step "Building and installing from $(pwd)"
+if ! cargo install --path crates/ghost-complete --locked; then
+    printf '\n\033[1;31m[fail]\033[0m cargo install failed; aborting before shell-integration step.\n' >&2
+    exit 1
+fi
+
+step "Reinstalling shell integration"
+ghost-complete install
+
+step "Opening config editor"
+exec ghost-complete config edit


### PR DESCRIPTION
## Summary

Adds a 50ms-deferred re-query + resize of the inner PTY at proxy startup, working around a TIOCGWINSZ race that strands the inner shell with stale terminal dimensions until the first real `SIGWINCH` arrives.

I'm running ghost-complete on Linux (Ghostty/Wayland), so this PR is firmly in "patch from a fork user who hit a platform-specific edge case" territory — flagging that up front since `CONTRIBUTING.md` declares the proxy as macOS-focused. Posting as draft so you can decide whether it's worth merging, ignoring, or pointing me at a better fix.

## The bug

On a fresh terminal window, the **first** zsh prompt renders misaligned:

- zsh's `PROMPT_SP` indicator (`%`) appears at column 0 because zsh's internal cursor-column tracking disagrees with the actual terminal width.
- Right-aligned RPROMPT segments (in my case oh-my-posh's clock) land on a new line instead of at the right edge.
- **Resizing the window** (zoom in/out) instantly fixes everything for the remainder of the session.

Every subsequent prompt is fine.

## Root cause

`gc_pty::spawn::spawn_shell` calls `get_terminal_size()` (a `crossterm::terminal::size()` → TIOCGWINSZ ioctl) once and uses the result to open the inner PTY. On Linux/Wayland with Ghostty, the outer terminal's window-size handshake with the compositor isn't always complete at the moment that ioctl runs, so the ioctl returns stale/default dimensions. The inner PTY is created with those dimensions; the inner shell's `$COLUMNS` is wrong until the next `SIGWINCH`.

The existing SIGWINCH handler in `proxy.rs` already does the right thing (re-query, `resize_pty`, update parser dimensions) — the only problem is that no `SIGWINCH` arrives during normal first-prompt rendering. Zooming "fixes" the bug only because zoom is what finally triggers SIGWINCH.

## Why macOS likely doesn't see this

On macOS, AppKit's window-creation/spawn flow is synchronous enough that TIOCGWINSZ at child-process start almost always returns correct dimensions. On Linux + Wayland the spawn-then-size sequence is multiple async round-trips across the compositor, and "process alive" precedes "process knows its window size." This is the same class of bug that's bitten tmux, screen, and other PTY proxies historically.

## The fix

```rust
// In run_proxy(), shortly before signal registration:
let (initial_resize_tx, mut initial_resize_rx) = mpsc::channel::<()>(1);
tokio::spawn(async move {
    tokio::time::sleep(Duration::from_millis(50)).await;
    let _ = initial_resize_tx.send(()).await;
});

// New tokio::select! branch (peer of sigwinch.recv()):
_ = initial_resize_rx.recv() => {
    // Re-query and propagate fresh size to inner PTY + parser.
    // Same as SIGWINCH branch minus the popup-overlay cleanup
    // (no popup can be visible 50ms after startup).
}
```

Single file change in `crates/gc-pty/src/proxy.rs` (+51 lines).

## Trade-offs / open questions

- **50ms is a magic number.** It's the cheapest thing that demonstrably resolves the symptom on my hardware. A principled v2 would poll `terminal::size()` until two consecutive reads agree (capped at, say, 200ms), or wire a one-shot timer that's cancelled by the first real SIGWINCH if one arrives early. Happy to rework if you'd prefer a less timing-coupled approach.
- **No regression test.** This race is hard to simulate in a unit test — you'd need to mock TIOCGWINSZ returning stale values for ~30ms then catching up. A weaker test (assert a second `resize_pty` call happens within 100ms of spawn, regardless of value) would at least pin the *behavior*. Let me know if you'd like one and I'll add it.
- **If the initial size was already correct**, the deferred resize is a no-op (`resize_pty` with same dims doesn't emit anything to the inner shell). So this is a free defensive layer for macOS users too — but I haven't tested on macOS.
- **The popup-cleanup path is omitted** from the new branch because no popup can be visible at the 50ms mark. If you'd prefer symmetry with the SIGWINCH handler, happy to factor the common body into a helper.

## Verification

Manually verified on Ghostty 1.x / Linux x86_64 / Wayland: with this patch, fresh windows render the first prompt correctly without any zoom workaround. Built with `cargo install --path crates/ghost-complete --locked --force` and exercised across ~20 fresh windows.

`cargo fmt --check` passes on the changed file. `cargo clippy -p gc-pty --all-targets -- -D warnings` passes on the changed file (there's a preexisting clippy warning in `gc-overlay/src/render.rs:67` from clippy 1.93's stricter doc-list rules — unrelated to this PR, worth a separate cleanup).

## Test plan

- [ ] Open a fresh Ghostty window on Linux — first prompt aligned, no `%` indicator
- [ ] Repeat 5+ times to confirm not flaky
- [ ] Verify no regression on macOS (I cannot test — would appreciate a Mac-side sanity check)
- [ ] Verify popup behavior unchanged (the new branch doesn't touch the overlay path)