### PR TITLE
0.17 phase 4 / PR C — TUI: adaptive layout, scroll, filter

### DIFF
--- a/crates/ghost-complete/src/tui/app.rs
+++ b/crates/ghost-complete/src/tui/app.rs
@@ -29,6 +29,10 @@ pub enum Prompt {
     /// Config file changed on disk after we loaded it; saving would clobber.
     /// r = reload from disk, o = overwrite anyway, c = cancel.
     FileChangedOnDisk,
+    /// User opened the `/` filter prompt and is typing the query into
+    /// `app.filter`. Enter commits (closes the prompt, keeps the filter);
+    /// Esc cancels (closes prompt, clears the filter).
+    FilterInput,
 }
 
 pub struct App {
@@ -61,6 +65,18 @@ pub struct App {
     pub loaded_mtime: Option<SystemTime>,
     /// Active modal prompt, if any. Blocks normal key handling while set.
     pub prompt: Option<Prompt>,
+    /// Scroll offset for the field list pane, in rendered rows. PgUp/PgDn,
+    /// Home, and End drive this. Long sections used to silently clip at the
+    /// bottom of the pane; the offset lets the user scroll them into view.
+    pub field_scroll: u16,
+    /// Active substring filter (case-insensitive match on key or help). When
+    /// `Some`, the field pane shows matches across *all* sections, ignoring
+    /// `section_idx`. `None` means show the current section's fields normally.
+    pub filter: Option<String>,
+    /// Whether the preview pane is shown at medium widths (60-99 cols). At
+    /// width >= 100 the pane is always shown; at width < 60 it is always
+    /// hidden. Toggled with `p` in nav mode.
+    pub show_preview: bool,
 }
 
 impl App {
@@ -83,6 +99,9 @@ impl App {
             should_quit: false,
             loaded_mtime,
             prompt: None,
+            field_scroll: 0,
+            filter: None,
+            show_preview: true,
         }
     }
 
@@ -104,6 +123,45 @@ impl App {
             .iter()
             .filter(|f| f.section == section)
             .collect()
+    }
+
+    /// Iterate over fields that match the current `filter`, ignoring section.
+    /// When `filter` is `None`, yields every field. Substring match is
+    /// case-insensitive against `key` and `help`.
+    pub fn visible_fields(&self) -> impl Iterator<Item = &FieldMeta> {
+        let needle = self.filter.as_ref().map(|s| s.to_lowercase());
+        self.all_fields
+            .iter()
+            .filter(move |f| match needle.as_ref() {
+                None => true,
+                Some(q) => f.key.to_lowercase().contains(q) || f.help.to_lowercase().contains(q),
+            })
+    }
+
+    /// What the field pane should actually render. When a filter is active,
+    /// match across every section; otherwise the selected section's fields.
+    pub fn displayed_fields(&self) -> Vec<&FieldMeta> {
+        if self.filter.is_some() {
+            self.visible_fields().collect()
+        } else {
+            self.current_section_fields()
+        }
+    }
+
+    /// Largest legal `field_scroll` value given the field pane's visible row
+    /// budget. Each field occupies four rendered rows (name + value + help +
+    /// blank); callers should clamp `field_scroll` to this before passing it
+    /// to `Paragraph::scroll`.
+    pub fn max_field_scroll_for(&self, visible_rows: u16) -> u16 {
+        let total_rows = self.displayed_fields().len().saturating_mul(4);
+        total_rows.saturating_sub(visible_rows as usize) as u16
+    }
+
+    /// True while the user is typing into the `/` filter prompt. Used to gate
+    /// global key handlers (`q` / `Esc` / `/`) so typed characters become part
+    /// of the filter buffer instead of quitting or restarting the prompt.
+    pub fn in_filter_input(&self) -> bool {
+        matches!(self.prompt, Some(Prompt::FilterInput))
     }
 
     /// Get the current value of a field from the config as a display string.
@@ -225,6 +283,98 @@ mod tests {
             .into_iter()
             .find(|field| field.section == "theme" && field.key == key)
             .expect("theme field should exist")
+    }
+
+    fn empty_app() -> App {
+        App::new(
+            GhostConfig::default(),
+            String::new(),
+            PathBuf::from("/tmp/test.toml"),
+        )
+    }
+
+    #[test]
+    fn filter_narrows_field_list() {
+        let mut app = empty_app();
+        app.filter = Some("render".to_string());
+        let filtered: Vec<&FieldMeta> = app.visible_fields().collect();
+        assert!(
+            !filtered.is_empty(),
+            "render filter should match at least one field"
+        );
+        assert!(filtered.iter().all(|f| {
+            f.key.to_lowercase().contains("render") || f.help.to_lowercase().contains("render")
+        }));
+    }
+
+    #[test]
+    fn filter_none_returns_every_field() {
+        let app = empty_app();
+        assert_eq!(app.visible_fields().count(), app.all_fields.len());
+    }
+
+    #[test]
+    fn filter_is_case_insensitive() {
+        let mut upper = empty_app();
+        upper.filter = Some("RENDER".to_string());
+        let mut lower = empty_app();
+        lower.filter = Some("render".to_string());
+        let lower_count = lower.visible_fields().count();
+        assert!(lower_count > 0);
+        assert_eq!(upper.visible_fields().count(), lower_count);
+    }
+
+    #[test]
+    fn filter_with_no_matches_yields_empty() {
+        let mut app = empty_app();
+        app.filter = Some("zzz-no-such-field-zzz".to_string());
+        assert_eq!(app.visible_fields().count(), 0);
+    }
+
+    #[test]
+    fn scroll_offset_clamped_to_field_count() {
+        let mut app = empty_app();
+        app.field_scroll = u16::MAX;
+        let max = app.max_field_scroll_for(80);
+        assert!(app.field_scroll >= max);
+    }
+
+    #[test]
+    fn max_field_scroll_is_zero_when_everything_fits() {
+        let app = empty_app();
+        let visible_rows = (app.all_fields.len() as u16).saturating_mul(4);
+        assert_eq!(app.max_field_scroll_for(visible_rows), 0);
+    }
+
+    #[test]
+    fn displayed_fields_falls_back_to_section_without_filter() {
+        let app = empty_app();
+        let displayed = app.displayed_fields();
+        let by_section = app.current_section_fields();
+        assert_eq!(displayed.len(), by_section.len());
+    }
+
+    #[test]
+    fn displayed_fields_uses_filter_across_sections_when_set() {
+        let mut app = empty_app();
+        app.filter = Some("theme".to_string());
+        let displayed = app.displayed_fields();
+        let sections: std::collections::HashSet<&str> =
+            displayed.iter().map(|f| f.section).collect();
+        assert!(
+            sections.contains("theme"),
+            "filter must include theme fields"
+        );
+    }
+
+    #[test]
+    fn in_filter_input_tracks_prompt_state() {
+        let mut app = empty_app();
+        assert!(!app.in_filter_input());
+        app.prompt = Some(Prompt::FilterInput);
+        assert!(app.in_filter_input());
+        app.prompt = Some(Prompt::ConfirmQuit);
+        assert!(!app.in_filter_input());
     }
 
     #[test]

--- a/crates/ghost-complete/src/tui/editor.rs
+++ b/crates/ghost-complete/src/tui/editor.rs
@@ -70,8 +70,39 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
 
     // Navigation mode (EditState::None)
     match key.code {
+        // Esc with an active filter clears the filter first; only a second
+        // Esc (or `q`) reaches the quit path. Matches vim/less muscle memory
+        // and prevents "I just wanted to drop the filter, why am I being
+        // asked to discard unsaved edits?".
+        KeyCode::Esc if app.filter.is_some() => {
+            app.filter = None;
+            app.field_scroll = 0;
+            app.field_idx = 0;
+        }
         KeyCode::Char('q') | KeyCode::Esc => {
             request_quit(app);
+        }
+        KeyCode::Char('/') => {
+            app.filter = Some(String::new());
+            app.field_scroll = 0;
+            app.field_idx = 0;
+            app.focus = Focus::Fields;
+            app.prompt = Some(Prompt::FilterInput);
+        }
+        KeyCode::Char('p') => {
+            app.show_preview = !app.show_preview;
+        }
+        KeyCode::PageDown => {
+            app.field_scroll = app.field_scroll.saturating_add(10);
+        }
+        KeyCode::PageUp => {
+            app.field_scroll = app.field_scroll.saturating_sub(10);
+        }
+        KeyCode::Home => {
+            app.field_scroll = 0;
+        }
+        KeyCode::End => {
+            app.field_scroll = u16::MAX;
         }
         KeyCode::Tab | KeyCode::BackTab => {
             app.focus = match app.focus {
@@ -98,7 +129,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
                 }
             }
             Focus::Fields => {
-                let max = app.current_section_fields().len().saturating_sub(1);
+                let max = app.displayed_fields().len().saturating_sub(1);
                 if app.field_idx < max {
                     app.field_idx += 1;
                 }
@@ -118,7 +149,9 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
 }
 
 fn start_edit(app: &mut App) {
-    let fields = app.current_section_fields();
+    // Use `displayed_fields` so editing while filtered targets the filtered
+    // row, not the section-indexed row underneath.
+    let fields = app.displayed_fields();
     let Some(field) = fields.get(app.field_idx) else {
         return;
     };
@@ -166,7 +199,7 @@ fn apply_edit(app: &mut App) {
     };
     let buffer = buffer.clone();
 
-    let fields = app.current_section_fields();
+    let fields = app.displayed_fields();
     let Some(field) = fields.get(app.field_idx) else {
         app.edit_state = EditState::None;
         return;
@@ -393,6 +426,38 @@ fn handle_prompt_key(app: &mut App, prompt: Prompt, key: KeyEvent) {
             }
             KeyCode::Char('c') | KeyCode::Char('C') | KeyCode::Esc => {
                 app.prompt = None;
+            }
+            _ => {}
+        },
+        Prompt::FilterInput => match key.code {
+            KeyCode::Enter => {
+                // Commit: keep `app.filter` as the active query, dismiss the
+                // prompt. If the user committed an empty string, drop the
+                // filter entirely so the section view returns.
+                app.prompt = None;
+                if matches!(&app.filter, Some(s) if s.is_empty()) {
+                    app.filter = None;
+                }
+            }
+            KeyCode::Esc => {
+                // Cancel: discard the filter entirely.
+                app.prompt = None;
+                app.filter = None;
+                app.field_scroll = 0;
+                app.field_idx = 0;
+            }
+            KeyCode::Backspace => {
+                if let Some(s) = &mut app.filter {
+                    s.pop();
+                    app.field_idx = 0;
+                }
+            }
+            KeyCode::Char(c) => {
+                if let Some(s) = &mut app.filter {
+                    s.push(c);
+                    app.field_idx = 0;
+                    app.field_scroll = 0;
+                }
             }
             _ => {}
         },
@@ -698,5 +763,150 @@ mod tests {
 
         assert!(!app.should_quit);
         assert_eq!(app.prompt, None);
+    }
+
+    #[test]
+    fn slash_opens_filter_prompt_with_empty_filter() {
+        let mut app = make_app("");
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE),
+        );
+        assert_eq!(app.prompt, Some(Prompt::FilterInput));
+        assert_eq!(app.filter.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn filter_prompt_collects_typed_characters() {
+        let mut app = make_app("");
+        app.prompt = Some(Prompt::FilterInput);
+        app.filter = Some(String::new());
+
+        for c in "render".chars() {
+            handle_prompt_key(
+                &mut app,
+                Prompt::FilterInput,
+                KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE),
+            );
+        }
+        assert_eq!(app.filter.as_deref(), Some("render"));
+
+        handle_prompt_key(
+            &mut app,
+            Prompt::FilterInput,
+            KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+        );
+        assert_eq!(app.filter.as_deref(), Some("rende"));
+    }
+
+    #[test]
+    fn filter_prompt_enter_commits_and_dismisses() {
+        let mut app = make_app("");
+        app.prompt = Some(Prompt::FilterInput);
+        app.filter = Some("render".to_string());
+
+        handle_prompt_key(
+            &mut app,
+            Prompt::FilterInput,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+        assert_eq!(app.prompt, None);
+        assert_eq!(app.filter.as_deref(), Some("render"));
+    }
+
+    #[test]
+    fn filter_prompt_enter_with_empty_clears_filter() {
+        let mut app = make_app("");
+        app.prompt = Some(Prompt::FilterInput);
+        app.filter = Some(String::new());
+
+        handle_prompt_key(
+            &mut app,
+            Prompt::FilterInput,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+        assert_eq!(app.prompt, None);
+        assert_eq!(app.filter, None);
+    }
+
+    #[test]
+    fn filter_prompt_esc_clears_filter() {
+        let mut app = make_app("");
+        app.prompt = Some(Prompt::FilterInput);
+        app.filter = Some("render".to_string());
+
+        handle_prompt_key(
+            &mut app,
+            Prompt::FilterInput,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        );
+        assert_eq!(app.prompt, None);
+        assert_eq!(app.filter, None);
+    }
+
+    #[test]
+    fn esc_with_active_filter_clears_filter_not_quit() {
+        let mut app = make_app("");
+        app.filter = Some("render".to_string());
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(!app.should_quit, "first Esc must clear filter, not quit");
+        assert_eq!(app.filter, None);
+        assert_eq!(app.prompt, None);
+    }
+
+    #[test]
+    fn page_down_advances_field_scroll() {
+        let mut app = make_app("");
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE),
+        );
+        assert_eq!(app.field_scroll, 10);
+
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE),
+        );
+        assert_eq!(app.field_scroll, 20);
+    }
+
+    #[test]
+    fn page_up_saturates_at_zero() {
+        let mut app = make_app("");
+        app.field_scroll = 5;
+        handle_key(&mut app, KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE));
+        assert_eq!(app.field_scroll, 0);
+
+        // Second PgUp from 0 stays at 0 — saturating, not wrapping.
+        handle_key(&mut app, KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE));
+        assert_eq!(app.field_scroll, 0);
+    }
+
+    #[test]
+    fn home_resets_and_end_jumps_to_max() {
+        let mut app = make_app("");
+        app.field_scroll = 42;
+        handle_key(&mut app, KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
+        assert_eq!(app.field_scroll, 0);
+
+        handle_key(&mut app, KeyEvent::new(KeyCode::End, KeyModifiers::NONE));
+        assert_eq!(app.field_scroll, u16::MAX);
+    }
+
+    #[test]
+    fn p_toggles_preview_visibility() {
+        let mut app = make_app("");
+        assert!(app.show_preview, "preview defaults to visible");
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+        );
+        assert!(!app.show_preview);
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+        );
+        assert!(app.show_preview);
     }
 }

