### PR TITLE
feat(suggest): add substring match mode for completion filter (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+
+- **Substring match mode** for the suggestion filter: set
+  `suggest.match_mode = "substring"` to require the typed characters to appear
+  contiguously (`cl` → `clone`/`include`, not `calendar`) instead of the
+  default fuzzy subsequence matching. Space-separated words are matched as
+  independent substrings. Configurable via `config.toml` or the TUI editor;
+  requires a restart (#149).
 
 ## [0.17.0] - 2026-06-07
 

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -1115,6 +1115,29 @@ match_mode = "substring"
     }
 
     #[test]
+    fn match_mode_rejects_unknown_variant() {
+        // An invalid match_mode must fail deserialization (an `unknown variant`
+        // serde error) rather than being silently defaulted — this pins the
+        // rejection contract so a future `#[serde(other)]` or variant rename
+        // can't quietly swallow a typo and take the proxy down on load.
+        let toml = r#"
+[suggest]
+match_mode = "contiguous"
+"#;
+        let result = toml::from_str::<GhostConfig>(toml);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("unknown variant"),
+            "expected an `unknown variant` error, got: {err}"
+        );
+        assert!(
+            err.contains("fuzzy") && err.contains("substring"),
+            "error should list the valid variants, got: {err}"
+        );
+    }
+
+    #[test]
     fn spec_cache_deserializes_from_toml() {
         let toml = r#"
 [suggest.spec_cache]

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -212,6 +212,23 @@ impl Default for PopupConfig {
     }
 }
 
+/// How the typed query filters and ranks candidates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MatchMode {
+    /// Subsequence fuzzy matching: the typed characters must appear in order
+    /// but need not be adjacent — `gco` matches `git checkout`. This is the
+    /// default and preserves the historical behavior.
+    #[default]
+    Fuzzy,
+    /// Contiguous substring matching: the typed characters must appear
+    /// together, in order — `cl` matches `clone` and `include`, but not
+    /// `calendar`. Space-separated words are matched as independent
+    /// substrings (every word must be present). Less noisy and marginally
+    /// faster than fuzzy on large candidate pools.
+    Substring,
+}
+
 /// Behavior for the optional adjacent description box.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -249,6 +266,12 @@ pub struct SuggestConfig {
     /// stalled generator does not keep the loading indicator spinning
     /// indefinitely. Default: 5000 ms.
     pub generator_timeout_ms: u64,
+    /// How the typed query filters candidates: `fuzzy` (subsequence, default)
+    /// or `substring` (contiguous). See [`MatchMode`].
+    ///
+    /// **Hot-reload:** Changes require a proxy restart — the value is baked
+    /// into the `SuggestionEngine` at builder time alongside `max_results`.
+    pub match_mode: MatchMode,
     pub providers: ProvidersConfig,
     pub spec_cache: SpecCacheConfig,
 }
@@ -259,6 +282,7 @@ impl Default for SuggestConfig {
             max_results: 50,
             max_history_results: 5,
             generator_timeout_ms: 5000,
+            match_mode: MatchMode::default(),
             providers: ProvidersConfig::default(),
             spec_cache: SpecCacheConfig::default(),
         }
@@ -639,6 +663,7 @@ pub fn all_field_paths() -> Vec<&'static str> {
         "suggest.max_results",
         "suggest.max_history_results",
         "suggest.generator_timeout_ms",
+        "suggest.match_mode",
         // [suggest.providers]
         "suggest.providers.commands",
         "suggest.providers.filesystem",
@@ -1053,6 +1078,40 @@ max_visible = 5
     fn suggest_config_includes_spec_cache_with_defaults() {
         let config = SuggestConfig::default();
         assert_eq!(config.spec_cache.idle_ttl_secs, 0);
+    }
+
+    #[test]
+    fn match_mode_defaults_to_fuzzy() {
+        let config = SuggestConfig::default();
+        assert_eq!(config.match_mode, MatchMode::Fuzzy);
+    }
+
+    #[test]
+    fn match_mode_deserializes_from_toml() {
+        let toml = r#"
+[suggest]
+match_mode = "substring"
+"#;
+        let parsed: GhostConfig = toml::from_str(toml).unwrap();
+        assert_eq!(parsed.suggest.match_mode, MatchMode::Substring);
+    }
+
+    #[test]
+    fn match_mode_round_trips_through_serialization() {
+        // The two-pass loader serializes the strict view back to TOML; a
+        // non-default match_mode must survive that round-trip without being
+        // flagged as an unknown key.
+        let config = GhostConfig {
+            suggest: SuggestConfig {
+                match_mode: MatchMode::Substring,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(serialized.contains("match_mode = \"substring\""));
+        let reparsed: GhostConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.suggest.match_mode, MatchMode::Substring);
     }
 
     #[test]

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -740,6 +740,52 @@ impl InputHandler {
         }
     }
 
