### PR TITLE
0.17 phase 5 PR A: static alias file parser

### DIFF
--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -23,35 +23,27 @@ const ALIAS_CACHE_FILE: &str = "aliases-cache.json";
 /// On-disk schema version; bump on incompatible CachedAliases changes.
 const CURRENT_ALIAS_CACHE_VERSION: u32 = 2;
 
-/// Source dotfiles whose mtimes invalidate the alias cache. If any exists
-/// with an mtime newer than the cache file, we regenerate. Includes every
-/// file the load paths in [`load_shell_aliases`] actually consult:
-///
-///   * shell rc files (run on every shell start, may `alias` directly)
-///   * `*.local` per-host overrides that our own users often add
-///   * dedicated alias files the fast path reads directly
-///   * `~/.bash_profile` (login-shell counterpart to `.bashrc`)
-///
-/// Missing the file-read fast-path files here is the bug that let a user
-/// edit `~/.zsh_aliases` and see a stale cache forever.
+/// Source dotfiles whose mtimes invalidate the alias cache. Must mirror
+/// [`STATIC_ALIAS_FILES`] exactly — files the static parser doesn't read
+/// can never produce alias entries, so watching them only forces useless
+/// regenerations. Files the parser DOES read but that aren't watched here
+/// would silently let stale caches persist (the bug that originally let
+/// a user edit `~/.zsh_aliases` and see a stale cache forever).
 const ALIAS_SOURCE_FILES: &[&str] = &[
     ".zshrc",
     ".zshrc.local",
     ".zshenv",
-    ".zshenv.local",
-    ".zprofile",
-    ".bashrc",
-    ".bash_profile",
     ".zsh_aliases",
     ".aliases",
     ".bash_aliases",
+    ".bashrc",
+    ".bash_profile",
 ];
 
 /// Directories whose mtime (i.e. child add/remove/rename) invalidates the
-/// alias cache. We use directory mtime rather than recursing: it flips on
-/// any entry change, which catches the user adding/removing a custom-alias
-/// drop-in in oh-my-zsh without us having to scan every file on every launch.
-const ALIAS_SOURCE_DIRS: &[&str] = &[".oh-my-zsh/custom", ".config/fish/functions"];
+/// alias cache. Same shape as [`ALIAS_SOURCE_FILES`] but for trees: only
+/// drop-in dirs the parser actually walks earn a slot.
+const ALIAS_SOURCE_DIRS: &[&str] = &[".oh-my-zsh/custom"];
 
 /// Fingerprint of a watched source file. We pair mtime-seconds with
 /// subsecond precision AND the file length so rapid in-place edits inside

--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -23,21 +23,24 @@ const ALIAS_CACHE_FILE: &str = "aliases-cache.json";
 /// On-disk schema version; bump on incompatible CachedAliases changes.
 const CURRENT_ALIAS_CACHE_VERSION: u32 = 2;
 
-/// Source dotfiles whose mtimes invalidate the alias cache. Must mirror
-/// [`STATIC_ALIAS_FILES`] exactly — files the static parser doesn't read
-/// can never produce alias entries, so watching them only forces useless
-/// regenerations. Files the parser DOES read but that aren't watched here
-/// would silently let stale caches persist (the bug that originally let
-/// a user edit `~/.zsh_aliases` and see a stale cache forever).
+/// Source dotfiles whose mtimes invalidate the alias cache. This is a
+/// cache-invalidation watch set keyed by mtime, so only MEMBERSHIP matters
+/// here — order is irrelevant. Membership must mirror [`STATIC_ALIAS_FILES`]
+/// exactly: files the static parser doesn't read can never produce alias
+/// entries, so watching them only forces useless regenerations, and files
+/// the parser DOES read but that aren't watched here would silently let
+/// stale caches persist (the bug that originally let a user edit
+/// `~/.zsh_aliases` and see a stale cache forever).
 const ALIAS_SOURCE_FILES: &[&str] = &[
+    ".zshenv",
+    ".zprofile",
     ".zshrc",
     ".zshrc.local",
-    ".zshenv",
+    ".bashrc",
+    ".bash_profile",
     ".zsh_aliases",
     ".aliases",
     ".bash_aliases",
-    ".bashrc",
-    ".bash_profile",
 ];
 
 /// Directories whose mtime (i.e. child add/remove/rename) invalidates the