--- a/crates/ghost-complete/src/tui/ui.rs
+++ b/crates/ghost-complete/src/tui/ui.rs
@@ -1,14 +1,37 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
 use ratatui::Frame;
 
 use super::app::{App, EditState, Focus, Prompt};
 use super::fields::{self, FieldMeta, ReloadBehavior, SECTIONS};
 use super::preview;
 
-/// Top-level render function. Draws the three-pane layout + footer.
+/// Layout the editor adopts for the current frame. Selected purely from
+/// `area.width`; key handlers consult [`layout_for_width`] when they need
+/// to interpret scroll/preview semantics consistently with what was drawn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutKind {
+    /// >=100 cols: sections | fields | preview, all visible.
+    ThreePane,
+    /// 60-99 cols: sections | fields, preview only when `show_preview`.
+    TwoPane,
+    /// <60 cols: section selector on a single row above fields; no preview.
+    Compact,
+}
+
+pub fn layout_for_width(width: u16) -> LayoutKind {
+    if width >= 100 {
+        LayoutKind::ThreePane
+    } else if width >= 60 {
+        LayoutKind::TwoPane
+    } else {
+        LayoutKind::Compact
+    }
+}
+
+/// Top-level render function. Draws an adaptive layout + footer.
 pub fn render(frame: &mut Frame, app: &App) {
     let size = frame.area();
 
@@ -21,27 +44,67 @@ pub fn render(frame: &mut Frame, app: &App) {
     let main_area = vertical[0];
     let footer_area = vertical[1];
 
-    // Horizontal split: sections | fields | preview
-    let horizontal = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Length(16),
-            Constraint::Fill(1),
-            Constraint::Length(50),
-        ])
-        .split(main_area);
+    match layout_for_width(main_area.width) {
+        LayoutKind::ThreePane => {
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Length(16),
+                    Constraint::Fill(1),
+                    Constraint::Length(50),
+                ])
+                .split(main_area);
+            render_sections(frame, app, chunks[0]);
+            render_fields(frame, app, chunks[1]);
+            preview::render_preview(frame, app, chunks[2]);
+        }
+        LayoutKind::TwoPane => {
+            if app.show_preview {
+                let chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([
+                        Constraint::Length(14),
+                        Constraint::Fill(1),
+                        Constraint::Length(40),
+                    ])
+                    .split(main_area);
+                render_sections(frame, app, chunks[0]);
+                render_fields(frame, app, chunks[1]);
+                preview::render_preview(frame, app, chunks[2]);
+            } else {
+                let chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Length(14), Constraint::Fill(1)])
+                    .split(main_area);
+                render_sections(frame, app, chunks[0]);
+                render_fields(frame, app, chunks[1]);
+            }
+        }
+        LayoutKind::Compact => {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(3), Constraint::Fill(1)])
+                .split(main_area);
+            render_sections_inline(frame, app, chunks[0]);
+            render_fields(frame, app, chunks[1]);
+        }
+    }
 
