### PR TITLE
0.17 Phase 5 PR B — feat(brew): query-aware search + cask split

### DIFF
--- a/crates/gc-suggest/src/providers/brew.rs
+++ b/crates/gc-suggest/src/providers/brew.rs
@@ -30,6 +30,19 @@ fn brew_search_cap() -> usize {
     BREW_SEARCH_CAP.load(Ordering::Relaxed)
 }
 
+/// Decide the `brew search` argv and the parser cap for `query`. Typed
+/// queries forward the user's token straight to `brew search <q>` and
+/// drop the cap — `brew search` already filters to substring matches,
+/// so the cap is only meaningful for the empty-query exploration path
+/// that returns the full formula list.
+pub(crate) fn brew_search_plan(query: &str, empty_cap: usize) -> ([&str; 2], usize) {
+    if query.is_empty() {
+        (["search", ""], empty_cap)
+    } else {
+        (["search", query], usize::MAX)
+    }
+}
+
 pub(crate) async fn run_brew_with_binary(
     cwd: &Path,
     binary: &str,
@@ -101,6 +114,51 @@ pub(crate) fn parse_formulae_searchable_output(text: &str, cap: usize) -> Vec<Su
     }
 
     suggestions
+}
+
+/// Parse `brew search --cask <query>` output, projecting cask names from
+/// the cask section only. Handles both the modern `==> Casks` header
+/// (Homebrew 4.x) and the legacy `Casks:` header (Homebrew 2.x).
+pub(crate) fn parse_casks_searchable_output(text: &str) -> Vec<Suggestion> {
+    let mut in_casks = false;
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with("==>") {
+            in_casks = line == "==> Casks";
+            continue;
+        }
+        if line.ends_with(':') {
+            in_casks = line.eq_ignore_ascii_case("Casks:");
+            continue;
+        }
+        if in_casks {
+            for cask in line.split_whitespace() {
+                out.push(provider_suggestion(cask, "brew cask"));
+            }
+        }
+    }
+    out
+}
+
+/// Parse `brew search <query>` output, projecting every token under both
+/// the formulae and casks sections. Used when the install/search position
+/// is ambiguous and either formula or cask names are acceptable.
+pub(crate) fn parse_packages_searchable_output(text: &str) -> Vec<Suggestion> {
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with("==>") || line.ends_with(':') {
+            continue;
+        }
+        for token in line.split_whitespace() {
+            out.push(provider_suggestion(token, "brew formula or cask"));
+        }
+    }
+    out
 }
 
 fn parse_one_per_line(text: &str, description: &'static str) -> Vec<Suggestion> {
@@ -199,9 +257,73 @@ impl BrewFormulaeSearchable {
         if !brew_is_supported(binary).await {
             return Ok(Vec::new());
         }
-        let Some(output) = run_brew_with_binary(&ctx.cwd, binary, &["search", ""]).await else {
+        let (args, cap) = brew_search_plan(ctx.current_token.as_str(), brew_search_cap());
+        let Some(output) = run_brew_with_binary(&ctx.cwd, binary, &args).await else {
             return Ok(Vec::new());
         };
-        Ok(parse_formulae_searchable_output(&output, brew_search_cap()))
+        Ok(parse_formulae_searchable_output(&output, cap))
+    }
+}
+
+pub struct BrewCasksSearchable;
+
+impl Provider for BrewCasksSearchable {
+    fn name(&self) -> &'static str {
+        "brew_casks_searchable"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        self.generate_with_binary(ctx, "brew").await
+    }
+}
+
+impl BrewCasksSearchable {
+    pub(crate) async fn generate_with_binary(
+        &self,
+        ctx: &ProviderCtx,
+        binary: &str,
+    ) -> Result<Vec<Suggestion>> {
+        if !brew_is_supported(binary).await {
+            return Ok(Vec::new());
+        }
+        let token = ctx.current_token.as_str();
+        let args: [&str; 3] = if token.is_empty() {
+            ["search", "--cask", ""]
+        } else {
+            ["search", "--cask", token]
+        };
+        let Some(output) = run_brew_with_binary(&ctx.cwd, binary, &args).await else {
+            return Ok(Vec::new());
+        };
+        Ok(parse_casks_searchable_output(&output))
+    }
+}
+
+pub struct BrewPackagesSearchable;
+
+impl Provider for BrewPackagesSearchable {
+    fn name(&self) -> &'static str {
+        "brew_packages_searchable"
+    }
+
+    async fn generate(&self, ctx: &ProviderCtx) -> Result<Vec<Suggestion>> {
+        self.generate_with_binary(ctx, "brew").await
+    }
+}
+
+impl BrewPackagesSearchable {
+    pub(crate) async fn generate_with_binary(
+        &self,
+        ctx: &ProviderCtx,
+        binary: &str,
+    ) -> Result<Vec<Suggestion>> {
+        if !brew_is_supported(binary).await {
+            return Ok(Vec::new());
+        }
+        let (args, _cap) = brew_search_plan(ctx.current_token.as_str(), brew_search_cap());
+        let Some(output) = run_brew_with_binary(&ctx.cwd, binary, &args).await else {
+            return Ok(Vec::new());
+        };
+        Ok(parse_packages_searchable_output(&output))
     }
 }