+    /// Set the query match strategy (fuzzy subsequence vs contiguous
+    /// substring) on the underlying engine. Builder-time only — must run
+    /// before the engine `Arc` is shared, like [`Self::with_suggest_config`].
+    pub fn with_match_mode(self, mode: gc_config::MatchMode) -> Self {
+        let engine = Arc::try_unwrap(self.engine)
+            .unwrap_or_else(|_| {
+                panic!("internal invariant: engine Arc was captured by shared reference")
+            })
+            .with_match_mode(mode);
+        Self {
+            engine: Arc::new(engine),
+            ..self
+        }
+    }
+
+    /// Re-rank a merged candidate `pool` against the live typed `word`.
+    ///
+    /// Shared by the two async merge paths (the bounded-block first paint and
+    /// `try_merge_dynamic`) so both honor the engine's [`MatchMode`] identically
+    /// — keeping them in lockstep instead of duplicating the branch at each
+    /// call site.
+    ///
+    /// An empty `word` keeps the FULL pool ordered by priority then text:
+    /// truncating on an empty query would alphabetically evict high-value
+    /// candidates from large dynamic pools (see the long rationale in
+    /// `try_merge_dynamic`), so a later non-empty re-rank can still recover
+    /// late arrivals. A non-empty `word` filters and ranks under the engine's
+    /// configured match mode, capped at `max_visible * 5`.
+    fn rerank_live(&self, word: &str, mut pool: Vec<Suggestion>) -> Vec<Suggestion> {
+        if word.is_empty() {
+            pool.sort_by(|a, b| {
+                gc_suggest::priority::effective(b)
+                    .cmp(&gc_suggest::priority::effective(a))
+                    .then_with(|| a.text.cmp(&b.text))
+            });
+            pool
+        } else {
+            gc_suggest::fuzzy::rank_with_mode(
+                word,
+                pool,
+                self.max_visible * 5,
+                self.engine.match_mode(),
+            )
+        }
+    }
+
     /// Update runtime-configurable fields without restarting the proxy.
     /// Called by the config file watcher when config.toml changes on disk.
     /// Returns cleanup bytes to write to stdout (e.g. popup clear on