-    render_sections(frame, app, horizontal[0]);
-    render_fields(frame, app, horizontal[1]);
-    preview::render_preview(frame, app, horizontal[2]);
     render_footer(frame, app, footer_area);
 
     if let Some(prompt) = app.prompt {
-        render_prompt(frame, size, prompt);
+        render_prompt(frame, size, prompt, app);
     }
 }
 
-fn render_prompt(frame: &mut Frame, area: Rect, prompt: Prompt) {
+fn render_prompt(frame: &mut Frame, area: Rect, prompt: Prompt, app: &App) {
+    // FilterInput is rendered inline in the footer rather than as a centered
+    // modal — typing a query into a popup that covers the field list defeats
+    // the purpose of filtering.
+    if prompt == Prompt::FilterInput {
+        return;
+    }
+
     let (title, lines) = match prompt {
         Prompt::ConfirmQuit => (
             " Unsaved Changes ",
@@ -74,7 +137,11 @@ fn render_prompt(frame: &mut Frame, area: Rect, prompt: Prompt) {
                 ]),
             ],
         ),
+        Prompt::FilterInput => unreachable!("handled above"),
     };
+    // Silence unused-warning when no centered modal is rendered (FilterInput
+    // path returns early).
+    let _ = app;
 
     let width = 60.min(area.width.saturating_sub(4));
     let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(4));
