### PR TITLE
0.17 phase 4 / PR A: docs/config drift battery + .zshrc preservation

### DIFF
--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -2081,3 +2081,82 @@ auto_trigger = false
         assert_eq!(cfg.popup.render_block_ms, 0);
     }
 }
+
+#[cfg(test)]
+mod docs_drift_tests {
+    use super::all_field_paths;
+
+    /// Read docs/CONFIGURATION.md via the workspace root computed from
+    /// CARGO_MANIFEST_DIR (gc-config is at `<root>/crates/gc-config`,
+    /// so we go up two levels).
+    fn configuration_md() -> String {
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let root = manifest
+            .parent()
+            .expect("crates/")
+            .parent()
+            .expect("repo root");
+        let path = root.join("docs/CONFIGURATION.md");
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+    }
+
+    /// Decide whether a single field key is "documented" in CONFIGURATION.md.
+    ///
+    /// Accept any of three forms — all are how the docs reference fields:
+    ///   1. Markdown code span:        `key`
+    ///   2. TOML assignment with ws:   key = ...
+    ///   3. TOML assignment no ws:     key=...
+    ///
+    /// Bare prose matches don't count — many leaf keys (`background`,
+    /// `description`, `accept`) are common English and would false-positive
+    /// against unrelated docs text.
+    fn is_documented(doc: &str, key: &str) -> bool {
+        let backtick = format!("`{key}`");
+        let toml_eq_ws = format!("{key} =");
+        let toml_eq_tight = format!("{key}=");
+        doc.contains(&backtick) || doc.contains(&toml_eq_ws) || doc.contains(&toml_eq_tight)
+    }
+
+    /// Every schema field must be referenced in CONFIGURATION.md. This is
+    /// the actual drift guard — a section-only check would silently allow
+    /// a field to be removed from the docs as long as the section header
+    /// stayed.
+    #[test]
+    fn configuration_md_lists_every_field() {
+        let doc = configuration_md();
+        let mut missing: Vec<&str> = Vec::new();
+        for path in all_field_paths() {
+            let (_section, key) = path.rsplit_once('.').expect("dotted path");
+            if !is_documented(&doc, key) {
+                missing.push(path);
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "CONFIGURATION.md is missing these schema fields: {:#?}",
+            missing,
+        );
+    }
+
+    /// Section headers are a cheaper smoke check — useful if the field
+    /// test fails wholesale (entire section gone) to surface a clearer
+    /// failure first.
+    #[test]
+    fn configuration_md_mentions_every_section() {
+        let doc = configuration_md();
+        let sections = [
+            "[trigger]",
+            "[popup]",
+            "[suggest]",
+            "[suggest.providers]",
+            "[suggest.spec_cache]",
+            "[paths]",
+            "[keybindings]",
+            "[theme]",
+            "[experimental]",
+        ];
+        for s in sections {
+            assert!(doc.contains(s), "CONFIGURATION.md missing section {}", s);
+        }
+    }
+}

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -608,6 +608,76 @@ const DESC_BOX_MAX_WIDTH_CEILING: u16 = 200;
 const DESC_BOX_LINES_CEILING: u16 = 20;
 const DESC_BOX_DEBOUNCE_CEILING: u16 = 500;
 
+/// Returns every leaf field path in dotted form, e.g. `popup.render_block_ms`.
+/// Used by drift tests in `ghost-complete` to verify the install template,
+/// TUI editor metadata, and `docs/CONFIGURATION.md` hot-reload table stay
+/// in sync with the schema.
+///
+/// New schema fields MUST appear here. Adding via copy-paste from
+/// `GhostConfig` is acceptable; the cost of forgetting is a failing
+/// drift test, not a runtime bug.
+pub fn all_field_paths() -> Vec<&'static str> {
+    vec![
+        // [trigger]
+        "trigger.auto_chars",
+        "trigger.delay_ms",
+        "trigger.auto_trigger",
+        // [popup]
+        "popup.max_visible",
+        "popup.borders",
+        "popup.feedback_dismiss_ms",
+        "popup.spinner",
+        "popup.show_provider_errors",
+        "popup.render_block_ms",
+        "popup.min_width",
+        "popup.max_width",
+        "popup.description_box",
+        "popup.description_box_max_width",
+        "popup.description_box_lines",
+        "popup.description_box_debounce_ms",
+        // [suggest]
+        "suggest.max_results",
+        "suggest.max_history_results",
+        "suggest.generator_timeout_ms",
+        // [suggest.providers]
+        "suggest.providers.commands",
+        "suggest.providers.filesystem",
+        "suggest.providers.specs",
+        "suggest.providers.git",
+        "suggest.providers.js_runtime",
+        // [suggest.spec_cache]
+        "suggest.spec_cache.idle_ttl_secs",
+        "suggest.spec_cache.sweep_interval_secs",
+        "suggest.spec_cache.keep_warm",
+        "suggest.spec_cache.max_resident_mb",
+        // [paths]
+        "paths.spec_dirs",
+        // [keybindings] — 6 fields
+        "keybindings.accept",
+        "keybindings.accept_and_enter",
+        "keybindings.dismiss",
+        "keybindings.navigate_up",
+        "keybindings.navigate_down",
+        "keybindings.trigger",
+        // [theme] — 10 fields
+        "theme.preset",
+        "theme.selected",
+        "theme.description",
+        "theme.match_highlight",
+        "theme.item_text",
+        "theme.scrollbar",
+        "theme.border",
+        "theme.feedback_loading",
+        "theme.feedback_empty",
+        "theme.feedback_error",
+        // [experimental]
+        "experimental.multi_terminal",
+        "experimental.aws_sdk_provider",
+        "experimental.aws_sdk_fallback_to_cli",
+        "experimental.brew_search_cap",
+    ]
+}
+
 impl GhostConfig {
     /// Clamp config values to sane bounds, logging warnings when clamping.
     ///
@@ -869,6 +939,38 @@ fn diff_unknown_keys(
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn all_field_paths_covers_every_section() {
+        let paths = all_field_paths();
+        let expected_sections = &[
+            "trigger.",
+            "popup.",
+            "suggest.",
+            "suggest.providers.",
+            "suggest.spec_cache.",
+            "paths.",
+            "keybindings.",
+            "theme.",
+            "experimental.",
+        ];
+        for prefix in expected_sections {
+            assert!(
+                paths.iter().any(|p| p.starts_with(prefix)),
+                "missing section: {}",
+                prefix,
+            );
+        }
+    }
+
+    #[test]
+    fn all_field_paths_includes_render_block_ms() {
+        let paths = all_field_paths();
+        assert!(paths.contains(&"popup.render_block_ms"));
+        assert!(paths.contains(&"suggest.providers.js_runtime"));
+        assert!(paths.contains(&"experimental.brew_search_cap"));
+        assert!(paths.contains(&"suggest.spec_cache.idle_ttl_secs"));
+    }
 
     #[test]
     fn test_default_config_matches_hardcoded() {

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -47,6 +47,7 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # feedback_dismiss_ms = 1200  # Empty/error feedback auto-dismiss delay; 0 disables
 # spinner = true  # Animate async Loading feedback in wide popups
 # show_provider_errors = false  # Set true to show provider names in error feedback
+# render_block_ms = 80  # Pre-paint window (ms, 0-300); 0 paints immediately, higher races fast async generators into the first frame
 # min_width = 20  # Lower bound for popup width; clamped to [10, 500]
 # max_width = 60  # Upper bound for popup width; clamped to [min_width, 500]
 # description_box = \"off\"  # \"off\" for inline descriptions, \"side\" for wrapped adjacent box
@@ -64,6 +65,16 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # filesystem = true
 # specs = true
 # git = true
+# js_runtime = true  # Master kill switch for the QuickJS evaluator backing requires_js generators; restart required
+
+# [suggest.spec_cache]
+# idle_ttl_secs = 0  # Seconds idle before a parsed spec is evicted; 0 disables eviction
+# sweep_interval_secs = 60  # Background sweep cadence (seconds); ignored when idle_ttl_secs = 0
+# keep_warm = []  # Spec names (filename stem) that are never evicted; e.g. [\"git\", \"docker\"]
+# max_resident_mb = 0  # LRU backstop in MB after TTL eviction; 0 disables
+
+# [paths]
+# spec_dirs = []  # Additional spec source directories searched at startup (highest precedence first)
 
 # [keybindings]
 # accept = \"tab\"
@@ -89,6 +100,7 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # multi_terminal = false  # Set to true to enable unsupported/unknown terminals
 # aws_sdk_provider = false  # Opt in to native AWS SDK completions; may make outbound AWS calls
 # aws_sdk_fallback_to_cli = true  # Fall back to the aws CLI when SDK completions cannot run
+# brew_search_cap = 1000  # Cap on `brew search \"\"` results before fuzzy ranking; raise for unfiltered exploration
 ";
 
 pub(crate) const INIT_BEGIN: &str = "# >>> ghost-complete initialize >>>";

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -526,14 +526,22 @@ fn install_to_with_cache_hooks(
     let (content, _) = remove_block(&existing, INIT_BEGIN, INIT_END);
     let (content, _) = remove_block(&content, SHELL_BEGIN, SHELL_END);
 
-    // 5. Prepend init block, append shell integration block
-    let content = content.trim().to_string();
+    // 5. Prepend init block, append shell integration block.
+    // We preserve user .zshrc bytes outside managed blocks byte-for-byte:
+    // do NOT trim() the deduped middle, and only add a trailing newline
+    // when the user's content does not already end with one. Reinstalls
+    // are byte-identical to first installs because remove_block consumes
+    // one trailing '\n' after each managed block, mirroring the single
+    // '\n' that this code inserts between init_block and the middle.
+    // See install_preserves_user_blank_lines_around_managed_blocks.
     let mut new_zshrc = String::new();
     new_zshrc.push_str(&init_block(&init_path));
     new_zshrc.push('\n');
     if !content.is_empty() {
         new_zshrc.push_str(&content);
-        new_zshrc.push('\n');
+        if !content.ends_with('\n') {
+            new_zshrc.push('\n');
+        }
     }
     new_zshrc.push_str(&shell_integration_block(&script_path));
     new_zshrc.push('\n');
@@ -1136,6 +1144,55 @@ mod tests {
         let shell_pos = content.find(SHELL_BEGIN).unwrap();
         assert!(init_pos < user_pos);
         assert!(user_pos < shell_pos);
+    }
+
+    #[test]
+    fn install_preserves_user_blank_lines_around_managed_blocks() {
+        let tmp = TempDir::new().unwrap();
+        let zshrc = tmp.path().join(".zshrc");
+        let user_content = "\n\n# top comment\n\nalias g=git\n\n\n# bottom comment\n\n";
+        fs::write(&zshrc, user_content).unwrap();
+
+        let cfg_dir = tmp.path().join(".config/ghost-complete");
+        fs::create_dir_all(&cfg_dir).unwrap();
+
+        install_to(&zshrc, &cfg_dir, false).expect("install");
+
+        let after = fs::read_to_string(&zshrc).unwrap();
+
+        let after_init_end =
+            after.find(INIT_END).expect("init end marker present") + INIT_END.len();
+        let user_region =
+            &after[after_init_end..after.find(SHELL_BEGIN).expect("shell begin marker present")];
+        assert!(
+            user_region.contains("# top comment")
+                && user_region.contains("alias g=git")
+                && user_region.contains("# bottom comment"),
+            "user content survived in middle region:\n{user_region}",
+        );
+
+        // The user's leading and trailing blank lines must survive verbatim.
+        // `.trim()` on user content destroyed them on first install AND on
+        // every reinstall. Look for the original "\n\n# top comment" and
+        // "# bottom comment\n\n" framing inside the middle region.
+        assert!(
+            user_region.contains("\n\n# top comment"),
+            "leading blank line before user content lost:\n{user_region:?}",
+        );
+        assert!(
+            user_region.contains("# bottom comment\n\n"),
+            "trailing blank line after user content lost:\n{user_region:?}",
+        );
+
+        // Reinstall should not accumulate blank lines around the managed blocks.
+        install_to(&zshrc, &cfg_dir, false).expect("reinstall");
+        let after2 = fs::read_to_string(&zshrc).unwrap();
+        let triple_blank = after2.matches("\n\n\n").count();
+        let original_triple = after.matches("\n\n\n").count();
+        assert!(
+            triple_blank <= original_triple + 1,
+            "reinstall accumulated blank lines: original={original_triple}, after={triple_blank}",
+        );
     }
 
     #[test]

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -1673,3 +1673,27 @@ mod tests {
         assert_eq!(entries.len(), 1);
     }
 }
+
+#[cfg(test)]
+mod drift_tests {
+    use super::DEFAULT_CONFIG_TOML;
+    use gc_config::all_field_paths;
+
+    #[test]
+    fn install_template_contains_every_schema_field() {
+        let mut missing = Vec::new();
+        for path in all_field_paths() {
+            let (_section, key) = path.rsplit_once('.').expect("dotted path");
+            // Field is "present" if its bare key appears in the template
+            // (commented-out lines count — the template is documentation).
+            if !DEFAULT_CONFIG_TOML.contains(key) {
+                missing.push(path);
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "install template missing keys: {:#?}",
+            missing,
+        );
+    }
+}

--- a/crates/ghost-complete/src/tui/fields.rs
+++ b/crates/ghost-complete/src/tui/fields.rs
@@ -651,3 +651,28 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod drift_tests {
+    use super::all_fields;
+    use gc_config::all_field_paths;
+
+    #[test]
+    fn tui_editor_metadata_contains_every_schema_field() {
+        let editor_keys: Vec<String> = all_fields()
+            .iter()
+            .map(|f| format!("{}.{}", f.section, f.key))
+            .collect();
+        let mut missing = Vec::new();
+        for path in all_field_paths() {
+            if !editor_keys.iter().any(|k| k == path) {
+                missing.push(path);
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "TUI editor missing keys: {:#?}",
+            missing,
+        );
+    }
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -411,6 +411,7 @@ match_highlight = "underline"
 | `[popup]` | `max_visible`, `borders`, `feedback_dismiss_ms`, `spinner`, `show_provider_errors`, `render_block_ms`, `min_width`, `max_width`, `description_box`, `description_box_max_width`, `description_box_lines`, `description_box_debounce_ms` | Yes |
 | `[suggest]` | All fields | No |
 | `[suggest.providers]` | All fields | No |
+| `[suggest.spec_cache]` | All fields | No |
 | `[paths]` | All fields | No |
 | `[experimental]` | All fields | No |
 


### PR DESCRIPTION
## Summary
- Adds `gc_config::all_field_paths()` catalog (Task 1).
- New drift tests pin install template, TUI editor, and CONFIGURATION.md
  against the GhostConfig schema (Task 2; in-crate per binary-crate
  constraint).
- Install template backfilled with `popup.render_block_ms`,
  `suggest.providers.js_runtime`, full `[suggest.spec_cache]`, `[paths]`,
  and `experimental.brew_search_cap` (Task 3).
- `install.rs:518` `content.trim()` replaced with a splice helper that
  preserves user `.zshrc` bytes outside managed blocks (Task 4).
- CONFIGURATION.md backfilled for every field caught by the drift test;
  hot-reload table audited against `ReloadBehavior` enum (Task 8).
- `render_block_ms` left as `Live` — rendering-polish (#138) wired it
  through `update_config`, so docs/editor are now truthful.

## Test plan
- [x] `cargo test --workspace` green.
- [x] All four drift tests green: install template, TUI editor, docs
      field-level, docs section smoke.
- [x] `install_preserves_user_blank_lines_around_managed_blocks` exercises
      install + reinstall, asserts no blank-line accumulation.
- [x] `cargo run -- install --dry-run` shows every schema key in the
      generated template.

## Notes for the reviewer

**Verified state corrections vs. the 2026-05-16 plan snapshot:**
- `content.trim()` was actually at `install.rs:518`, not the plan's :505 reference.
- `render_block_ms` IS wired through `InputHandler::update_config` (see
  `crates/gc-pty/src/handler.rs:763` — 13th positional parameter). Task 8
  Steps 3-5 (the demotion logic in the plan) are therefore intentionally
  skipped; docs + editor now match reality.
- Plan's `keybindings.*` (6 fields) and `theme.*` (10 fields) listings had
  stale names; `gc_config::all_field_paths()` uses the actual struct field
  names (`accept_and_enter`, `navigate_up`, `navigate_down`, `trigger`,
  `preset`, `feedback_loading/empty/error`, etc.) — 48 total leaf paths.

**Implementation deviation in Task 4:** The plan's `splice_managed_blocks` +
`replace_or_append_block` helpers would have placed the init block at the
*bottom* of a fresh `.zshrc` (no prepend semantics in `replace_or_append`).
Took the minimal fix instead: remove `.trim()` and guard the trailing newline
insertion so idempotent reinstalls are byte-identical to the first install.
Same byte-preservation guarantee, no new helpers, no risk to the existing
init-at-top / shell-at-bottom convention. The new test
`install_preserves_user_blank_lines_around_managed_blocks` is the contract.

**CONFIGURATION.md backfill turned out trivially small:** the field-level and
section-level docs drift tests both passed on first run — every key already
appears as a backtick code span or TOML assignment. The only hot-reload table
gap was a missing `[suggest.spec_cache]` row, fixed in Task 8.

## Coordination notes
- PR B (status --verbose, README, SECURITY) touches separate files; no
  conflict expected.
- PR C (TUI ergonomics) touches `tui/{ui,app,editor}.rs` and may add filter
  state to `tui/fields.rs` runtime code. My touch on `tui/fields.rs` is a
  bottom-of-file `#[cfg(test)] mod drift_tests` only — should auto-merge.
  If conflicts arise, the test module is the dropper-in.
- Phase 5 (macos-smart-completions) is running in parallel. Their file
  touch set (`gc-suggest/*`, `handler.rs:1268-1276/2840-2856`, `specs/*.json`,
  fig-converter, PROVIDERS.md) does NOT intersect this PR. The drift
  tests this PR ships are the contract: if phase 5 ever adds a
  `GhostConfig` field, they must extend `all_field_paths()`, the install
  template, the TUI editor metadata, and CONFIGURATION.md in lockstep.
  The forward contract on `all_field_paths()`'s doc comment makes this
  explicit.