--- a/crates/gc-suggest/src/providers/brew.rs
+++ b/crates/gc-suggest/src/providers/brew.rs
@@ -34,8 +34,9 @@ fn brew_search_cap() -> usize {
 /// Decide the `brew search` argv and the parser cap for `query`. Typed
 /// queries forward the user's token straight to `brew search <q>` and
 /// drop the cap — `brew search` already filters to substring matches,
-/// so the cap is only meaningful for the empty-query exploration path
-/// that returns the full package list (every formula and cask).
+/// so the cap is only meaningful for the empty-query exploration path,
+/// which returns the full result set for the given `flag_prefix` (every
+/// formula and cask for `&[]`, every cask for `&["--cask"]`).
 ///
 /// `flag_prefix` is spliced in between `search` and the query token so a
 /// single planner serves the plain (`&[]`), cask-only (`&["--cask"]`),
@@ -73,7 +74,9 @@ pub(crate) fn brew_search_plan<'a>(
 /// and stay at `warn`.
 fn is_brew_no_match(error: &anyhow::Error) -> bool {
     let message = error.to_string();
-    message.contains("No formula") || message.contains("No formulae") || message.contains("No cask")
+    // "No formula" subsumes "No formulae" (the latter contains the former
+    // as a substring), so the two cover both phrasings with one check.
+    message.contains("No formula") || message.contains("No cask")
 }
 
 pub(crate) async fn run_brew_with_binary(

--- a/crates/gc-suggest/src/providers/brew.rs
+++ b/crates/gc-suggest/src/providers/brew.rs
@@ -1,5 +1,6 @@
 // Homebrew native providers for installed formulae, installed casks,
-// and searchable formulae.
+// searchable formulae, searchable casks, and searchable packages
+// (the formulae + casks union).
 
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -34,13 +35,45 @@ fn brew_search_cap() -> usize {
 /// queries forward the user's token straight to `brew search <q>` and
 /// drop the cap — `brew search` already filters to substring matches,
 /// so the cap is only meaningful for the empty-query exploration path
-/// that returns the full formula list.
-pub(crate) fn brew_search_plan(query: &str, empty_cap: usize) -> ([&str; 2], usize) {
+/// that returns the full package list (every formula and cask).
+///
+/// `flag_prefix` is spliced in between `search` and the query token so a
+/// single planner serves the plain (`&[]`), cask-only (`&["--cask"]`),
+/// and any future filtered search path with one argv-construction and
+/// one cap rule — no per-provider divergence. The empty-query branch
+/// still passes a single empty-string argument so `brew search ""` keeps
+/// exploring the full list rather than treating the prefix flag as the
+/// final positional.
+pub(crate) fn brew_search_plan<'a>(
+    query: &'a str,
+    flag_prefix: &[&'a str],
+    empty_cap: usize,
+) -> (Vec<&'a str>, usize) {
+    let mut args = Vec::with_capacity(2 + flag_prefix.len());
+    args.push("search");
+    args.extend_from_slice(flag_prefix);
     if query.is_empty() {
-        (["search", ""], empty_cap)
+        args.push("");
+        (args, empty_cap)
     } else {
-        (["search", query], usize::MAX)
+        args.push(query);
+        (args, usize::MAX)
     }
+}
+
+/// Detect Homebrew's "nothing matched this query" failure. Modern `brew
+/// search <token>` exits non-zero and writes
+/// `Error: No formulae or casks found for "<token>".` to stderr when the
+/// partial token matches nothing — an expected outcome on the
+/// keystroke-to-suggestion hot path, not a command failure. The
+/// non-zero exit is surfaced by [`spawn_with_timeout`] as an
+/// `anyhow::Error` whose message embeds the trimmed stderr, so we match
+/// on the rendered error string. Kept deliberately narrow: genuine
+/// failures (timeout, other nonzero exits) do not carry these phrases
+/// and stay at `warn`.
+fn is_brew_no_match(error: &anyhow::Error) -> bool {
+    let message = error.to_string();
+    message.contains("No formula") || message.contains("No formulae") || message.contains("No cask")
 }
 
 pub(crate) async fn run_brew_with_binary(
@@ -60,6 +93,10 @@ pub(crate) async fn run_brew_with_binary(
         Ok(stdout) => Some(stdout),
         Err(error) if is_binary_missing(&error) => {
             tracing::trace!(binary, "brew binary not installed");
+            None
+        }
+        Err(error) if is_brew_no_match(&error) => {
+            tracing::trace!(binary, error = %error, "brew search found no matches");
             None
         }
         Err(error) => {
@@ -116,11 +153,22 @@ pub(crate) fn parse_formulae_searchable_output(text: &str, cap: usize) -> Vec<Su
     suggestions
 }
 
-/// Parse `brew search --cask <query>` output, projecting cask names from
-/// the cask section only. Handles both the modern `==> Casks` header
-/// (Homebrew 4.x) and the legacy `Casks:` header (Homebrew 2.x).
-pub(crate) fn parse_casks_searchable_output(text: &str) -> Vec<Suggestion> {
-    let mut in_casks = false;
+/// Parse `brew search --cask <query>` output, projecting cask names.
+///
+/// `brew search --cask <q>` on modern Homebrew (5.x) prints a BARE,
+/// header-less token list — it emits no `==> Casks` / `==> Formulae`
+/// section headers at all because the `--cask` filter already scopes the
+/// result to casks. So this defaults `in_casks` ON (mirroring
+/// [`parse_formulae_searchable_output`], which defaults its section flag
+/// on): a header-less run treats every line as a cask. A header is only
+/// honoured to SUPPRESS — once a non-cask section (`==> Formulae` /
+/// legacy `Formulae:`) appears, subsequent lines are dropped until a
+/// `==> Casks` / `Casks:` header re-enables emission. This keeps a
+/// TTY/legacy `brew search` run that does print headers working while
+/// fixing the header-less `--cask` path that previously returned empty.
+/// Capped for popup latency on the empty-query exploration path.
+pub(crate) fn parse_casks_searchable_output(text: &str, cap: usize) -> Vec<Suggestion> {
+    let mut in_casks = true;
     let mut out = Vec::new();
     for line in text.lines() {
         let line = line.trim();
@@ -137,6 +185,9 @@ pub(crate) fn parse_casks_searchable_output(text: &str) -> Vec<Suggestion> {
         }
         if in_casks {
             for cask in line.split_whitespace() {
+                if out.len() >= cap {
+                    return out;
+                }
                 out.push(provider_suggestion(cask, "brew cask"));
             }
         }
@@ -146,8 +197,11 @@ pub(crate) fn parse_casks_searchable_output(text: &str) -> Vec<Suggestion> {
 
 /// Parse `brew search <query>` output, projecting every token under both
 /// the formulae and casks sections. Used when the install/search position
-/// is ambiguous and either formula or cask names are acceptable.
-pub(crate) fn parse_packages_searchable_output(text: &str) -> Vec<Suggestion> {
+/// is ambiguous and either formula or cask names are acceptable. Capped
+/// for popup latency: the empty-query exploration path (`brew search ""`)
+/// returns ~16k lines (formulae + casks) on modern Homebrew, so the cap
+/// must be honoured here exactly as it is for the formulae-only path.
+pub(crate) fn parse_packages_searchable_output(text: &str, cap: usize) -> Vec<Suggestion> {
     let mut out = Vec::new();
     for line in text.lines() {
         let line = line.trim();
@@ -155,6 +209,9 @@ pub(crate) fn parse_packages_searchable_output(text: &str) -> Vec<Suggestion> {
             continue;
         }
         for token in line.split_whitespace() {
+            if out.len() >= cap {
+                return out;
+            }
             out.push(provider_suggestion(token, "brew formula or cask"));
         }
     }
@@ -257,7 +314,7 @@ impl BrewFormulaeSearchable {
         if !brew_is_supported(binary).await {
             return Ok(Vec::new());
         }
-        let (args, cap) = brew_search_plan(ctx.current_token.as_str(), brew_search_cap());
+        let (args, cap) = brew_search_plan(ctx.current_token.as_str(), &[], brew_search_cap());
         let Some(output) = run_brew_with_binary(&ctx.cwd, binary, &args).await else {
             return Ok(Vec::new());
         };
@@ -286,16 +343,12 @@ impl BrewCasksSearchable {
         if !brew_is_supported(binary).await {
             return Ok(Vec::new());
         }
-        let token = ctx.current_token.as_str();
-        let args: [&str; 3] = if token.is_empty() {
-            ["search", "--cask", ""]
-        } else {
-            ["search", "--cask", token]
-        };
+        let (args, cap) =
+            brew_search_plan(ctx.current_token.as_str(), &["--cask"], brew_search_cap());
         let Some(output) = run_brew_with_binary(&ctx.cwd, binary, &args).await else {
             return Ok(Vec::new());
         };
-        Ok(parse_casks_searchable_output(&output))
+        Ok(parse_casks_searchable_output(&output, cap))
     }
 }
 
@@ -320,10 +373,10 @@ impl BrewPackagesSearchable {
         if !brew_is_supported(binary).await {
             return Ok(Vec::new());
         }
-        let (args, _cap) = brew_search_plan(ctx.current_token.as_str(), brew_search_cap());
+        let (args, cap) = brew_search_plan(ctx.current_token.as_str(), &[], brew_search_cap());
         let Some(output) = run_brew_with_binary(&ctx.cwd, binary, &args).await else {
             return Ok(Vec::new());
         };
-        Ok(parse_packages_searchable_output(&output))
+        Ok(parse_packages_searchable_output(&output, cap))
     }
 }

--- a/crates/gc-suggest/src/providers/mod.rs
+++ b/crates/gc-suggest/src/providers/mod.rs
@@ -352,6 +352,12 @@ pub enum ProviderKind {
     BrewCasksInstalled,
     /// searchable Homebrew formulae, capped for popup latency.
     BrewFormulaeSearchable,
+    /// searchable Homebrew casks via `brew search --cask <query>`.
+    BrewCasksSearchable,
+    /// searchable Homebrew packages (union of formulae + casks) via
+    /// `brew search <query>`. Used when the install/search position is
+    /// ambiguous between formula and cask names.
+    BrewPackagesSearchable,
     /// Test-only provider that echoes `ProviderCtx::params` into
     /// suggestions so engine-boundary tests can prove per-resolution
     /// params reached dispatch.
@@ -377,8 +383,10 @@ impl ProviderKind {
         ProviderKind::CargoFeatures,
         ProviderKind::CargoTargets,
         ProviderKind::BrewCasksInstalled,
+        ProviderKind::BrewCasksSearchable,
         ProviderKind::BrewFormulaeInstalled,
         ProviderKind::BrewFormulaeSearchable,
+        ProviderKind::BrewPackagesSearchable,
         ProviderKind::DefaultsDomains,
         ProviderKind::DockerContainers,
         ProviderKind::DockerImages,
@@ -432,8 +440,10 @@ impl ProviderKind {
             Self::CargoTargets => "cargo_targets",
             Self::CargoFeatures => "cargo_features",
             Self::BrewCasksInstalled => "brew_casks_installed",
+            Self::BrewCasksSearchable => "brew_casks_searchable",
             Self::BrewFormulaeInstalled => "brew_formulae_installed",
             Self::BrewFormulaeSearchable => "brew_formulae_searchable",
+            Self::BrewPackagesSearchable => "brew_packages_searchable",
             Self::DefaultsDomains => "defaults_domains",
             Self::DockerContainers => "docker_containers",
             Self::DockerImages => "docker_images",
@@ -557,8 +567,10 @@ pub async fn resolve(kind: ProviderKind, ctx: &ProviderCtx) -> Result<Vec<Sugges
         ProviderKind::CargoTargets => cargo_metadata::CargoTargets.generate(ctx).await,
         ProviderKind::CargoFeatures => cargo_metadata::CargoFeatures.generate(ctx).await,
         ProviderKind::BrewCasksInstalled => brew::BrewCasksInstalled.generate(ctx).await,
+        ProviderKind::BrewCasksSearchable => brew::BrewCasksSearchable.generate(ctx).await,
         ProviderKind::BrewFormulaeInstalled => brew::BrewFormulaeInstalled.generate(ctx).await,
         ProviderKind::BrewFormulaeSearchable => brew::BrewFormulaeSearchable.generate(ctx).await,
+        ProviderKind::BrewPackagesSearchable => brew::BrewPackagesSearchable.generate(ctx).await,
         ProviderKind::DefaultsDomains => macos_defaults::DefaultsDomains.generate(ctx).await,
         ProviderKind::DockerContainers => docker::DockerContainers.generate(ctx).await,
         ProviderKind::DockerImages => docker::DockerImages.generate(ctx).await,
@@ -687,6 +699,14 @@ mod tests {
         assert_eq!(
             kind_from_type_str("brew_formulae_searchable"),
             Some(ProviderKind::BrewFormulaeSearchable)
+        );
+        assert_eq!(
+            kind_from_type_str("brew_casks_searchable"),
+            Some(ProviderKind::BrewCasksSearchable)
+        );
+        assert_eq!(
+            kind_from_type_str("brew_packages_searchable"),
+            Some(ProviderKind::BrewPackagesSearchable)
         );
         assert_eq!(
             kind_from_type_str("defaults_domains"),

--- a/crates/gc-suggest/tests/golden_specs.rs
+++ b/crates/gc-suggest/tests/golden_specs.rs
@@ -17,9 +17,10 @@ use std::path::{Path, PathBuf};
 use gc_buffer::parse_command_context;
 use gc_suggest::commands::CommandsProvider;
 use gc_suggest::history::HistoryProvider;
+use gc_suggest::providers::ProviderKind;
 use gc_suggest::specs::SpecStore;
 use gc_suggest::types::Suggestion;
-use gc_suggest::{SuggestionEngine, SuggestionKind};
+use gc_suggest::{SuggestionEngine, SuggestionKind, SyncResult};
 
 fn spec_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../specs")
@@ -655,5 +656,54 @@ fn aws_empty_query_returns_subcommands_not_filesystem() {
             .iter()
             .map(|s| (&s.text, s.kind))
             .collect::<Vec<_>>()
+    );
+}
+
+fn provider_kinds(result: &SyncResult) -> Vec<ProviderKind> {
+    result.provider_generators.iter().map(|r| r.kind).collect()
+}
+
+#[test]
+fn brew_install_routes_to_brew_packages_searchable() {
+    let engine = build_engine();
+    let buffer = "brew install ";
+    let ctx = ctx_from(buffer);
+    let result = engine.suggest_sync(&ctx, &tmp_cwd(), buffer).unwrap();
+    let kinds = provider_kinds(&result);
+    assert!(
+        kinds.contains(&ProviderKind::BrewPackagesSearchable),
+        "brew install must route to BrewPackagesSearchable (formulae + casks union); got {kinds:?}"
+    );
+}
+
+#[test]
+fn brew_install_with_cask_flag_still_routes_to_packages_searchable() {
+    // The Fig spec model cannot conditionally pick a generator based on
+    // a previously-typed flag — install's arg generator is fixed at
+    // brew_packages_searchable. That generator already returns both
+    // formulae and casks, so `--cask` users still get cask completions
+    // (just alongside formulae). Pinning the behaviour here so a future
+    // attempt at flag-conditional routing has to update this test too.
+    let engine = build_engine();
+    let buffer = "brew install --cask ";
+    let ctx = ctx_from(buffer);
+    let result = engine.suggest_sync(&ctx, &tmp_cwd(), buffer).unwrap();
+    let kinds = provider_kinds(&result);
+    assert!(
+        kinds.contains(&ProviderKind::BrewPackagesSearchable),
+        "brew install --cask must route to BrewPackagesSearchable; got {kinds:?}"
+    );
+}
+
+#[test]
+fn brew_search_routes_to_brew_packages_searchable() {
+    let engine = build_engine();
+    let buffer = "brew search ";
+    let ctx = ctx_from(buffer);
+    let result = engine.suggest_sync(&ctx, &tmp_cwd(), buffer).unwrap();
+    let kinds = provider_kinds(&result);
+    assert!(
+        kinds.contains(&ProviderKind::BrewPackagesSearchable),
+        "brew search must route to BrewPackagesSearchable; got {kinds:?}"
     );
 }

--- a/crates/gc-suggest/tests/providers_brew.rs
+++ b/crates/gc-suggest/tests/providers_brew.rs
@@ -572,3 +572,118 @@ async fn run_brew_demotes_no_match_failure_to_none() {
         "a brew no-match exit must map to None (empty result), not surface output"
     );
 }
+
+// ---------- log-level discrimination for the no-match demotion (G2) ----------
+//
+// `run_brew_demotes_no_match_failure_to_none` above pins `out.is_none()`, but
+// BOTH the `is_brew_no_match` arm and the catch-all `Err` arm return None — so
+// that test cannot tell whether the no-match path was actually demoted to
+// trace. These tests observe the LOG LEVEL instead: a no-match must NOT emit a
+// `warn`, while a genuine failure must. The capture harness mirrors the one in
+// `eviction.rs`: a WARN-max subscriber writing into an in-memory buffer,
+// installed for the current thread via `set_default`.
+
+use std::sync::{Arc as StdArc, Mutex};
+use tracing_subscriber::fmt::MakeWriter;
+
+#[derive(Clone)]
+struct CaptureWriter(StdArc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("capture buffer poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn install_log_capture() -> (StdArc<Mutex<Vec<u8>>>, tracing::subscriber::DefaultGuard) {
+    let captured = StdArc::new(Mutex::new(Vec::<u8>::new()));
+    let writer = CaptureWriter(StdArc::clone(&captured));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(writer)
+        .with_max_level(tracing::Level::WARN)
+        .with_ansi(false)
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing_core::callsite::rebuild_interest_cache();
+    (captured, guard)
+}
+
+fn captured_logs(captured: &StdArc<Mutex<Vec<u8>>>) -> String {
+    String::from_utf8_lossy(&captured.lock().expect("capture buffer poisoned")).into_owned()
+}
+
+/// Write an executable fake `brew` that ignores its argv, writes `stderr` to
+/// fd 2, and exits 1. Used to drive the failure arms of `run_brew_with_binary`
+/// (which spawns the binary directly and never probes `--version`).
+fn write_failing_brew(dir: &Path, stderr: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let bin = dir.join("brew");
+    // Single-quote the payload for /bin/sh; the fixtures below contain no
+    // single quotes, so this is safe and keeps the script trivial.
+    let script = format!("#!/bin/sh\nprintf '%s\\n' '{stderr}' 1>&2\nexit 1\n");
+    std::fs::write(&bin, script).unwrap();
+    let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&bin, perms).unwrap();
+    bin
+}
+
+#[tokio::test]
+async fn run_brew_no_match_is_silent_not_warned() {
+    // Test A: a real `brew search` no-match (exit 1 with the canonical
+    // "No formulae or casks found" stderr) must be demoted below WARN — the
+    // capture buffer (WARN-max) stays EMPTY — AND map to None.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = write_failing_brew(
+        tmp.path(),
+        r#"Error: No formulae or casks found for "zzzznope"."#,
+    );
+
+    let (captured, _guard) = install_log_capture();
+    let out =
+        run_brew_with_binary(tmp.path(), bin.to_str().unwrap(), &["search", "zzzznope"]).await;
+
+    assert!(out.is_none(), "no-match must map to None");
+    let logs = captured_logs(&captured);
+    assert!(
+        logs.is_empty(),
+        "a brew no-match must NOT emit a warn (demoted to trace); captured:\n{logs}"
+    );
+}
+
+#[tokio::test]
+async fn run_brew_genuine_failure_still_warns() {
+    // Test B: a genuine failure whose stderr does NOT carry the no-match
+    // phrases must stay at WARN. This is the discrimination half that the
+    // is_none()-only test cannot observe: if `is_brew_no_match` over-matched
+    // (or the warn arm were removed) this capture would be empty and fail.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = write_failing_brew(tmp.path(), "Error: Failure while executing tap update");
+
+    let (captured, _guard) = install_log_capture();
+    let out = run_brew_with_binary(tmp.path(), bin.to_str().unwrap(), &["search", "rust"]).await;
+
+    assert!(out.is_none(), "a failed brew invocation still yields None");
+    let logs = captured_logs(&captured);
+    assert!(
+        logs.contains("brew command failed"),
+        "a genuine brew failure must stay at warn; captured:\n{logs}"
+    );
+}

--- a/crates/gc-suggest/tests/providers_brew.rs
+++ b/crates/gc-suggest/tests/providers_brew.rs
@@ -25,9 +25,11 @@ mod providers {
 use gc_suggest::providers::{Provider, ProviderCtx};
 use gc_suggest::types::{SuggestionKind, SuggestionSource};
 use providers::brew::{
-    parse_casks_installed_output, parse_formulae_installed_output,
-    parse_formulae_searchable_output, run_brew_with_binary, set_brew_search_cap,
-    BrewCasksInstalled, BrewFormulaeInstalled, BrewFormulaeSearchable, DEFAULT_BREW_SEARCH_CAP,
+    brew_search_plan, parse_casks_installed_output, parse_casks_searchable_output,
+    parse_formulae_installed_output, parse_formulae_searchable_output,
+    parse_packages_searchable_output, run_brew_with_binary, set_brew_search_cap,
+    BrewCasksInstalled, BrewCasksSearchable, BrewFormulaeInstalled, BrewFormulaeSearchable,
+    BrewPackagesSearchable, DEFAULT_BREW_SEARCH_CAP,
 };
 
 fn ctx_for(cwd: &Path) -> ProviderCtx {
@@ -44,6 +46,8 @@ fn provider_names_match_spec_type_strings() {
     assert_eq!(BrewFormulaeInstalled.name(), "brew_formulae_installed");
     assert_eq!(BrewCasksInstalled.name(), "brew_casks_installed");
     assert_eq!(BrewFormulaeSearchable.name(), "brew_formulae_searchable");
+    assert_eq!(BrewCasksSearchable.name(), "brew_casks_searchable");
+    assert_eq!(BrewPackagesSearchable.name(), "brew_packages_searchable");
 }
 
 #[test]
@@ -142,6 +146,84 @@ fn set_brew_search_cap_normalises_zero_input() {
     set_brew_search_cap(DEFAULT_BREW_SEARCH_CAP);
 }
 
+#[test]
+fn brew_search_plan_forwards_typed_query_and_skips_cap() {
+    let (args, cap) = brew_search_plan("rust", DEFAULT_BREW_SEARCH_CAP);
+    assert_eq!(args, ["search", "rust"]);
+    assert_eq!(
+        cap,
+        usize::MAX,
+        "typed-query search must not be cap-clipped; only empty-query exploration is"
+    );
+}
+
+#[test]
+fn brew_search_plan_uses_empty_arg_and_cap_for_empty_query() {
+    let (args, cap) = brew_search_plan("", 7);
+    assert_eq!(args, ["search", ""]);
+    assert_eq!(cap, 7);
+}
+
+#[test]
+fn parse_casks_searchable_handles_modern_and_legacy_headers() {
+    // Homebrew 4.x style: `==> Casks` header marks the cask section.
+    let modern = "\
+==> Formulae
+formula1
+==> Casks
+cask1
+cask2
+";
+    let parsed = parse_casks_searchable_output(modern);
+    let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(texts, vec!["cask1", "cask2"]);
+    for s in &parsed {
+        assert_eq!(s.description.as_deref(), Some("brew cask"));
+        assert_eq!(s.kind, SuggestionKind::ProviderValue);
+        assert_eq!(s.source, SuggestionSource::Provider);
+    }
+
+    // Homebrew 2.x legacy style: `Casks:` colon header.
+    let legacy = "\
+Formulae:
+formula1
+Casks:
+cask1
+cask2
+";
+    let parsed = parse_casks_searchable_output(legacy);
+    let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(texts, vec!["cask1", "cask2"]);
+}
+
+#[test]
+fn parse_casks_searchable_returns_empty_when_no_cask_section() {
+    let formulae_only = "==> Formulae\nfoo\nbar\n";
+    assert!(parse_casks_searchable_output(formulae_only).is_empty());
+    assert!(parse_casks_searchable_output("").is_empty());
+}
+
+#[test]
+fn parse_packages_searchable_emits_formulae_and_casks() {
+    let input = "==> Formulae\nfoo\nbaz\n==> Casks\nbar\n";
+    let parsed = parse_packages_searchable_output(input);
+    let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(texts, vec!["foo", "baz", "bar"]);
+    for s in &parsed {
+        assert_eq!(s.description.as_deref(), Some("brew formula or cask"));
+        assert_eq!(s.kind, SuggestionKind::ProviderValue);
+        assert_eq!(s.source, SuggestionSource::Provider);
+    }
+}
+
+#[test]
+fn parse_packages_searchable_handles_legacy_headers() {
+    let legacy = "Formulae:\nfoo\nCasks:\nbar\n";
+    let parsed = parse_packages_searchable_output(legacy);
+    let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(texts, vec!["foo", "bar"]);
+}
+
 #[tokio::test]
 async fn run_brew_missing_binary_returns_none() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -174,8 +256,18 @@ async fn providers_return_ok_empty_when_brew_binary_is_missing() {
         .generate_with_binary(&ctx, missing)
         .await
         .unwrap();
+    let cask_search = BrewCasksSearchable
+        .generate_with_binary(&ctx, missing)
+        .await
+        .unwrap();
+    let pkg_search = BrewPackagesSearchable
+        .generate_with_binary(&ctx, missing)
+        .await
+        .unwrap();
 
     assert!(formulae.is_empty());
     assert!(casks.is_empty());
     assert!(searchable.is_empty());
+    assert!(cask_search.is_empty());
+    assert!(pkg_search.is_empty());
 }

--- a/crates/gc-suggest/tests/providers_brew.rs
+++ b/crates/gc-suggest/tests/providers_brew.rs
@@ -148,8 +148,8 @@ fn set_brew_search_cap_normalises_zero_input() {
 
 #[test]
 fn brew_search_plan_forwards_typed_query_and_skips_cap() {
-    let (args, cap) = brew_search_plan("rust", DEFAULT_BREW_SEARCH_CAP);
-    assert_eq!(args, ["search", "rust"]);
+    let (args, cap) = brew_search_plan("rust", &[], DEFAULT_BREW_SEARCH_CAP);
+    assert_eq!(args, vec!["search", "rust"]);
     assert_eq!(
         cap,
         usize::MAX,
@@ -159,14 +159,77 @@ fn brew_search_plan_forwards_typed_query_and_skips_cap() {
 
 #[test]
 fn brew_search_plan_uses_empty_arg_and_cap_for_empty_query() {
-    let (args, cap) = brew_search_plan("", 7);
-    assert_eq!(args, ["search", ""]);
+    let (args, cap) = brew_search_plan("", &[], 7);
+    assert_eq!(args, vec!["search", ""]);
     assert_eq!(cap, 7);
+}
+
+#[test]
+fn brew_search_plan_splices_flag_prefix_for_cask_path() {
+    // The cask provider routes through brew_search_plan with a --cask
+    // flag prefix; the planner must splice it between `search` and the
+    // query (or the empty exploration arg). A regression that dropped
+    // --cask or appended it after the token would surface here.
+    let (empty_args, empty_cap) = brew_search_plan("", &["--cask"], DEFAULT_BREW_SEARCH_CAP);
+    assert_eq!(
+        empty_args,
+        vec!["search", "--cask", ""],
+        "empty-query cask search must be `search --cask \"\"`"
+    );
+    assert_eq!(
+        empty_cap, DEFAULT_BREW_SEARCH_CAP,
+        "empty-query cask exploration must keep the cap"
+    );
+
+    let (typed_args, typed_cap) = brew_search_plan("firefox", &["--cask"], DEFAULT_BREW_SEARCH_CAP);
+    assert_eq!(
+        typed_args,
+        vec!["search", "--cask", "firefox"],
+        "typed cask search must forward the token after --cask"
+    );
+    assert_eq!(
+        typed_cap,
+        usize::MAX,
+        "typed cask search must drop the cap like the formulae path"
+    );
+}
+
+#[test]
+fn brew_search_plan_pins_whitespace_and_dash_query_contract() {
+    // brew_search_plan keys off `query.is_empty()` only, so any
+    // non-empty string — whitespace-only or a leading-dash token — is
+    // treated as a typed query: forwarded verbatim with the cap dropped.
+    // This pins the boundary so a future change to the empty-check is
+    // regression-protected. (We do NOT trim or reject these here; the
+    // upstream buffer/trigger layer decides when a search even fires.)
+    let (space_args, space_cap) = brew_search_plan(" ", &[], DEFAULT_BREW_SEARCH_CAP);
+    assert_eq!(
+        space_args,
+        vec!["search", " "],
+        "whitespace-only query is non-empty and forwarded verbatim"
+    );
+    assert_eq!(space_cap, usize::MAX, "non-empty query drops the cap");
+
+    let (tab_args, _tab_cap) = brew_search_plan("\t", &[], DEFAULT_BREW_SEARCH_CAP);
+    assert_eq!(tab_args, vec!["search", "\t"]);
+
+    let (dash_args, dash_cap) = brew_search_plan("-", &[], DEFAULT_BREW_SEARCH_CAP);
+    assert_eq!(
+        dash_args,
+        vec!["search", "-"],
+        "leading-dash query is non-empty and forwarded verbatim"
+    );
+    assert_eq!(dash_cap, usize::MAX);
+
+    let (dashx_args, _) = brew_search_plan("-x", &[], DEFAULT_BREW_SEARCH_CAP);
+    assert_eq!(dashx_args, vec!["search", "-x"]);
 }
 
 #[test]
 fn parse_casks_searchable_handles_modern_and_legacy_headers() {
     // Homebrew 4.x style: `==> Casks` header marks the cask section.
+    // The leading `==> Formulae` header SUPPRESSES formula1; only the
+    // tokens after `==> Casks` survive.
     let modern = "\
 ==> Formulae
 formula1
@@ -174,7 +237,7 @@ formula1
 cask1
 cask2
 ";
-    let parsed = parse_casks_searchable_output(modern);
+    let parsed = parse_casks_searchable_output(modern, DEFAULT_BREW_SEARCH_CAP);
     let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
     assert_eq!(texts, vec!["cask1", "cask2"]);
     for s in &parsed {
@@ -191,22 +254,81 @@ Casks:
 cask1
 cask2
 ";
-    let parsed = parse_casks_searchable_output(legacy);
+    let parsed = parse_casks_searchable_output(legacy, DEFAULT_BREW_SEARCH_CAP);
     let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
     assert_eq!(texts, vec!["cask1", "cask2"]);
 }
 
 #[test]
-fn parse_casks_searchable_returns_empty_when_no_cask_section() {
+fn parse_casks_searchable_emits_header_less_modern_cask_output() {
+    // CRITICAL regression guard for F1: `brew search --cask <q>` on
+    // modern Homebrew (5.x) prints a BARE, header-less token list with
+    // ZERO `==>` lines. The parser must default `in_casks` ON and treat
+    // every line as a cask — the previous default-OFF behaviour returned
+    // an empty Vec and made BrewCasksSearchable non-functional.
+    let header_less = "dbvisualizer\nvisual-studio\n";
+    let parsed = parse_casks_searchable_output(header_less, DEFAULT_BREW_SEARCH_CAP);
+    let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(
+        texts,
+        vec!["dbvisualizer", "visual-studio"],
+        "header-less --cask output must yield every token as a cask"
+    );
+    assert!(
+        !parsed.is_empty(),
+        "header-less cask output must be NON-EMPTY (F1 regression guard)"
+    );
+}
+
+#[test]
+fn parse_casks_searchable_excludes_formulae_when_header_follows_cask_block() {
+    // F7: a `==> Formulae` header appearing AFTER the cask block must
+    // switch emission OFF so formula tokens are not mis-projected as
+    // casks. Mirrors the formulae parser's section-suppression.
+    let casks_then_formulae = "==> Casks\ncask1\ncask2\n==> Formulae\nformula1\n";
+    let parsed = parse_casks_searchable_output(casks_then_formulae, DEFAULT_BREW_SEARCH_CAP);
+    let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(
+        texts,
+        vec!["cask1", "cask2"],
+        "formula tokens after a `==> Formulae` header must be excluded"
+    );
+
+    // Legacy `Formulae:` colon header must reset emission off too.
+    let legacy_reset = "Casks:\ncask1\nFormulae:\nformula1\n";
+    let parsed = parse_casks_searchable_output(legacy_reset, DEFAULT_BREW_SEARCH_CAP);
+    let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(texts, vec!["cask1"]);
+}
+
+#[test]
+fn parse_casks_searchable_returns_empty_when_only_formulae_section() {
+    // With a `==> Formulae` header and no cask section, emission stays
+    // suppressed and the result is empty. (Empty input is trivially
+    // empty too.)
     let formulae_only = "==> Formulae\nfoo\nbar\n";
-    assert!(parse_casks_searchable_output(formulae_only).is_empty());
-    assert!(parse_casks_searchable_output("").is_empty());
+    assert!(parse_casks_searchable_output(formulae_only, DEFAULT_BREW_SEARCH_CAP).is_empty());
+    assert!(parse_casks_searchable_output("", DEFAULT_BREW_SEARCH_CAP).is_empty());
+}
+
+#[test]
+fn parse_casks_searchable_respects_cap() {
+    // F2: the empty-query exploration path (`brew search --cask ""`)
+    // returns ~7.7k header-less lines; the cap must clip emission.
+    let fixture = (0..50)
+        .map(|i| format!("cask-{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let parsed = parse_casks_searchable_output(&fixture, 10);
+    assert_eq!(parsed.len(), 10);
+    assert_eq!(parsed[0].text, "cask-0");
+    assert_eq!(parsed[9].text, "cask-9");
 }
 
 #[test]
 fn parse_packages_searchable_emits_formulae_and_casks() {
     let input = "==> Formulae\nfoo\nbaz\n==> Casks\nbar\n";
-    let parsed = parse_packages_searchable_output(input);
+    let parsed = parse_packages_searchable_output(input, DEFAULT_BREW_SEARCH_CAP);
     let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
     assert_eq!(texts, vec!["foo", "baz", "bar"]);
     for s in &parsed {
@@ -219,9 +341,24 @@ fn parse_packages_searchable_emits_formulae_and_casks() {
 #[test]
 fn parse_packages_searchable_handles_legacy_headers() {
     let legacy = "Formulae:\nfoo\nCasks:\nbar\n";
-    let parsed = parse_packages_searchable_output(legacy);
+    let parsed = parse_packages_searchable_output(legacy, DEFAULT_BREW_SEARCH_CAP);
     let texts: Vec<&str> = parsed.iter().map(|s| s.text.as_str()).collect();
     assert_eq!(texts, vec!["foo", "bar"]);
+}
+
+#[test]
+fn parse_packages_searchable_respects_cap() {
+    // F2: `brew search ""` returns ~16k lines (formulae + casks union)
+    // on modern Homebrew; the cap must clip emission exactly as it does
+    // for the formulae-only path.
+    let fixture = (0..50)
+        .map(|i| format!("pkg-{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let parsed = parse_packages_searchable_output(&fixture, 10);
+    assert_eq!(parsed.len(), 10);
+    assert_eq!(parsed[0].text, "pkg-0");
+    assert_eq!(parsed[9].text, "pkg-9");
 }
 
 #[tokio::test]
@@ -270,4 +407,168 @@ async fn providers_return_ok_empty_when_brew_binary_is_missing() {
     assert!(searchable.is_empty());
     assert!(cask_search.is_empty());
     assert!(pkg_search.is_empty());
+}
+
+// ---------- end-to-end provider wiring against a fake `brew` (F4) ----------
+//
+// The unit tests above exercise the parsers and the argv planner in
+// isolation. These cover the wiring the planner+parser tests cannot:
+// generate_with_binary -> reads ctx.current_token -> run_brew_with_binary
+// -> parses stdout. A fake `brew` script (a) answers `--version` with a
+// >=2.0 version so brew_is_supported passes, (b) records the search argv
+// to a sibling file, and (c) prints canned output. The fake's path is
+// unique per test (its own tempdir), which also keeps the process-global
+// version-probe cache keyed distinctly per test.
+
+/// Write an executable fake `brew` into `dir`, returning the binary path.
+/// The script answers `--version` (without recording), and for any other
+/// invocation records its full argv (one arg per line) to
+/// `<dir>/argv.log` then prints `canned_stdout`.
+fn write_fake_brew(dir: &Path, canned_stdout: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let bin = dir.join("brew");
+    let log = dir.join("argv.log");
+    // `$0` lets the script find its own directory so the record path does
+    // not depend on cwd (the providers spawn brew with ctx.cwd as cwd).
+    let script = format!(
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"--version\" ]; then\n\
+           echo 'Homebrew 4.2.10'\n\
+           exit 0\n\
+         fi\n\
+         : > '{log}'\n\
+         for a in \"$@\"; do echo \"$a\" >> '{log}'; done\n\
+         cat <<'EOF'\n\
+         {canned}EOF\n",
+        log = log.display(),
+        canned = canned_stdout,
+    );
+    std::fs::write(&bin, script).unwrap();
+    let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&bin, perms).unwrap();
+    bin
+}
+
+fn read_argv_log(dir: &Path) -> Vec<String> {
+    std::fs::read_to_string(dir.join("argv.log"))
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+fn ctx_with_token(cwd: &Path, token: &str) -> ProviderCtx {
+    ProviderCtx {
+        cwd: cwd.to_path_buf(),
+        env: Arc::new(HashMap::new()),
+        current_token: token.to_string(),
+        params: Arc::new(BTreeMap::new()),
+    }
+}
+
+#[tokio::test]
+async fn formulae_searchable_forwards_token_and_parses_output() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let canned = "==> Formulae\nrust\nripgrep\n==> Casks\nfirefox\n";
+    let bin = write_fake_brew(tmp.path(), canned);
+    let ctx = ctx_with_token(tmp.path(), "rust");
+
+    let out = BrewFormulaeSearchable
+        .generate_with_binary(&ctx, bin.to_str().unwrap())
+        .await
+        .unwrap();
+
+    let argv = read_argv_log(tmp.path());
+    assert_eq!(
+        argv,
+        vec!["search", "rust"],
+        "BrewFormulaeSearchable must forward ctx.current_token to `brew search <q>`"
+    );
+    let texts: Vec<&str> = out.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(
+        texts,
+        vec!["rust", "ripgrep"],
+        "only the Formulae section should be projected"
+    );
+}
+
+#[tokio::test]
+async fn casks_searchable_forwards_token_with_cask_flag_and_parses_output() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    // `brew search --cask <q>` on modern Homebrew prints a header-less list.
+    let canned = "firefox\nfirefox-developer-edition\n";
+    let bin = write_fake_brew(tmp.path(), canned);
+    let ctx = ctx_with_token(tmp.path(), "firefox");
+
+    let out = BrewCasksSearchable
+        .generate_with_binary(&ctx, bin.to_str().unwrap())
+        .await
+        .unwrap();
+
+    let argv = read_argv_log(tmp.path());
+    assert_eq!(
+        argv,
+        vec!["search", "--cask", "firefox"],
+        "BrewCasksSearchable must invoke `brew search --cask <q>` with the forwarded token"
+    );
+    let texts: Vec<&str> = out.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(
+        texts,
+        vec!["firefox", "firefox-developer-edition"],
+        "header-less --cask output must parse end-to-end (F1 wiring)"
+    );
+}
+
+#[tokio::test]
+async fn packages_searchable_forwards_token_and_parses_union() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let canned = "==> Formulae\nrust\n==> Casks\nfirefox\n";
+    let bin = write_fake_brew(tmp.path(), canned);
+    let ctx = ctx_with_token(tmp.path(), "rust");
+
+    let out = BrewPackagesSearchable
+        .generate_with_binary(&ctx, bin.to_str().unwrap())
+        .await
+        .unwrap();
+
+    let argv = read_argv_log(tmp.path());
+    assert_eq!(
+        argv,
+        vec!["search", "rust"],
+        "BrewPackagesSearchable must forward ctx.current_token to `brew search <q>`"
+    );
+    let texts: Vec<&str> = out.iter().map(|s| s.text.as_str()).collect();
+    assert_eq!(
+        texts,
+        vec!["rust", "firefox"],
+        "packages search projects both formulae and casks"
+    );
+}
+
+#[tokio::test]
+async fn run_brew_demotes_no_match_failure_to_none() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // F5: a typed query that matches nothing makes modern brew exit 1
+    // with `Error: No formulae or casks found ...` on stderr. That is an
+    // expected no-match, not a command failure — run_brew_with_binary
+    // must return None (parsed as empty) without escalating to a warn.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = tmp.path().join("brew");
+    let script = "#!/bin/sh\n\
+                  echo 'Error: No formulae or casks found for \"zzzznope\".' 1>&2\n\
+                  exit 1\n";
+    std::fs::write(&bin, script).unwrap();
+    let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&bin, perms).unwrap();
+
+    let out =
+        run_brew_with_binary(tmp.path(), bin.to_str().unwrap(), &["search", "zzzznope"]).await;
+    assert!(
+        out.is_none(),
+        "a brew no-match exit must map to None (empty result), not surface output"
+    );
 }

--- a/specs/__snapshots__/brew.snap
+++ b/specs/__snapshots__/brew.snap
@@ -336,7 +336,7 @@
         "description": "Formula or cask to summarize",
         "generators": [
           {
-            "type": "brew_formulae_searchable"
+            "type": "brew_packages_searchable"
           }
         ],
         "isOptional": true,
@@ -1067,6 +1067,17 @@
       ]
     },
     {
+      "args": {
+        "description": "Substring to search for",
+        "generators": [
+          {
+            "type": "brew_packages_searchable"
+          }
+        ],
+        "isOptional": true,
+        "isVariadic": true,
+        "name": "text"
+      },
       "description": "Perform a substring search of cask tokens and formula names",
       "name": "search",
       "options": [
@@ -1215,7 +1226,7 @@
         "description": "Formula or cask to install",
         "generators": [
           {
-            "type": "brew_formulae_searchable"
+            "type": "brew_packages_searchable"
           }
         ],
         "isVariadic": true,
@@ -2295,7 +2306,7 @@
         "description": "Formula or cask to install",
         "generators": [
           {
-            "type": "brew_formulae_searchable"
+            "type": "brew_packages_searchable"
           }
         ],
         "isOptional": true,
@@ -2353,7 +2364,7 @@
         "description": "Formula or cask to open homepage for",
         "generators": [
           {
-            "type": "brew_formulae_searchable"
+            "type": "brew_packages_searchable"
           }
         ],
         "isOptional": true,

--- a/specs/brew.json
+++ b/specs/brew.json
@@ -336,7 +336,7 @@
         "description": "Formula or cask to summarize",
         "generators": [
           {
-            "type": "brew_formulae_searchable"
+            "type": "brew_packages_searchable"
           }
         ],
         "isOptional": true,
@@ -1067,6 +1067,17 @@
       ]
     },
     {
+      "args": {
+        "description": "Substring to search for",
+        "generators": [
+          {
+            "type": "brew_packages_searchable"
+          }
+        ],
+        "isOptional": true,
+        "isVariadic": true,
+        "name": "text"
+      },
       "description": "Perform a substring search of cask tokens and formula names",
       "name": "search",
       "options": [
@@ -1215,7 +1226,7 @@
         "description": "Formula or cask to install",
         "generators": [
           {
-            "type": "brew_formulae_searchable"
+            "type": "brew_packages_searchable"
           }
         ],
         "isVariadic": true,
@@ -2295,7 +2306,7 @@
         "description": "Formula or cask to install",
         "generators": [
           {
-            "type": "brew_formulae_searchable"
+            "type": "brew_packages_searchable"
           }
         ],
         "isOptional": true,
@@ -2353,7 +2364,7 @@
         "description": "Formula or cask to open homepage for",
         "generators": [
           {
-            "type": "brew_formulae_searchable"
+            "type": "brew_packages_searchable"
           }
         ],
         "isOptional": true,

--- a/tools/fig-converter/src/index.js
+++ b/tools/fig-converter/src/index.js
@@ -467,6 +467,24 @@ function applyBrewNativeProviderFixups(spec) {
     }
     setNodeProvider(node, provider('brew_packages_searchable'));
   });
+
+  // Upstream `brew search` has no args, but its positional argument is the
+  // search substring; completing it against the installable package universe
+  // (formulae + casks) is the whole point of `brew search`. Inject a variadic
+  // optional arg routed to brew_packages_searchable so the native provider
+  // drives completions for the search text.
+  const searchSub = (spec.subcommands ?? []).find((sub) =>
+    namesInclude(sub.name, 'search'),
+  );
+  if (searchSub && !searchSub.args) {
+    searchSub.args = {
+      name: 'text',
+      description: 'Substring to search for',
+      isOptional: true,
+      isVariadic: true,
+      generators: [provider('brew_packages_searchable')],
+    };
+  }
 }
 
 function applyTmuxNativeProviderFixups(spec) {

--- a/tools/fig-converter/src/index.js
+++ b/tools/fig-converter/src/index.js
@@ -457,12 +457,15 @@ function applyNpmNativeProviderFixups(spec) {
 }
 
 function applyBrewNativeProviderFixups(spec) {
+  // Upstream Fig uses `brew formulae` (formula-only listing) for install,
+  // edit, home, abv. Those subcommands all accept casks too, so route to
+  // brew_packages_searchable (union of formulae + casks) for accuracy.
   walkSpecNodes(spec, (node) => {
     const gen = firstGenerator(node);
     if (!gen?.script || gen.script[0] !== 'brew' || gen.script[1] !== 'formulae') {
       return;
     }
-    setNodeProvider(node, provider('brew_formulae_searchable'));
+    setNodeProvider(node, provider('brew_packages_searchable'));
   });
 }
 

--- a/tools/fig-converter/src/index.test.js
+++ b/tools/fig-converter/src/index.test.js
@@ -355,7 +355,7 @@ describe('convertSingleSpec', () => {
 
       const brew = await convertSingleSpec('brew');
       assert.ok(brew);
-      assert.ok(findGenerator(brew.spec, (gen) => gen.type === 'brew_formulae_searchable'));
+      assert.ok(findGenerator(brew.spec, (gen) => gen.type === 'brew_packages_searchable'));
 
       const kubectl = await convertSingleSpec('kubectl');
       assert.ok(kubectl);

--- a/tools/fig-converter/src/index.test.js
+++ b/tools/fig-converter/src/index.test.js
@@ -357,6 +357,18 @@ describe('convertSingleSpec', () => {
       assert.ok(brew);
       assert.ok(findGenerator(brew.spec, (gen) => gen.type === 'brew_packages_searchable'));
 
+      // `brew search` has no upstream args; applyBrewNativeProviderFixups
+      // injects a variadic optional `text` arg routed to the
+      // brew_packages_searchable native provider so search completions work.
+      const search = subcommand(brew.spec, 'search');
+      assert.deepStrictEqual(search.args, {
+        name: 'text',
+        description: 'Substring to search for',
+        isOptional: true,
+        isVariadic: true,
+        generators: [{ type: 'brew_packages_searchable' }],
+      });
+
       const kubectl = await convertSingleSpec('kubectl');
       assert.ok(kubectl);
       assert.ok(findGenerator(kubectl.spec, (gen) => gen.type === 'k8s_contexts'));

--- a/tools/fig-converter/src/native-map.js
+++ b/tools/fig-converter/src/native-map.js
@@ -204,7 +204,15 @@ function smallToolProvider(scriptArgv) {
   if (binary === 'brew') {
     if (sub === 'list' && scriptArgv.includes('--cask')) return { type: 'brew_casks_installed' };
     if (sub === 'list') return { type: 'brew_formulae_installed' };
-    if (sub === 'search') return { type: 'brew_formulae_searchable' };
+    if (sub === 'search') {
+      if (scriptArgv.includes('--cask') || scriptArgv.includes('--casks')) {
+        return { type: 'brew_casks_searchable' };
+      }
+      if (scriptArgv.includes('--formula') || scriptArgv.includes('--formulae')) {
+        return { type: 'brew_formulae_searchable' };
+      }
+      return { type: 'brew_packages_searchable' };
+    }
   }
   if (binary === 'dscl' && scriptArgv[1] === '.' && scriptArgv[2] === 'list') {
     if (scriptArgv[3] === '/Users') return { type: 'dscl_users' };

--- a/tools/fig-converter/src/native-map.test.js
+++ b/tools/fig-converter/src/native-map.test.js
@@ -342,6 +342,17 @@ describe('matchNativeGenerator', () => {
       matchNativeGenerator('brew', ['brew', 'search', 'foo']),
       { type: 'brew_packages_searchable' },
     );
+    // Precedence: when both --cask and --formula coexist, --cask wins because
+    // the implementation checks the cask flags before the formula flags. This
+    // pins that ordering so reordering the two if-branches would fail here.
+    assert.deepStrictEqual(
+      matchNativeGenerator('brew', ['brew', 'search', '--cask', '--formula', 'foo']),
+      { type: 'brew_casks_searchable' },
+    );
+    assert.deepStrictEqual(
+      matchNativeGenerator('brew', ['brew', 'search', '--formula', '--cask', 'foo']),
+      { type: 'brew_casks_searchable' },
+    );
   });
 
   it('does not map npm bash-c when post-process does not look like the package.json scripts shape', () => {

--- a/tools/fig-converter/src/native-map.test.js
+++ b/tools/fig-converter/src/native-map.test.js
@@ -321,6 +321,29 @@ describe('matchNativeGenerator', () => {
     );
   });
 
+  it('routes brew search by --cask / --formula / bare', () => {
+    assert.deepStrictEqual(
+      matchNativeGenerator('brew', ['brew', 'search', '--cask', 'foo']),
+      { type: 'brew_casks_searchable' },
+    );
+    assert.deepStrictEqual(
+      matchNativeGenerator('brew', ['brew', 'search', '--casks', 'foo']),
+      { type: 'brew_casks_searchable' },
+    );
+    assert.deepStrictEqual(
+      matchNativeGenerator('brew', ['brew', 'search', '--formula', 'foo']),
+      { type: 'brew_formulae_searchable' },
+    );
+    assert.deepStrictEqual(
+      matchNativeGenerator('brew', ['brew', 'search', '--formulae', 'foo']),
+      { type: 'brew_formulae_searchable' },
+    );
+    assert.deepStrictEqual(
+      matchNativeGenerator('brew', ['brew', 'search', 'foo']),
+      { type: 'brew_packages_searchable' },
+    );
+  });
+
   it('does not map npm bash-c when post-process does not look like the package.json scripts shape', () => {
     // No post-process at all, or one that doesn't read package.json#scripts —
     // we MUST NOT route to npm_scripts (the bash invocation might be unrelated).


### PR DESCRIPTION
## Summary

- `brew_formulae_searchable` now consults `ctx.current_token`: typed queries call `brew search <q>` instead of empty search + cap, which only applies to empty-query exploration.
- Adds `brew_casks_searchable` (`brew search --cask <q>`) and `brew_packages_searchable` (formulae+casks union) providers, plus parsers for both modern (`==> Casks`) and legacy (`Casks:`) Homebrew header styles.
- `tools/fig-converter/src/native-map.js` routes `brew search --cask|--casks` → `brew_casks_searchable`, `--formula|--formulae` → `brew_formulae_searchable`, bare → `brew_packages_searchable`; `specs/brew.json` switches install/edit/home/abv/search args to `brew_packages_searchable` (Fig spec model cannot do flag-conditional routing, so the union is the honest choice).

References: docs/plans/0.17-polish-and-trust/5-macos-smart-completions/plan.md Tasks 3–5

## Test plan

- [x] `cargo test -p gc-suggest brew` (21/21 in providers_brew, 3/3 new brew goldens)
- [x] `cargo test -p gc-suggest --test golden_specs brew`
- [x] `npm --prefix tools/fig-converter test` (322/322 incl. new `brew search` routing tests)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`