@@ -132,28 +199,51 @@ fn render_sections(frame: &mut Frame, app: &App, area: Rect) {
 
 fn render_fields(frame: &mut Frame, app: &App, area: Rect) {
     let section = app.current_section();
-    let section_fields = app.current_section_fields();
+    let displayed = app.displayed_fields();
+
+    let title = if app.filter.is_some() {
+        format!(" Filtered ({} matches) ", displayed.len())
+    } else {
+        format!(" {} ", fields::section_label(section))
+    };
 
     let block = Block::default()
-        .title(format!(" {} ", fields::section_label(section)))
+        .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::DarkGray));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    if section_fields.is_empty() {
+    if displayed.is_empty() {
+        let msg = if app.filter.is_some() {
+            "No fields match the current filter."
+        } else {
+            "No fields in this section."
+        };
+        let para = Paragraph::new(Line::from(Span::styled(
+            format!("  {msg}"),
+            Style::default().fg(Color::DarkGray),
+        )));
+        frame.render_widget(para, inner);
         return;
     }
 
     let mut lines: Vec<Line> = Vec::new();
 
-    for (i, field) in section_fields.iter().enumerate() {
+    for (i, field) in displayed.iter().enumerate() {
         let is_selected = app.focus == Focus::Fields && i == app.field_idx;
         let value = app.field_value(field);
 
-        // Field name line
-        let mut name_spans: Vec<Span> = Vec::new();
+        // When filtering across sections, prefix the field name with its
+        // section so the user can tell `theme.preset` from `popup.preset` at
+        // a glance. In the unfiltered path the section pane already conveys
+        // this, so we keep the bare key.
+        let name_prefix = if app.filter.is_some() {
+            format!("  {}.{}", field.section, field.key)
+        } else {
+            format!("  {}", field.key)
+        };
 
         let name_style = if is_selected {
             Style::default()
@@ -164,7 +254,7 @@ fn render_fields(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(Color::Yellow)
         };
 
-        name_spans.push(Span::styled(format!("  {}", field.key), name_style));
+        let mut name_spans: Vec<Span> = vec![Span::styled(name_prefix, name_style)];
 
         if field.reload == ReloadBehavior::RequiresRestart {
             name_spans.push(Span::styled(
@@ -217,7 +307,7 @@ fn render_fields(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     // Show validation errors at bottom
-    let field_errors = visible_errors(app, &section_fields);
+    let field_errors = visible_errors(app, &displayed);
 
     for (key, msg) in &field_errors {
         lines.push(Line::from(Span::styled(
@@ -226,11 +316,80 @@ fn render_fields(frame: &mut Frame, app: &App, area: Rect) {
         )));
     }
 
-    let paragraph = Paragraph::new(lines);
+    // Each field block is four rendered rows tall (name + value + help + blank).
+    // The total line budget cannot exceed `u16::MAX` because ratatui's
+    // `Paragraph::scroll` takes a `u16` row offset and we have to clamp.
+    let visible_rows = inner.height;
+    let max_scroll = app.max_field_scroll_for(visible_rows);
+    let scroll = app.field_scroll.min(max_scroll);
+    let paragraph = Paragraph::new(lines)
+        .scroll((scroll, 0))
+        .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, inner);
 }
 
+/// Compact-mode section selector — a single horizontal row instead of a side
+/// pane, so the field list gets the remaining height when the terminal is
+/// narrower than 60 columns.
+fn render_sections_inline(frame: &mut Frame, app: &App, area: Rect) {
+    let mut spans: Vec<Span> = Vec::with_capacity(SECTIONS.len() * 2);
+    for (idx, section) in SECTIONS.iter().enumerate() {
+        let label = fields::section_label(section);
+        let style = if idx == app.section_idx && app.focus == Focus::Sections {
+            Style::default()
+                .bg(Color::Cyan)
+                .fg(Color::Black)
+                .add_modifier(Modifier::BOLD)
+        } else if idx == app.section_idx {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        spans.push(Span::styled(format!(" {label} "), style));
+        if idx + 1 < SECTIONS.len() {
+            spans.push(Span::styled("·", Style::default().fg(Color::DarkGray)));
+        }
+    }
+
+    let block = Block::default()
+        .borders(Borders::BOTTOM)
+        .border_style(Style::default().fg(Color::DarkGray));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let para = Paragraph::new(Line::from(spans)).wrap(Wrap { trim: false });
+    frame.render_widget(para, inner);
+}
+
 fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
+    // FilterInput overrides the keybinding hint line — the user is typing into
+    // the filter buffer and needs to see what they've typed plus an "N / M
+    // matched" count, not the standard nav cheatsheet.
+    if app.in_filter_input() {
+        let query = app.filter.as_deref().unwrap_or("");
+        let matched = app.displayed_fields().len();
+        let total = app.all_fields.len();
+        let line1 = Line::from(vec![
+            Span::styled(" / ", Style::default().fg(Color::Green)),
+            Span::raw(query),
+            Span::styled("_", Style::default().add_modifier(Modifier::REVERSED)),
+        ]);
+        let line2 = Line::from(vec![
+            Span::styled(
+                format!(" Matched {matched} / {total} fields"),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::raw("  "),
+            Span::styled("Enter", Style::default().fg(Color::Cyan)),
+            Span::raw(" commit  "),
+            Span::styled("Esc", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ]);
+        let para = Paragraph::new(vec![line1, line2]);
+        frame.render_widget(para, area);
+        return;
+    }
+
     let mode_str = match app.edit_state {
         EditState::None => "Navigate",
         EditState::Text { .. } => "Edit",
@@ -241,6 +400,8 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         Span::raw(" switch  "),
         Span::styled("Enter", Style::default().fg(Color::Cyan)),
         Span::raw(" edit  "),
+        Span::styled("/", Style::default().fg(Color::Cyan)),
+        Span::raw(" filter  "),
         Span::styled("Ctrl+S", Style::default().fg(Color::Cyan)),
         Span::raw(" save  "),
         Span::styled("q/Esc", Style::default().fg(Color::Cyan)),
@@ -262,11 +423,21 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(Color::DarkGray),
         ),
         Span::raw("  "),
-        Span::styled(
+    ];
+
+    if let Some(query) = &app.filter {
+        let matched = app.displayed_fields().len();
+        let total = app.all_fields.len();
+        footer_line_2_spans.push(Span::styled(
+            format!("Filter: /{query}  ({matched} / {total})"),
+            Style::default().fg(Color::Green),
+        ));
+    } else {
+        footer_line_2_spans.push(Span::styled(
             format!("Section: {}", fields::section_label(app.current_section())),
             Style::default().fg(Color::DarkGray),
-        ),
-    ];
+        ));
+    }
 
     if let Some(status) = footer_status(app) {
         footer_line_2_spans.push(Span::raw("  "));
@@ -332,5 +503,73 @@ mod tests {
             .push(("save".to_string(), "write failed".to_string()));
 
         assert_eq!(footer_status(&app), Some("write failed".to_string()));
+    }
+
+    #[test]
+    fn layout_for_width_thresholds() {
+        assert_eq!(layout_for_width(120), LayoutKind::ThreePane);
+        assert_eq!(layout_for_width(100), LayoutKind::ThreePane);
+        assert_eq!(layout_for_width(99), LayoutKind::TwoPane);
+        assert_eq!(layout_for_width(60), LayoutKind::TwoPane);
+        assert_eq!(layout_for_width(59), LayoutKind::Compact);
+        assert_eq!(layout_for_width(0), LayoutKind::Compact);
+    }
+
+    /// Headless smoke test: render at each layout tier and confirm no panic
+    /// (chunk-indexing or wrap math) reaches the user. Substitutes for an
+    /// interactive resize: we can't drive a real terminal from a unit test,
+    /// but we can prove the three code paths terminate normally.
+    fn render_at(width: u16, height: u16, mutate: impl FnOnce(&mut App)) {
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("create test terminal");
+        let mut app = App::new(
+            GhostConfig::default(),
+            String::new(),
+            PathBuf::from("/tmp/test.toml"),
+        );
+        mutate(&mut app);
+        terminal.draw(|f| super::render(f, &app)).expect("render");
+    }
+
+    #[test]
+    fn render_three_pane_at_120_cols_does_not_panic() {
+        render_at(120, 30, |_| {});
+    }
+
+    #[test]
+    fn render_two_pane_at_80_cols_does_not_panic() {
+        render_at(80, 24, |_| {});
+    }
+
+    #[test]
+    fn render_two_pane_with_preview_overlay_at_80_cols() {
+        render_at(80, 24, |app| app.show_preview = true);
+    }
+
+    #[test]
+    fn render_compact_at_50_cols_does_not_panic() {
+        render_at(50, 24, |_| {});
+    }
+
+    #[test]
+    fn render_compact_at_30_cols_does_not_panic() {
+        render_at(30, 24, |_| {});
+    }
+
+    #[test]
+    fn render_with_active_filter_does_not_panic() {
+        render_at(80, 24, |app| {
+            app.filter = Some("render".to_string());
+        });
+    }
+
+    #[test]
+    fn render_filter_input_prompt_does_not_panic() {
+        render_at(80, 24, |app| {
+            app.prompt = Some(Prompt::FilterInput);
+            app.filter = Some("ren".to_string());
+        });
     }
 }


### PR DESCRIPTION
## Summary
- `config edit` adapts: 3-pane at width >=100, 2-pane >=60, 1-pane below.
  Preview pane collapsible (`p`) at medium widths.
- Field list now uses `Paragraph::scroll` with offset state; PgUp/PgDn/
  Home/End scroll it. Long sections no longer silently clip.
- `/` opens a filter prompt; key + help substring matched
  case-insensitively. Esc clears.
- Footer shows "Matched N / M fields" while filtered.

## Test plan
- [x] `cargo test --workspace` green (all crates; tui crate alone runs 81 tests including 17 new ones).
- [x] `filter_narrows_field_list` and `scroll_offset_clamped_to_field_count`
      cover the new state.
- [x] Headless render smoke via `ratatui::backend::TestBackend` at 30, 50,
      80, 120 cols, plus the filtered + FilterInput prompt variants —
      every layout branch in `render()` exercised end-to-end.
- [ ] Manual smoke (resize a real terminal): not done by me; flagging
      explicitly per CLAUDE.md ("if you can't test the UI, say so
      explicitly rather than claiming success"). The 7 render smoke unit
      tests replace the no-panic side of the manual smoke; visual
      verification still wanted before merge.

## Coordination
- Disjoint from PR A (`tui/fields.rs` test mod append) and PR B
  (status.rs / main.rs / README.md / SECURITY.md). My only `fields.rs`
  reference is `all_fields()` reads from `App::new`, unchanged.
- Disjoint from phase 5 (gc-suggest providers, gc-pty handler, specs).