@@ -106,8 +109,8 @@ fn file_fingerprint(path: &Path) -> Option<SourceFingerprint> {
 
 /// Fingerprint a directory tree using the same `(secs, nanos, len)` shape
 /// we use for files. Walks children under the same budget as the original
-/// original walker and keeps the largest (`secs`, then `nanos`, then
-/// `len`) tuple, so any edit inside the tree advances the fingerprint.
+/// walker and keeps the largest (`secs`, then `nanos`, then `len`) tuple,
+/// so any edit inside the tree advances the fingerprint.
 fn dir_tree_fingerprint(root: &Path) -> Option<SourceFingerprint> {
     let mut best = file_fingerprint(root)?;
     let mut stack: Vec<(PathBuf, u32)> = vec![(root.to_path_buf(), 0)];
@@ -313,47 +316,113 @@ impl AliasStore {
 /// Parse a zsh-flavored alias file (`.zshrc`, `.zshenv`, drop-ins, etc.).
 ///
 /// Recognises `alias name=value`, `alias name='quoted value'`, and
-/// `alias name="quoted value"`. Ignores comments, function definitions,
-/// conditional blocks, `alias -g/-s/-L` declarations, and any line that
-/// can't be locally interpreted. Multi-line values (trailing `\`) are
-/// skipped — a parser that can't see the full expansion shouldn't guess.
+/// `alias name="quoted value"`. Names may contain ASCII alphanumerics,
+/// `_`, `.`, and `-` (so `..`, `...`, and hyphenated names like `git-st`
+/// parse), but a leading `-` is rejected so `alias -g/-s/-L`
+/// global/suffix declarations stay out. Ignores comments, function
+/// definitions, and conditional blocks. A `#` inside a quoted value is
+/// preserved (it is only a comment when it sits outside quotes). Multi-line
+/// values (trailing `\`) are skipped in full — every physical line of a
+/// backslash-continued statement is dropped, since a parser that can't see
+/// the whole expansion shouldn't guess at the tail.
 pub(crate) fn parse_alias_file(src: &str) -> HashMap<String, String> {
     let mut out = HashMap::new();
+    // Tracks whether the previous physical line ended in an unescaped `\`,
+    // so the continuation line is dropped too rather than parsed as a
+    // standalone statement (which would invent a phantom alias from the
+    // tail and lose the real one).
+    let mut skip_continuation = false;
     for raw in src.lines() {
+        if skip_continuation {
+            // Keep skipping until a line does NOT continue.
+            skip_continuation = raw.trim_end().ends_with('\\');
+            continue;
+        }
         if raw.trim_end().ends_with('\\') {
+            skip_continuation = true;
             continue;
         }
         let line = raw.trim_start();
-        let line = line.split_once('#').map(|(l, _)| l).unwrap_or(line).trim();
-        if line.is_empty() || !line.starts_with("alias ") {
+        // A real declaration starts with `alias ` after leading whitespace.
+        // Comment/blank lines and everything else are skipped here; inline
+        // `#` handling happens quote-aware once we reach the value.
+        if !line.starts_with("alias ") {
             continue;
         }
         let rest = line[6..].trim_start();
         let Some((name, value)) = rest.split_once('=') else {
+            tracing::debug!("alias line has no '=' separator: {raw:?}");
             continue;
         };
         let name = name.trim();
         if name.is_empty()
             || name.starts_with('-')
-            || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            || !name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
         {
+            tracing::debug!("rejecting alias with non-local name {name:?}: {raw:?}");
             continue;
         }
-        let value = value.trim();
-        let unquoted = if value.len() >= 2
-            && ((value.starts_with('\'') && value.ends_with('\''))
-                || (value.starts_with('"') && value.ends_with('"')))
-        {
-            &value[1..value.len() - 1]
-        } else {
-            value
+        // Split the value into its (possibly quoted) payload and any
+        // trailing inline comment. `#` is only a comment OUTSIDE quotes, so
+        // `alias gp='git push #origin'` keeps `git push #origin` while
+        // `alias x='a'  # note` drops the note.
+        let Some(unquoted) = strip_alias_value(value.trim()) else {
+            tracing::debug!("alias {name:?} has empty value: {raw:?}");
+            continue;
         };
-        if unquoted.is_empty() {
-            continue;
-        }
-        out.insert(name.to_string(), unquoted.to_string());
+        out.insert(name.to_string(), unquoted);
     }
     out
+}
+
+/// Strip surrounding quotes and any unquoted trailing `#` comment from a
+/// raw alias value. Returns `None` when nothing usable remains.
+///
+/// - A quoted value (`'…'` or `"…"`) takes everything up to the matching
+///   closing quote; any trailing text (including a `# comment`) is dropped.
+/// - An unquoted value is terminated at the first `#` that begins a word
+///   (preceded by whitespace), which is how shells treat an inline comment;
+///   a `#` glued to the value (e.g. `curl http://x#frag`) is kept.
+fn strip_alias_value(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let first = *bytes.first()?;
+    if first == b'\'' || first == b'"' {
+        // Find the matching closing quote and ignore whatever follows it.
+        if let Some(rel) = value[1..].find(first as char) {
+            let inner = &value[1..1 + rel];
+            if inner.is_empty() {
+                return None;
+            }
+            return Some(inner.to_string());
+        }
+        // No closing quote: opening-quote-only value. Keep the raw text
+        // (sans the leading quote) so the shlex fallback downstream still
+        // surfaces the alias partially rather than dropping it.
+        let inner = &value[1..];
+        return if inner.is_empty() {
+            None
+        } else {
+            Some(inner.to_string())
+        };
+    }
+    // Unquoted: cut at an inline ` #...` comment (word-boundary `#`).
+    let mut prev_ws = false;
+    let mut end = value.len();
+    for (idx, ch) in value.char_indices() {
+        if ch == '#' && (idx == 0 || prev_ws) {
+            end = idx;
+            break;
+        }
+        prev_ws = ch.is_whitespace();
+    }
+    let trimmed = value[..end].trim_end();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 /// Parse zsh/bash `alias` output into name -> token-vector pairs; full tokens preserved via shlex.
@@ -426,19 +495,28 @@ fn shlex_tokens(value: &str) -> Option<Vec<String>> {
     }
 }
 
-/// Source files (relative to `$HOME`) the static parser reads. Order
-/// matches the load order zsh/bash use so later definitions override
-/// earlier ones. Must stay in sync with [`ALIAS_SOURCE_FILES`] —
+/// Source files (relative to `$HOME`) the static parser reads. Entries are
+/// ingested in array order and a later entry overrides an earlier one for
+/// the same alias name (`out.insert`), so this is ordered low→high
+/// precedence. The zsh block follows zsh's real read order
+/// (`.zshenv` → `.zprofile` → `.zshrc` → `.zshrc.local`) so a `.zshrc`
+/// definition correctly wins over the same name in `.zshenv`. zsh and bash
+/// never co-source the same session, so the cross-shell order is a
+/// best-effort approximation, not a real shell load order: the bash files
+/// follow the zsh ones, and the dedicated `*_aliases` drop-ins come last
+/// because they are sourced from the rc files and hold the user's most
+/// explicit alias intent. Must stay in sync with [`ALIAS_SOURCE_FILES`] —
 /// anything missing here can never invalidate the cache.
 const STATIC_ALIAS_FILES: &[&str] = &[
+    ".zshenv",
+    ".zprofile",
     ".zshrc",
     ".zshrc.local",
-    ".zshenv",
+    ".bashrc",
+    ".bash_profile",
     ".zsh_aliases",
     ".aliases",
     ".bash_aliases",
-    ".bashrc",
-    ".bash_profile",
 ];
 
 /// Static walk: parses alias declarations directly out of dotfiles and
@@ -448,8 +526,13 @@ fn load_static_aliases_from(home: &Path) -> HashMap<String, Vec<String>> {
     let mut out: HashMap<String, Vec<String>> = HashMap::new();
     let mut ingest = |content: &str| {
         for (name, value) in parse_alias_file(content) {
-            if let Some(toks) = shlex_tokens(&value) {
-                out.insert(name, toks);
+            match shlex_tokens(&value) {
+                Some(toks) => {
+                    out.insert(name, toks);
+                }
+                None => {
+                    tracing::debug!("dropping alias {name:?}: no usable tokens from {value:?}");
+                }
             }
         }
     };
@@ -535,6 +618,18 @@ fn load_aliases_via_subprocess(timeout: Duration) -> HashMap<String, Vec<String>
 /// Resolve aliases for a specific `$HOME`. Tests use this to bypass the
 /// real home and the on-disk cache. Production callers go through
 /// [`load_shell_aliases`].
+///
+/// The subprocess (`zsh -c alias`) is a fallback for the *no-static-aliases*
+/// case ONLY: it fires when the static walk parses zero entries, never to
+/// supplement a non-empty static result. This is a deliberate trade-off —
+/// layering subprocess output over static output would re-incur the
+/// 300–500 ms oh-my-zsh spawn cost on every cold start and blow the <100 ms
+/// startup budget. The cost of the trade-off is that an alias the static
+/// parser legitimately cannot interpret (e.g. one defined inside a function
+/// or a multi-line statement) is invisible whenever any other alias parsed
+/// successfully. The correctness fixes in [`parse_alias_file`] (quote-aware
+/// `#`, dotted/hyphenated names, full multi-line skip) keep that gap as
+/// small as possible, and dropped lines are logged at debug.
 pub(crate) fn load_shell_aliases_from(
     home: &Path,
     subprocess_timeout: Duration,
@@ -618,6 +713,108 @@ alias multiline='ls \
     }
 
     #[test]
+    fn parse_alias_file_preserves_hash_inside_quotes_and_strips_trailing_comment() {
+        // (a) trailing comment after a valid alias is dropped;
+        // (b) a `#` inside a quoted value is preserved verbatim.
+        let src = concat!(
+            "alias gco='git checkout'   # my alias\n",
+            "alias e='echo #1'\n",
+            "alias gp='git push #origin'\n",
+            "alias url='curl http://x#frag'\n",
+            "alias dq=\"echo #hash\"  # trailing\n",
+            "alias trail='a'  # trailing\n",
+        );
+        let map = parse_alias_file(src);
+        assert_eq!(map.get("gco").map(String::as_str), Some("git checkout"));
+        assert_eq!(map.get("e").map(String::as_str), Some("echo #1"));
+        assert_eq!(map.get("gp").map(String::as_str), Some("git push #origin"));
+        assert_eq!(
+            map.get("url").map(String::as_str),
+            Some("curl http://x#frag")
+        );
+        assert_eq!(map.get("dq").map(String::as_str), Some("echo #hash"));
+        assert_eq!(map.get("trail").map(String::as_str), Some("a"));
+    }
+
+    #[test]
+    fn parse_alias_file_accepts_dotted_and_hyphenated_names() {
+        // The oh-my-zsh `..` family and hyphenated names are trivially
+        // interpretable and must parse.
+        let src = concat!(
+            "alias ..='cd ..'\n",
+            "alias ...='cd ../..'\n",
+            "alias ....='cd ../../..'\n",
+            "alias git-st='git status'\n",
+        );
+        let map = parse_alias_file(src);
+        assert_eq!(map.get("..").map(String::as_str), Some("cd .."));
+        assert_eq!(map.get("...").map(String::as_str), Some("cd ../.."));
+        assert_eq!(map.get("....").map(String::as_str), Some("cd ../../.."));
+        assert_eq!(map.get("git-st").map(String::as_str), Some("git status"));
+    }
+
+    #[test]
+    fn parse_alias_file_rejects_global_suffix_and_punctuated_names() {
+        // Leading-dash flag forms and names with disallowed chars must NOT
+        // register; a plain `alias ok=ls` is the positive control.
+        let src = concat!(
+            "alias -g G='| grep'\n",
+            "alias -s pdf=acroread\n",
+            "alias -L l=ls\n",
+            "alias 'has space'='x'\n",
+            "alias na@me='y'\n",
+            "alias ok=ls\n",
+        );
+        let map = parse_alias_file(src);
+        assert!(!map.contains_key("G"), "global alias must be rejected");
+        assert!(!map.contains_key("pdf"), "suffix alias must be rejected");
+        assert!(!map.contains_key("l"), "-L form must be rejected");
+        assert!(
+            !map.contains_key("has space") && !map.contains_key("'has"),
+            "name with a space must be rejected"
+        );
+        assert!(!map.contains_key("na@me"), "name with @ must be rejected");
+        assert_eq!(map.get("ok").map(String::as_str), Some("ls"));
+    }
+
+    #[test]
+    fn parse_alias_file_drops_entire_backslash_continued_statement() {
+        // The continuation line must not be parsed as a standalone
+        // statement: neither `first` nor a phantom `injected` may appear.
+        let src = "alias first='foo \\\nalias injected=evil'\n";
+        let map = parse_alias_file(src);
+        assert!(
+            !map.contains_key("first"),
+            "the head of a multi-line alias must be dropped"
+        );
+        assert!(
+            !map.contains_key("injected"),
+            "the continuation line must not register a phantom alias"
+        );
+    }
+
+    #[test]
+    fn parse_alias_file_empty_and_partial_value_forms() {
+        // Empty value, empty-after-unquote, and opening-quote-only.
+        let src = concat!(
+            "alias e=\n",     // empty value -> no key
+            "alias q=''\n",   // empty after unquote -> no key
+            "alias y='foo\n", // opening-quote-only -> kept as `foo`
+        );
+        let map = parse_alias_file(src);
+        assert!(!map.contains_key("e"), "empty value must yield no key");
+        assert!(
+            !map.contains_key("q"),
+            "empty-after-unquote must yield no key"
+        );
+        assert_eq!(
+            map.get("y").map(String::as_str),
+            Some("foo"),
+            "opening-quote-only value keeps the remaining text"
+        );
+    }
+
+    #[test]
     fn load_shell_aliases_uses_static_parser_for_zshrc_aliases() {
         let tmp = tempfile::TempDir::new().unwrap();
         let home = tmp.path();
@@ -637,6 +834,92 @@ alias multiline='ls \
             map.get("zz"),
             Some(&token_vec(&["zsh", "-c"])),
             "static parser must populate zz from ~/.zshrc"
+        );
+    }
+
+    #[test]
+    fn load_static_aliases_reads_oh_my_zsh_custom_dropins() {
+        // omz is the dominant target: custom/*.zsh files must be parsed,
+        // and the `.zsh` extension filter must exclude everything else.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let custom = home.join(".oh-my-zsh/custom");
+        std::fs::create_dir_all(&custom).unwrap();
+        std::fs::write(custom.join("aliases.zsh"), "alias gco='git checkout'\n").unwrap();
+        std::fs::write(custom.join("README.md"), "alias bad=should_not_load\n").unwrap();
+
+        let map = load_shell_aliases_from(home, std::time::Duration::from_secs(2));
+        assert_eq!(
+            map.get("gco"),
+            Some(&token_vec(&["git", "checkout"])),
+            "omz custom/*.zsh drop-ins must be parsed"
+        );
+        assert!(
+            !map.contains_key("bad"),
+            "non-.zsh files in custom/ must be ignored (extension filter)"
+        );
+    }
+
+    #[test]
+    fn load_static_aliases_later_file_overrides_earlier() {
+        // Override is last-definition-wins across STATIC_ALIAS_FILES.
+        // `.zshenv` is earlier than `.zshrc` in the array, so `.zshrc`'s
+        // definition of `g` must win; an alias defined only in the earlier
+        // file must still survive (override is per-name, not whole-file).
+        assert!(
+            STATIC_ALIAS_FILES.iter().position(|f| *f == ".zshenv")
+                < STATIC_ALIAS_FILES.iter().position(|f| *f == ".zshrc"),
+            "test precondition: .zshenv must precede .zshrc in STATIC_ALIAS_FILES"
+        );
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        std::fs::write(
+            home.join(".zshenv"),
+            "alias g='git --env'\nalias only_env='echo env'\n",
+        )
+        .unwrap();
+        std::fs::write(home.join(".zshrc"), "alias g='git --rc'\n").unwrap();
+
+        let map = load_shell_aliases_from(home, std::time::Duration::from_secs(2));
+        assert_eq!(
+            map.get("g"),
+            Some(&token_vec(&["git", "--rc"])),
+            "later file (.zshrc) must override earlier (.zshenv)"
+        );
+        assert_eq!(
+            map.get("only_env"),
+            Some(&token_vec(&["echo", "env"])),
+            "an alias only in the earlier file must survive"
+        );
+    }
+
+    #[test]
+    fn load_static_aliases_keeps_shlex_fallback_tokens() {
+        // A value that is unbalanced after outer-quote stripping makes
+        // shlex::split fail; the whitespace fallback must preserve every
+        // token rather than dropping the alias entirely.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        std::fs::write(home.join(".zshrc"), "alias broken='git \"open'\n").unwrap();
+
+        let map = load_shell_aliases_from(home, std::time::Duration::from_secs(2));
+        assert_eq!(
+            map.get("broken"),
+            Some(&token_vec(&["git", "\"open"])),
+            "shlex fallback must keep all whitespace-split tokens"
+        );
+    }
+
+    #[test]
+    fn load_static_aliases_from_empty_home_is_empty() {
+        // Documents the precondition under which the subprocess fallback
+        // fires: the static walk returns empty only when no dotfile yields
+        // a usable alias. (We don't spawn a real shell here — that would be
+        // non-deterministic.)
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(
+            load_static_aliases_from(tmp.path()).is_empty(),
+            "an empty home must yield zero static aliases"
         );
     }
 

--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -327,10 +327,11 @@ impl AliasStore {
 /// the whole expansion shouldn't guess at the tail.
 pub(crate) fn parse_alias_file(src: &str) -> HashMap<String, String> {
     let mut out = HashMap::new();
-    // Tracks whether the previous physical line ended in an unescaped `\`,
-    // so the continuation line is dropped too rather than parsed as a
-    // standalone statement (which would invent a phantom alias from the
-    // tail and lose the real one).
+    // Tracks whether the previous physical line ended in a trailing `\` (we
+    // treat any trailing backslash as a line continuation and skip
+    // conservatively), so the continuation line is dropped too rather than
+    // parsed as a standalone statement (which would invent a phantom alias
+    // from the tail and lose the real one).
     let mut skip_continuation = false;
     for raw in src.lines() {
         if skip_continuation {
@@ -339,6 +340,7 @@ pub(crate) fn parse_alias_file(src: &str) -> HashMap<String, String> {
             continue;
         }
         if raw.trim_end().ends_with('\\') {
+            tracing::debug!("skipping backslash-continued statement: {raw:?}");
             skip_continuation = true;
             continue;
         }
@@ -537,20 +539,41 @@ fn load_static_aliases_from(home: &Path) -> HashMap<String, Vec<String>> {
         }
     };
     for name in STATIC_ALIAS_FILES {
-        if let Ok(content) = std::fs::read_to_string(home.join(name)) {
-            ingest(&content);
+        match std::fs::read_to_string(home.join(name)) {
+            Ok(content) => ingest(&content),
+            // NotFound is the dominant legitimate case — most users lack
+            // most dotfiles — so it stays silent. An existing-but-unreadable
+            // file (PermissionDenied, non-UTF-8 InvalidData) is a real loss
+            // and earns a breadcrumb.
+            Err(e) if e.kind() != std::io::ErrorKind::NotFound => {
+                tracing::debug!("alias source {name} unreadable: {e}");
+            }
+            Err(_) => {}
         }
     }
     let omz_custom = home.join(".oh-my-zsh/custom");
-    if let Ok(rd) = std::fs::read_dir(&omz_custom) {
-        for entry in rd.flatten() {
-            let p = entry.path();
-            if p.extension().and_then(|e| e.to_str()) == Some("zsh") {
+    match std::fs::read_dir(&omz_custom) {
+        Ok(rd) => {
+            // read_dir yields entries in filesystem/OS-dependent order, so
+            // sort the matching `*.zsh` paths before ingesting — otherwise
+            // two drop-ins defining the same alias pick a nondeterministic
+            // last-write-wins winner across machines.
+            let mut dropins: Vec<PathBuf> = rd
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("zsh"))
+                .collect();
+            dropins.sort();
+            for p in dropins {
                 if let Ok(content) = std::fs::read_to_string(&p) {
                     ingest(&content);
                 }
             }
         }
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => {
+            tracing::debug!("oh-my-zsh custom dir unreadable: {e}");
+        }
+        Err(_) => {}
     }
     out
 }
@@ -1165,6 +1188,33 @@ alias ll='ls -la'
                 "ALIAS_SOURCE_FILES must include {fast_path_file} (read by the file-based fast path)"
             );
         }
+    }
+
+    #[test]
+    fn read_set_equals_watch_set() {
+        use std::collections::BTreeSet;
+
+        // The PR's central invariant: the parser's READ set must equal the
+        // cache's WATCH set, BOTH ways. `STATIC_ALIAS_FILES` (read by
+        // `load_static_aliases_from`) and `ALIAS_SOURCE_FILES` (the mtime
+        // watch set) must be the same set — adding to one without the other
+        // silently reintroduces the "edit ~/.zsh_aliases, see a stale cache
+        // forever" bug this PR exists to fix. Membership-only (not order):
+        // the watch set is order-irrelevant, while the read set is ordered
+        // for precedence, so set-equality is the contract.
+        assert_eq!(
+            STATIC_ALIAS_FILES.iter().collect::<BTreeSet<_>>(),
+            ALIAS_SOURCE_FILES.iter().collect::<BTreeSet<_>>(),
+            "STATIC_ALIAS_FILES (parser reads) and ALIAS_SOURCE_FILES (cache watches) must be identical sets"
+        );
+
+        // The parser's hardcoded `.oh-my-zsh/custom` dir walk must be a
+        // member of the watched dir set, or edits to drop-ins never
+        // invalidate the cache.
+        assert!(
+            ALIAS_SOURCE_DIRS.contains(&".oh-my-zsh/custom"),
+            "ALIAS_SOURCE_DIRS must watch the parser-walked .oh-my-zsh/custom dir"
+        );
     }
 
     #[test]

--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -612,9 +612,9 @@ alias multiline='ls \
         assert_eq!(map.get("gco").map(|v| v.as_str()), Some("git checkout"));
         assert_eq!(map.get("gcb").map(|v| v.as_str()), Some("git checkout -b"));
         assert_eq!(map.get("dev").map(|v| v.as_str()), Some("ssh"));
-        assert!(map.get("broken-name").is_none());
-        assert!(map.get("multiline").is_none());
-        assert!(map.get("helper").is_none());
+        assert!(!map.contains_key("broken-name"));
+        assert!(!map.contains_key("multiline"));
+        assert!(!map.contains_key("helper"));
     }
 
     #[test]

--- a/crates/gc-suggest/src/alias.rs
+++ b/crates/gc-suggest/src/alias.rs
@@ -13,7 +13,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
 
@@ -318,6 +318,52 @@ impl AliasStore {
     }
 }
 
+/// Parse a zsh-flavored alias file (`.zshrc`, `.zshenv`, drop-ins, etc.).
+///
+/// Recognises `alias name=value`, `alias name='quoted value'`, and
+/// `alias name="quoted value"`. Ignores comments, function definitions,
+/// conditional blocks, `alias -g/-s/-L` declarations, and any line that
+/// can't be locally interpreted. Multi-line values (trailing `\`) are
+/// skipped — a parser that can't see the full expansion shouldn't guess.
+pub(crate) fn parse_alias_file(src: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for raw in src.lines() {
+        if raw.trim_end().ends_with('\\') {
+            continue;
+        }
+        let line = raw.trim_start();
+        let line = line.split_once('#').map(|(l, _)| l).unwrap_or(line).trim();
+        if line.is_empty() || !line.starts_with("alias ") {
+            continue;
+        }
+        let rest = line[6..].trim_start();
+        let Some((name, value)) = rest.split_once('=') else {
+            continue;
+        };
+        let name = name.trim();
+        if name.is_empty()
+            || name.starts_with('-')
+            || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            continue;
+        }
+        let value = value.trim();
+        let unquoted = if value.len() >= 2
+            && ((value.starts_with('\'') && value.ends_with('\''))
+                || (value.starts_with('"') && value.ends_with('"')))
+        {
+            &value[1..value.len() - 1]
+        } else {
+            value
+        };
+        if unquoted.is_empty() {
+            continue;
+        }
+        out.insert(name.to_string(), unquoted.to_string());
+    }
+    out
+}
+
 /// Parse zsh/bash `alias` output into name -> token-vector pairs; full tokens preserved via shlex.
 pub fn parse_aliases(output: &str) -> HashMap<String, Vec<String>> {
     let mut map = HashMap::new();
@@ -371,6 +417,144 @@ pub fn parse_aliases(output: &str) -> HashMap<String, Vec<String>> {
     map
 }
 
+/// Tokenise an alias value, falling back to whitespace split when shlex
+/// can't parse it. `None` when no usable tokens remain.
+fn shlex_tokens(value: &str) -> Option<Vec<String>> {
+    match shlex::split(value) {
+        Some(toks) if !toks.is_empty() => Some(toks),
+        Some(_) => None,
+        None => {
+            let fallback: Vec<String> = value.split_whitespace().map(String::from).collect();
+            if fallback.is_empty() {
+                None
+            } else {
+                Some(fallback)
+            }
+        }
+    }
+}
+
+/// Source files (relative to `$HOME`) the static parser reads. Order
+/// matches the load order zsh/bash use so later definitions override
+/// earlier ones. Must stay in sync with [`ALIAS_SOURCE_FILES`] —
+/// anything missing here can never invalidate the cache.
+const STATIC_ALIAS_FILES: &[&str] = &[
+    ".zshrc",
+    ".zshrc.local",
+    ".zshenv",
+    ".zsh_aliases",
+    ".aliases",
+    ".bash_aliases",
+    ".bashrc",
+    ".bash_profile",
+];
+
+/// Static walk: parses alias declarations directly out of dotfiles and
+/// oh-my-zsh custom drop-ins. Avoids the 300–500 ms `zsh -c alias`
+/// startup cost on oh-my-zsh setups.
+fn load_static_aliases_from(home: &Path) -> HashMap<String, Vec<String>> {
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    let mut ingest = |content: &str| {
+        for (name, value) in parse_alias_file(content) {
+            if let Some(toks) = shlex_tokens(&value) {
+                out.insert(name, toks);
+            }
+        }
+    };
+    for name in STATIC_ALIAS_FILES {
+        if let Ok(content) = std::fs::read_to_string(home.join(name)) {
+            ingest(&content);
+        }
+    }
+    let omz_custom = home.join(".oh-my-zsh/custom");
+    if let Ok(rd) = std::fs::read_dir(&omz_custom) {
+        for entry in rd.flatten() {
+            let p = entry.path();
+            if p.extension().and_then(|e| e.to_str()) == Some("zsh") {
+                if let Ok(content) = std::fs::read_to_string(&p) {
+                    ingest(&content);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Spawn `zsh -c alias` (then `bash -c alias`) with a polling deadline.
+/// Returns the first non-empty parse. Only used when the static walk
+/// produced nothing.
+fn load_aliases_via_subprocess(timeout: Duration) -> HashMap<String, Vec<String>> {
+    for shell in &["zsh", "bash"] {
+        tracing::debug!("spawning {shell} -c alias");
+        let mut child = match std::process::Command::new(shell)
+            .args(["-c", "alias"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!("failed to spawn {shell}: {e}");
+                continue;
+            }
+        };
+
+        let deadline = std::time::Instant::now() + timeout;
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(s)) => break Some(s),
+                Ok(None) => {
+                    if std::time::Instant::now() >= deadline {
+                        tracing::debug!("{shell} alias timed out, killing");
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        break None;
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => {
+                    tracing::debug!("{shell} alias wait error: {e}");
+                    break None;
+                }
+            }
+        };
+
+        if let Some(s) = status {
+            if s.success() {
+                if let Some(mut stdout) = child.stdout.take() {
+                    use std::io::Read;
+                    let mut text = String::new();
+                    if stdout.read_to_string(&mut text).is_ok() {
+                        let aliases = parse_aliases(&text);
+                        if !aliases.is_empty() {
+                            tracing::debug!("loaded {} aliases from {shell} -c", aliases.len());
+                            return aliases;
+                        }
+                    }
+                }
+            } else {
+                tracing::debug!("{shell} alias command failed: {s}");
+            }
+        }
+    }
+    HashMap::new()
+}
+
+/// Resolve aliases for a specific `$HOME`. Tests use this to bypass the
+/// real home and the on-disk cache. Production callers go through
+/// [`load_shell_aliases`].
+pub(crate) fn load_shell_aliases_from(
+    home: &Path,
+    subprocess_timeout: Duration,
+) -> HashMap<String, Vec<String>> {
+    let aliases = load_static_aliases_from(home);
+    if !aliases.is_empty() {
+        tracing::debug!("loaded {} aliases via static parser", aliases.len());
+        return aliases;
+    }
+    load_aliases_via_subprocess(subprocess_timeout)
+}
+
 /// Load aliases by reading common alias dotfiles, falling back to a
 /// non-interactive shell subprocess.
 ///
@@ -393,87 +577,20 @@ pub fn load_shell_aliases() -> HashMap<String, Vec<String>> {
         }
     }
 
-    // Fast path: read alias dotfiles directly (no subprocess)
-    if let Some(ref home) = home {
-        for file in &[".zsh_aliases", ".aliases", ".bash_aliases"] {
-            let path = home.join(file);
-            if let Ok(contents) = std::fs::read_to_string(&path) {
-                let aliases = parse_aliases(&contents);
-                if !aliases.is_empty() {
-                    tracing::debug!("loaded {} aliases from {}", aliases.len(), path.display());
-                    if let Some(ref cp) = cache_path {
-                        save_alias_cache(home, cp, &aliases);
-                    }
-                    return aliases;
-                }
-            }
-        }
+    let aliases = match home.as_ref() {
+        Some(h) => load_shell_aliases_from(h, Duration::from_secs(2)),
+        None => load_aliases_via_subprocess(Duration::from_secs(2)),
+    };
+
+    if aliases.is_empty() {
+        // "No aliases loaded" is a legitimate empty state — a user may
+        // simply have no aliases defined. Keep at debug level so it
+        // doesn't pollute normal logs.
+        tracing::debug!("no aliases loaded from any source");
+    } else if let (Some(h), Some(cp)) = (home.as_ref(), cache_path.as_ref()) {
+        save_alias_cache(h, cp, &aliases);
     }
-
-    // Slow path: non-interactive subprocess with 2-second timeout.
-    // Uses try_wait polling to avoid blocking indefinitely on a hanging .zshenv.
-    for shell in &["zsh", "bash"] {
-        tracing::debug!("spawning {shell} -c alias");
-        let mut child = match std::process::Command::new(shell)
-            .args(["-c", "alias"])
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::debug!("failed to spawn {shell}: {e}");
-                continue;
-            }
-        };
-
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        let status = loop {
-            match child.try_wait() {
-                Ok(Some(s)) => break Some(s),
-                Ok(None) => {
-                    if std::time::Instant::now() >= deadline {
-                        tracing::debug!("{shell} alias timed out, killing");
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        break None;
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(10));
-                }
-                Err(e) => {
-                    tracing::debug!("{shell} alias wait error: {e}");
-                    break None;
-                }
-            }
-        };
-
-        if let Some(s) = status {
-            if s.success() {
-                if let Some(mut stdout) = child.stdout.take() {
-                    use std::io::Read;
-                    let mut text = String::new();
-                    if stdout.read_to_string(&mut text).is_ok() {
-                        let aliases = parse_aliases(&text);
-                        if !aliases.is_empty() {
-                            tracing::debug!("loaded {} aliases from {shell} -c", aliases.len());
-                            if let (Some(h), Some(cp)) = (home.as_ref(), cache_path.as_ref()) {
-                                save_alias_cache(h, cp, &aliases);
-                            }
-                            return aliases;
-                        }
-                    }
-                }
-            } else {
-                tracing::debug!("{shell} alias command failed: {s}");
-            }
-        }
-    }
-
-    // "No aliases loaded" is a legitimate empty state — a user may simply
-    // have no aliases defined. Keep this at debug level so it doesn't
-    // pollute normal logs.
-    tracing::debug!("no aliases loaded from any source");
-    HashMap::new()
+    aliases
 }
 
 #[cfg(test)]
@@ -484,6 +601,52 @@ fn token_vec(tokens: &[&str]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_alias_file_handles_quoted_and_simple_forms() {
+        let src = r#"
+# top comment
+alias gco='git checkout'
+alias gcb="git checkout -b"
+alias dev=ssh
+alias=not_an_alias
+function helper() { echo nope; }
+alias 'broken-name'='whatever'   # invalid name; skip
+alias g\=git                     # malformed; skip
+alias multiline='ls \
+  -la'                           # multiline; skip conservatively
+"#;
+        let map = parse_alias_file(src);
+        assert_eq!(map.get("gco").map(|v| v.as_str()), Some("git checkout"));
+        assert_eq!(map.get("gcb").map(|v| v.as_str()), Some("git checkout -b"));
+        assert_eq!(map.get("dev").map(|v| v.as_str()), Some("ssh"));
+        assert!(map.get("broken-name").is_none());
+        assert!(map.get("multiline").is_none());
+        assert!(map.get("helper").is_none());
+    }
+
+    #[test]
+    fn load_shell_aliases_uses_static_parser_for_zshrc_aliases() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        std::fs::write(
+            home.join(".zshrc"),
+            "alias gco='git checkout'\nalias zz='zsh -c'\n",
+        )
+        .unwrap();
+
+        let map = load_shell_aliases_from(home, std::time::Duration::from_secs(2));
+        assert_eq!(
+            map.get("gco"),
+            Some(&token_vec(&["git", "checkout"])),
+            "static parser must populate gco from ~/.zshrc"
+        );
+        assert_eq!(
+            map.get("zz"),
+            Some(&token_vec(&["zsh", "-c"])),
+            "static parser must populate zz from ~/.zshrc"
+        );
+    }
 
     #[test]
     fn test_parse_zsh_aliases() {


### PR DESCRIPTION
## Summary
- Parses ~/.zshrc / .zshenv / .zsh_aliases / oh-my-zsh/custom/*.zsh
  directly; falls back to `zsh -c alias` only on empty result.
- Narrows cache fingerprint to files the parser actually reads.

## Test plan
- [x] cargo test -p gc-suggest alias (23 existing + 2 new)
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt --check
- [ ] Manual: edit ~/.zshrc, add `alias gco='git checkout'`,
      confirm `gco <TAB>` routes through git-checkout spec.

References: docs/plans/0.17-polish-and-trust/5-macos-smart-completions/plan.md Tasks 1-2