@@ -1791,22 +1837,8 @@ impl InputHandler {
         all.extend(extras);
         // Mirror try_merge_dynamic: rank against the LIVE query so a
         // user keystroke during the bounded wait re-filters the pool
-        // instead of ranking against the stale spawn-time word. When the
-        // user has typed nothing we keep the full pool sorted by priority
-        // (truncating with an empty query would alphabetically evict
-        // high-value candidates from large dynamic pools — see the long
-        // comment in try_merge_dynamic). When they have typed, fuzzy rank
-        // against the query and cap at max_visible * 5.
-        all = if live_word.is_empty() {
-            all.sort_by(|a, b| {
-                gc_suggest::priority::effective(b)
-                    .cmp(&gc_suggest::priority::effective(a))
-                    .then_with(|| a.text.cmp(&b.text))
-            });
-            all
-        } else {
-            gc_suggest::fuzzy::rank(&live_word, all, self.max_visible * 5)
-        };
+        // instead of ranking against the stale spawn-time word.
+        let all = self.rerank_live(&live_word, all);
 
         self.replace_suggestions_and_reset_overlay(all);
         self.visible = true;
@@ -2264,19 +2296,7 @@ impl InputHandler {
             let extras = merge_dedup_against(&self.suggestions, dynamic_results);
             self.suggestions.extend(extras);
             let merged = std::mem::take(&mut self.suggestions);
-            // Empty query: keep the full pool untruncated so a non-empty re-rank can still recover late candidates.
-            self.suggestions = if current_word.is_empty() {
-                // Re-sort so higher-priority dynamic arrivals outrank residual sync items.
-                let mut m = merged;
-                m.sort_by(|a, b| {
-                    gc_suggest::priority::effective(b)
-                        .cmp(&gc_suggest::priority::effective(a))
-                        .then_with(|| a.text.cmp(&b.text))
-                });
-                m
-            } else {
-                gc_suggest::fuzzy::rank(&current_word, merged, self.max_visible * 5)
-            };
+            self.suggestions = self.rerank_live(&current_word, merged);
             // The rerank above reorders self.suggestions in place, so any
             // displayed_detail_idx captured pre-rerank now points at a
             // different suggestion. Clear the debounce state so a stale
@@ -4218,6 +4238,69 @@ mod tests {
         let mut h = make_visible_handler(vec![suggestion]);
         h.overlay.selected = Some(0);
         h
+    }
+
+    #[test]
+    fn rerank_live_honors_substring_match_mode() {
+        // The live keystroke filter (issue #149) runs through rerank_live,
+        // shared by both async merge paths. In Substring mode a candidate that
+        // only matches as a subsequence ("calendar" for "cl") must be dropped;
+        // the contiguous match ("clone") survives. This guards against either
+        // merge site silently reverting to fuzzy-only ranking.
+        use gc_config::MatchMode;
+
+        let substring = make_handler().with_match_mode(MatchMode::Substring);
+        let ranked = substring.rerank_live(
+            "cl",
+            vec![
+                command_suggestion("clone", None),
+                command_suggestion("calendar", None),
+            ],
+        );
+        let texts: Vec<&str> = ranked.iter().map(|s| s.text.as_str()).collect();
+        assert!(
+            texts.contains(&"clone"),
+            "contiguous 'cl' must survive substring mode: {texts:?}"
+        );
+        assert!(
+            !texts.contains(&"calendar"),
+            "subsequence-only 'c..l' must be dropped in substring mode: {texts:?}"
+        );
+
+        // Contrast: the default fuzzy handler keeps the subsequence match.
+        let fuzzy = make_handler();
+        let ranked = fuzzy.rerank_live(
+            "cl",
+            vec![
+                command_suggestion("clone", None),
+                command_suggestion("calendar", None),
+            ],
+        );
+        let texts: Vec<&str> = ranked.iter().map(|s| s.text.as_str()).collect();
+        assert!(
+            texts.contains(&"calendar"),
+            "default fuzzy mode keeps the c..l subsequence: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn rerank_live_empty_word_keeps_full_pool_ordered() {
+        // Empty word must neither filter nor truncate — the full pool is
+        // preserved, ordered by priority then text. Guards the empty-query
+        // branch both merge paths share.
+        let handler = make_handler();
+        let ranked = handler.rerank_live(
+            "",
+            vec![
+                command_suggestion("zebra", None),
+                command_suggestion("alpha", None),
+            ],
+        );
+        assert_eq!(ranked.len(), 2, "empty word keeps every candidate");
+        assert_eq!(
+            ranked[0].text, "alpha",
+            "equal-priority candidates fall back to alphabetical order"
+        );
     }
 
     #[test]

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -764,10 +764,9 @@ impl InputHandler {
     ///
     /// An empty `word` keeps the FULL pool ordered by priority then text:
     /// truncating on an empty query would alphabetically evict high-value
-    /// candidates from large dynamic pools (see the long rationale in
-    /// `try_merge_dynamic`), so a later non-empty re-rank can still recover
-    /// late arrivals. A non-empty `word` filters and ranks under the engine's
-    /// configured match mode, capped at `max_visible * 5`.
+    /// candidates from large dynamic pools, so a later non-empty re-rank can
+    /// still recover late arrivals. A non-empty `word` filters and ranks under
+    /// the engine's configured match mode, capped at `max_visible * 5`.
     fn rerank_live(&self, word: &str, mut pool: Vec<Suggestion>) -> Vec<Suggestion> {
         if word.is_empty() {
             pool.sort_by(|a, b| {

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -228,6 +228,7 @@ pub async fn run_proxy(shell: &OsStr, args: &[OsString], config: &GhostConfig) -
                 config.suggest.providers.js_runtime,
                 config.suggest.generator_timeout_ms,
             )
+            .with_match_mode(config.suggest.match_mode)
             .with_aws_sdk_config(
                 config.experimental.aws_sdk_provider,
                 config.experimental.aws_sdk_fallback_to_cli,

--- a/crates/gc-suggest/src/engine.rs
+++ b/crates/gc-suggest/src/engine.rs
@@ -358,6 +358,10 @@ pub struct SuggestionEngine {
     frecency_db: FrecencyDb,
     max_results: usize,
     max_history_results: usize,
+    /// Match strategy applied by every `fuzzy::rank_with_mode` call in this
+    /// engine (fuzzy subsequence vs contiguous substring). Mirrors
+    /// `SuggestConfig::match_mode` from `gc-config`.
+    match_mode: fuzzy::MatchMode,
     providers_commands: bool,
     providers_filesystem: bool,
     providers_specs: bool,
@@ -407,6 +411,7 @@ impl SuggestionEngine {
             frecency_db: FrecencyDb::load(),
             max_results: fuzzy::DEFAULT_MAX_RESULTS,
             max_history_results: 5,
+            match_mode: fuzzy::MatchMode::Fuzzy,
             providers_commands: true,
             providers_filesystem: true,
             providers_specs: true,
@@ -450,6 +455,19 @@ impl SuggestionEngine {
         self
     }
 
+    /// Set the query match strategy (fuzzy subsequence vs contiguous
+    /// substring). Baked at builder time; a change requires a proxy restart.
+    pub fn with_match_mode(mut self, mode: fuzzy::MatchMode) -> Self {
+        self.match_mode = mode;
+        self
+    }
+
+    /// The active query match strategy. Read by the PTY handler so its live
+    /// re-rank on keystrokes uses the same mode as the engine's own ranking.
+    pub fn match_mode(&self) -> fuzzy::MatchMode {
+        self.match_mode
+    }
+
     /// Test/bench constructor — inject providers directly for deterministic setup.
     pub fn with_providers(
         spec_store: SpecStore,
@@ -470,6 +488,7 @@ impl SuggestionEngine {
             frecency_db: FrecencyDb::empty(),
             max_results: fuzzy::DEFAULT_MAX_RESULTS,
             max_history_results: 5,
+            match_mode: fuzzy::MatchMode::Fuzzy,
             providers_commands: true,
             providers_filesystem: true,
             providers_specs: true,
@@ -1009,10 +1028,11 @@ impl SuggestionEngine {
         // higher under an extended query (e.g. mid-word `h` scoring low for
         // `"h"` but a contiguous mid-word `ho` scoring high for `"ho"`).
         // Full correctness here also requires Option B.
-        Ok(fuzzy::rank(
+        Ok(fuzzy::rank_with_mode(
             &ctx.current_word,
             all_results,
             MAX_DYNAMIC_CANDIDATES,
+            self.match_mode,
         ))
     }
 
@@ -1046,7 +1066,12 @@ impl SuggestionEngine {
         // guarantee false negatives past position ~1000 in large
         // monorepos. See `run_generators` for the full rationale and the
         // known edge-case limitation.
-        Ok(fuzzy::rank(query, all, MAX_DYNAMIC_CANDIDATES))
+        Ok(fuzzy::rank_with_mode(
+            query,
+            all,
+            MAX_DYNAMIC_CANDIDATES,
+            self.match_mode,
+        ))
     }
 
     /// Resolve native providers asynchronously. Mirrors `resolve_git`:
@@ -1093,7 +1118,12 @@ impl SuggestionEngine {
         if query.is_empty() {
             return Ok(all);
         }
-        Ok(fuzzy::rank(query, all, MAX_DYNAMIC_CANDIDATES))
+        Ok(fuzzy::rank_with_mode(
+            query,
+            all,
+            MAX_DYNAMIC_CANDIDATES,
+            self.match_mode,
+        ))
     }
 
     /// Resolve each provider resolution independently and preserve the
@@ -1132,7 +1162,12 @@ impl SuggestionEngine {
         if query.is_empty() {
             return Ok(suggestions);
         }
-        Ok(fuzzy::rank(query, suggestions, MAX_DYNAMIC_CANDIDATES))
+        Ok(fuzzy::rank_with_mode(
+            query,
+            suggestions,
+            MAX_DYNAMIC_CANDIDATES,
+            self.match_mode,
+        ))
     }
 
     /// Per-kind variant of [`Self::resolve_providers`] that surfaces errors instead of logging-and-swallowing.
@@ -1159,7 +1194,12 @@ impl SuggestionEngine {
         if query.is_empty() {
             return Ok(suggestions);
         }
-        Ok(fuzzy::rank(query, suggestions, MAX_DYNAMIC_CANDIDATES))
+        Ok(fuzzy::rank_with_mode(
+            query,
+            suggestions,
+            MAX_DYNAMIC_CANDIDATES,
+            self.match_mode,
+        ))
     }
 
     /// Convenience method that resolves the spec and runs script generators.
@@ -1694,7 +1734,12 @@ impl SuggestionEngine {
             .min(self.max_history_results);
         let normal_budget = self.max_results.saturating_sub(reserved_history);
 
-        let mut results = fuzzy::rank(&ctx.current_word, candidates, normal_budget);
+        let mut results = fuzzy::rank_with_mode(
+            &ctx.current_word,
+            candidates,
+            normal_budget,
+            self.match_mode,
+        );
 
         // History fuzzy-fill: with `normal_budget` shrunk above, there is
         // now at least `reserved_history` extra room for the entries that
@@ -1705,7 +1750,12 @@ impl SuggestionEngine {
                 .max_history_results
                 .min(self.max_results.saturating_sub(results.len()));
             if remaining > 0 {
-                results.extend(fuzzy::rank(buffer, history_entries, remaining));
+                results.extend(fuzzy::rank_with_mode(
+                    buffer,
+                    history_entries,
+                    remaining,
+                    self.match_mode,
+                ));
             }
         }
 
@@ -4653,6 +4703,49 @@ mod tests {
         assert_eq!(
             history_count, 2,
             "two prefix-matching history entries must survive: {results:?}"
+        );
+    }
+
+    #[test]
+    fn engine_substring_mode_drops_subsequence_only_candidates() {
+        // Issue #149 end-to-end: with match_mode = Substring the engine's
+        // rank_with_history must drop a candidate that only matches the query
+        // as a subsequence ("calendar" for "cl") while keeping the contiguous
+        // match ("clone"). The default fuzzy engine keeps both.
+        use crate::fuzzy::MatchMode;
+        let engine = SuggestionEngine::with_providers(
+            SpecStore::load_from_dir(&spec_dir()).unwrap().store,
+            HistoryProvider::from_entries(vec![]),
+            CommandsProvider::from_list(vec![]),
+        )
+        .with_match_mode(MatchMode::Substring);
+        assert_eq!(engine.match_mode(), MatchMode::Substring);
+
+        let ctx = make_ctx(Some("git"), vec![], "cl", 1);
+        let candidates = vec![
+            Suggestion {
+                text: "clone".into(),
+                kind: SuggestionKind::Subcommand,
+                source: SuggestionSource::Spec,
+                ..Default::default()
+            },
+            Suggestion {
+                text: "calendar".into(),
+                kind: SuggestionKind::Subcommand,
+                source: SuggestionSource::Spec,
+                ..Default::default()
+            },
+        ];
+        let results =
+            engine.rank_with_history(&ctx, Path::new("/tmp"), "git cl", candidates, false);
+        let texts: Vec<&str> = results.iter().map(|s| s.text.as_str()).collect();
+        assert!(
+            texts.contains(&"clone"),
+            "contiguous 'cl' match must survive: {texts:?}"
+        );
+        assert!(
+            !texts.contains(&"calendar"),
+            "subsequence-only 'c..l' must be dropped in substring mode: {texts:?}"
         );
     }
 

--- a/crates/gc-suggest/src/fuzzy.rs
+++ b/crates/gc-suggest/src/fuzzy.rs
@@ -77,7 +77,8 @@ pub fn rank_with_mode(
     // History is partitioned to the bottom regardless of fuzzy score so a
     // boosted history match can never outrank domain content. The two
     // merge paths in `gc-pty/src/handler.rs` that bypass `rank_with_history`
-    // and call `rank` directly depend on this guarantee.
+    // and rank via `rerank_live` (which calls `rank_with_mode`) depend on
+    // this guarantee.
     suggestions.sort_by(|a, b| {
         let a_hist = a.source == SuggestionSource::History;
         let b_hist = b.source == SuggestionSource::History;

--- a/crates/gc-suggest/src/fuzzy.rs
+++ b/crates/gc-suggest/src/fuzzy.rs
@@ -4,9 +4,41 @@ use nucleo::{Config, Matcher, Utf32String};
 use crate::priority;
 use crate::types::{Suggestion, SuggestionSource};
 
+/// How the typed query filters candidates. Re-exported from `gc-config` so
+/// callers in this crate (and the PTY handler) can pass it to [`rank_with_mode`]
+/// without depending on `gc-config` directly.
+pub use gc_config::MatchMode;
+
 pub const DEFAULT_MAX_RESULTS: usize = 50;
 
-pub fn rank(query: &str, mut suggestions: Vec<Suggestion>, max_results: usize) -> Vec<Suggestion> {
+/// Map a [`MatchMode`] to the corresponding nucleo atom kind.
+fn atom_kind(mode: MatchMode) -> AtomKind {
+    match mode {
+        MatchMode::Fuzzy => AtomKind::Fuzzy,
+        MatchMode::Substring => AtomKind::Substring,
+    }
+}
+
+/// Rank `suggestions` against `query` using the default fuzzy (subsequence)
+/// match mode. Thin wrapper over [`rank_with_mode`] preserved for callers and
+/// tests that always want fuzzy matching.
+pub fn rank(query: &str, suggestions: Vec<Suggestion>, max_results: usize) -> Vec<Suggestion> {
+    rank_with_mode(query, suggestions, max_results, MatchMode::Fuzzy)
+}
+
+/// Rank `suggestions` against `query` under the given [`MatchMode`].
+///
+/// In [`MatchMode::Substring`] only candidates that contain the typed
+/// characters as a contiguous run survive; in [`MatchMode::Fuzzy`] the
+/// characters may be spread out as a subsequence. Either way the surviving
+/// candidates are sorted by `(history-last, score, priority, text)` and
+/// truncated to `max_results`.
+pub fn rank_with_mode(
+    query: &str,
+    mut suggestions: Vec<Suggestion>,
+    max_results: usize,
+    mode: MatchMode,
+) -> Vec<Suggestion> {
     if query.is_empty() {
         // Empty query: priority alone determines order (score is 0 for all).
         suggestions.sort_by(|a, b| {
@@ -22,7 +54,7 @@ pub fn rank(query: &str, mut suggestions: Vec<Suggestion>, max_results: usize) -
         query,
         CaseMatching::Smart,
         Normalization::Smart,
-        AtomKind::Fuzzy,
+        atom_kind(mode),
     );
     let mut matcher = Matcher::new(Config::DEFAULT);
     let mut indices_buf = Vec::new();
@@ -177,6 +209,109 @@ mod tests {
         let items = vec![make("checkout")];
         let result = rank("", items, DEFAULT_MAX_RESULTS);
         assert!(result[0].match_indices.is_empty());
+    }
+
+    #[test]
+    fn test_substring_excludes_subsequence_only_matches() {
+        // The issue #149 case: typing "cl" should keep only candidates that
+        // contain "cl" contiguously, not every word that has a 'c' and an 'l'
+        // somewhere.
+        let items = vec![make("clone"), make("include"), make("calendar")];
+        let result = rank_with_mode("cl", items, DEFAULT_MAX_RESULTS, MatchMode::Substring);
+        let texts: Vec<&str> = result.iter().map(|s| s.text.as_str()).collect();
+        assert!(texts.contains(&"clone"), "clone contains 'cl'");
+        assert!(texts.contains(&"include"), "include contains 'cl'");
+        assert!(
+            !texts.contains(&"calendar"),
+            "calendar has c..l as a subsequence but not 'cl' contiguously"
+        );
+    }
+
+    #[test]
+    fn test_fuzzy_keeps_subsequence_matches_substring_drops() {
+        // Same candidate set, contrasting the two modes: fuzzy keeps the
+        // subsequence-only "calendar", substring drops it.
+        let fuzzy = rank_with_mode(
+            "cl",
+            vec![make("calendar")],
+            DEFAULT_MAX_RESULTS,
+            MatchMode::Fuzzy,
+        );
+        assert_eq!(fuzzy.len(), 1, "fuzzy keeps c..l subsequence");
+
+        let substring = rank_with_mode(
+            "cl",
+            vec![make("calendar")],
+            DEFAULT_MAX_RESULTS,
+            MatchMode::Substring,
+        );
+        assert!(
+            substring.is_empty(),
+            "substring rejects non-contiguous c..l"
+        );
+    }
+
+    #[test]
+    fn test_substring_multi_word_requires_every_word_as_substring() {
+        // Pins the documented contract: in substring mode, space-separated
+        // words are matched as independent substrings and EVERY word must be
+        // present. "git ch" keeps only the candidate containing both "git"
+        // and "ch" contiguously. This behavior rides on nucleo's Pattern::new
+        // whitespace tokenization — a regression there would otherwise pass
+        // silently.
+        let items = vec![
+            make("git checkout"), // has "git" and "ch"
+            make("git push"),     // has "git", lacks "ch"
+            make("touch change"), // has "ch" (twice), lacks "git"
+        ];
+        let result = rank_with_mode("git ch", items, DEFAULT_MAX_RESULTS, MatchMode::Substring);
+        let texts: Vec<&str> = result.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(
+            texts,
+            vec!["git checkout"],
+            "only the candidate containing every space-separated substring survives: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn test_substring_smart_case_is_case_insensitive_for_lowercase_query() {
+        // Smart-case (inherited from the fuzzy path): an all-lowercase query
+        // matches case-insensitively, so "cl" still finds "CLONE".
+        let result = rank_with_mode(
+            "cl",
+            vec![make("CLONE")],
+            DEFAULT_MAX_RESULTS,
+            MatchMode::Substring,
+        );
+        assert_eq!(
+            result.len(),
+            1,
+            "lowercase query matches uppercase haystack"
+        );
+    }
+
+    #[test]
+    fn test_substring_match_indices_are_contiguous() {
+        let items = vec![make("include")];
+        let result = rank_with_mode("cl", items, DEFAULT_MAX_RESULTS, MatchMode::Substring);
+        assert_eq!(result.len(), 1);
+        // "in*cl*ude" — the 'c' and 'l' are at indices 2 and 3.
+        assert_eq!(result[0].match_indices, vec![2, 3]);
+    }
+
+    #[test]
+    fn test_rank_delegates_to_fuzzy_mode() {
+        // `rank` must remain a fuzzy alias: a subsequence-only candidate that
+        // substring mode would drop still survives through `rank`.
+        let result = rank("cl", vec![make("calendar")], DEFAULT_MAX_RESULTS);
+        assert_eq!(result.len(), 1, "rank() keeps fuzzy subsequence match");
+    }
+
+    #[test]
+    fn test_substring_empty_query_returns_all() {
+        let items: Vec<Suggestion> = (0..5).map(|i| make(&format!("item{i}"))).collect();
+        let result = rank_with_mode("", items, DEFAULT_MAX_RESULTS, MatchMode::Substring);
+        assert_eq!(result.len(), 5, "empty query is mode-agnostic");
     }
 
     #[test]

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -59,6 +59,7 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # max_results = 50
 # max_history_results = 5
 # generator_timeout_ms = 5000  # Per-invocation timeout (ms) for async script/git generators
+# match_mode = \"fuzzy\"  # \"fuzzy\" = subsequence (gco -> git checkout); \"substring\" = contiguous (cl -> clone, not calendar); restart required
 
 # [suggest.providers]
 # commands = true

--- a/crates/ghost-complete/src/tui/fields.rs
+++ b/crates/ghost-complete/src/tui/fields.rs
@@ -594,6 +594,7 @@ mod tests {
         for (section, key) in [
             ("popup", "render_block_ms"),
             ("popup", "feedback_dismiss_ms"),
+            ("suggest", "match_mode"),
             ("suggest.providers", "js_runtime"),
             ("experimental", "aws_sdk_provider"),
             ("experimental", "aws_sdk_fallback_to_cli"),
@@ -617,13 +618,23 @@ mod tests {
         for (section, key) in [
             ("popup", "render_block_ms"),
             ("popup", "feedback_dismiss_ms"),
+            ("suggest", "match_mode"),
             ("suggest.providers", "js_runtime"),
             ("experimental", "aws_sdk_provider"),
             ("experimental", "aws_sdk_fallback_to_cli"),
             ("experimental", "brew_search_cap"),
         ] {
             let field = find_field(section, key);
-            let doc = format!("[{section}]\n{key} = {}\n", field.default);
+            // Numeric / bool defaults are valid bare TOML scalars; string-valued
+            // field types (enum variants, plain strings, style strings) must be
+            // quoted to form a valid `key = "value"` document.
+            let rhs = match field.field_type {
+                FieldType::Enum(_) | FieldType::String | FieldType::StyleString => {
+                    format!("\"{}\"", field.default)
+                }
+                _ => field.default.to_string(),
+            };
+            let doc = format!("[{section}]\n{key} = {rhs}\n");
             let cfg: gc_config::GhostConfig = toml::from_str(&doc)
                 .unwrap_or_else(|e| panic!("{section}.{key} parse failed: {e}"));
             let round = toml::Value::try_from(&cfg).expect("config serializes");
@@ -633,6 +644,24 @@ mod tests {
                 "{section}.{key} did not survive serialize/deserialize round-trip"
             );
         }
+    }
+
+    #[test]
+    fn match_mode_default_is_a_valid_enum_member() {
+        // The editor seeds its selection from the index of `default` within the
+        // `Enum` options slice; if the default ever drifts outside that slice the
+        // start-index lookup would be wrong, so pin membership here.
+        let field = find_field("suggest", "match_mode");
+        let options = match field.field_type {
+            FieldType::Enum(opts) => opts,
+            other => panic!("suggest.match_mode should be an Enum field, got {other:?}"),
+        };
+        assert!(
+            options.contains(&field.default),
+            "match_mode default {:?} is not in its enum options {:?}",
+            field.default,
+            options
+        );
     }
 
     #[test]

--- a/crates/ghost-complete/src/tui/fields.rs
+++ b/crates/ghost-complete/src/tui/fields.rs
@@ -213,6 +213,14 @@ pub fn all_fields() -> Vec<FieldMeta> {
             reload: ReloadBehavior::RequiresRestart,
             help: "Timeout in ms for async script generators",
         },
+        FieldMeta {
+            section: "suggest",
+            key: "match_mode",
+            field_type: FieldType::Enum(&["fuzzy", "substring"]),
+            default: "fuzzy",
+            reload: ReloadBehavior::RequiresRestart,
+            help: "Query matching: fuzzy (subsequence) or substring (contiguous)",
+        },
         // suggest.providers
         FieldMeta {
             section: "suggest.providers",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -69,12 +69,14 @@ Controls the suggestion engine behavior.
 | `max_results` | integer | `50` | Maximum total candidates to consider |
 | `max_history_results` | integer | `5` | Maximum history entries shown in popup. Set to `0` to disable history. |
 | `generator_timeout_ms` | integer | `5000` | Per-invocation timeout (milliseconds) for script and git generators. |
+| `match_mode` | string | `"fuzzy"` | How the typed query filters candidates. `"fuzzy"` matches characters as an in-order subsequence (`gco` → `git checkout`); `"substring"` requires the characters to appear contiguously (`cl` → `clone`, `include`, but not `calendar`). Space-separated words are matched as independent substrings. Requires a restart. |
 
 ```toml
 [suggest]
 max_results = 50
 max_history_results = 5
 generator_timeout_ms = 5000
+match_mode = "fuzzy"  # or "substring" for contiguous matching
 ```
 
 Shell history loads up to 10,000 entries.


### PR DESCRIPTION
## Summary

Resolves #149. Adds a configurable **match mode** to the suggestion filter so users can choose between the existing fuzzy (subsequence) matching and **contiguous substring** matching.

The reporter wanted typing `cl` to surface only candidates that contain `cl` *together* (e.g. `clone`, `include`) rather than every candidate with a `c` and an `l` somewhere (e.g. `calendar`). This is now opt-in via:

```toml
[suggest]
match_mode = "substring"   # default: "fuzzy"
```

| Mode | `cl` matches | `cl` rejects |
|------|--------------|--------------|
| `fuzzy` (default) | `clone`, `include`, `calendar` | — |
| `substring` | `clone`, `include` | `calendar` |

Space-separated words are matched as independent substrings (every word must be present), mirroring fzf "exact" semantics — `git ch` keeps only `git checkout`.

## Why the default stays `fuzzy`

`fuzzy` remains the default so existing behavior is unchanged — no surprise for current users, no golden-test churn. Flipping the default later is a one-line change if desired.

## Implementation

`gc-suggest/src/fuzzy.rs` is the single matching chokepoint (confirmed: the only `nucleo` matcher in the workspace). The change maps `MatchMode` → `AtomKind::{Fuzzy,Substring}` there.

- **`gc-config`**: new `MatchMode` enum (`#[serde(rename_all = "lowercase")]`) + `SuggestConfig.match_mode` field (default `Fuzzy`), registered in `all_field_paths()`.
- **`gc-suggest`**: `rank_with_mode()` core + `rank()` thin fuzzy wrapper (back-compat for existing callers/tests); `SuggestionEngine` stores `match_mode`, exposes `with_match_mode()` builder + `match_mode()` accessor; all 7 internal rank sites thread the configured mode.
- **`gc-pty`**: the two async-merge live re-rank paths were extracted into a shared `InputHandler::rerank_live()` helper that reads `self.engine.match_mode()` — removing the prior duplication (the two sites could drift) and giving the keystroke filter a unit-testable seam. `InputHandler::with_match_mode()` builder; proxy wires `config.suggest.match_mode`.
- **`ghost-complete`**: install template line, TUI editor enum field (`["fuzzy","substring"]`, RequiresRestart).
- **Docs**: `CONFIGURATION.md` field row + example; `CHANGELOG.md` Unreleased entry.

Match mode is baked at builder time (requires restart), consistent with `max_results`.

## Tests

- `gc-config`: default-is-fuzzy, TOML deserialization, serialize round-trip.
- `gc-suggest/fuzzy`: substring excludes subsequence-only matches; fuzzy vs substring contrast; **multi-word AND-semantics** (`git ch` → only `git checkout`); smart-case insensitivity; contiguous `match_indices` for highlighting; `rank()` stays fuzzy; empty-query is mode-agnostic.
- `gc-suggest/engine`: end-to-end `rank_with_history` drops `calendar`, keeps `clone`.
- `gc-pty/handler`: `rerank_live` honors substring mode (drops `calendar`, keeps `clone`) and contrasts fuzzy; empty-word keeps the full pool ordered.
- Existing drift guards (install template / TUI editor / CONFIGURATION.md must list every field) all green.

## Verification

`cargo test --workspace`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` all pass. The change was put through a multi-agent adversarial review (correctness / config-UX / test-coverage); the two confirmed findings were both test-coverage gaps and are addressed by the tests above — no correctness or config defects were found.
