### PR TITLE
feat(popup): add tab_accepts_top to accept the top suggestion on Tab (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tab-accepts-top option**: set `popup.tab_accepts_top = true` to make the
+  accept key (Tab) accept the top-ranked suggestion even when nothing has been
+  navigated yet, instead of forwarding a literal tab to the shell. Restores the
+  Fig/Kiro "type, glance, Tab" flow without the extra arrow-key press. Default
+  `false` preserves the historical "navigate first, then accept" behavior. Only
+  the `accept` action is affected: with the default bindings the `accept_and_enter`
+  action (Enter) is a separate binding and still runs the command line, so a stray
+  Enter never silently accepts the top suggestion. Hot-reloadable via `config.toml`
+  or the TUI editor (#150).
 - **Substring match mode** for the suggestion filter: set
   `suggest.match_mode = "substring"` to require the typed characters to appear
   contiguously (`cl` → `clone`/`include`, not `calendar`) instead of the

--- a/crates/gc-config/src/lib.rs
+++ b/crates/gc-config/src/lib.rs
@@ -191,6 +191,15 @@ pub struct PopupConfig {
     /// Default 80, matching `render_block_ms`.
     #[serde(deserialize_with = "deserialize_saturating_u16")]
     pub description_box_debounce_ms: u16,
+    /// When `true`, the accept key (Tab) accepts the top-ranked suggestion even
+    /// when nothing has been navigated yet, instead of forwarding a literal tab
+    /// to the shell. Lets users coming from Fig/Kiro keep a "type, glance, Tab"
+    /// flow without an extra arrow-key press. Default `false` preserves the
+    /// historical "navigate first, then accept" behavior. Only the `accept`
+    /// action is affected: with the default bindings the `accept_and_enter`
+    /// action (Enter) is a separate binding and still runs the command line, so
+    /// a stray Enter never silently accepts the top suggestion. See issue #150.
+    pub tab_accepts_top: bool,
 }
 
 impl Default for PopupConfig {
@@ -208,6 +217,7 @@ impl Default for PopupConfig {
             description_box_max_width: 60,
             description_box_lines: 5,
             description_box_debounce_ms: 80,
+            tab_accepts_top: false,
         }
     }
 }
@@ -659,6 +669,7 @@ pub fn all_field_paths() -> Vec<&'static str> {
         "popup.description_box_max_width",
         "popup.description_box_lines",
         "popup.description_box_debounce_ms",
+        "popup.tab_accepts_top",
         // [suggest]
         "suggest.max_results",
         "suggest.max_history_results",
@@ -1526,6 +1537,21 @@ max_width = 80
         let cfg = PopupConfig::default();
         assert_eq!(cfg.min_width, 20);
         assert_eq!(cfg.max_width, 60);
+    }
+
+    #[test]
+    fn test_popup_tab_accepts_top_defaults_false() {
+        assert!(
+            !PopupConfig::default().tab_accepts_top,
+            "tab_accepts_top must default off to preserve historical behavior"
+        );
+    }
+
+    #[test]
+    fn test_popup_tab_accepts_top_parses() {
+        let toml_str = "[popup]\ntab_accepts_top = true\n";
+        let config: GhostConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.popup.tab_accepts_top);
     }
 
     #[test]

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -288,6 +288,36 @@ mod tests {
         assert_eq!(handler.lock().unwrap().render_block_ms(), 150);
     }
 
+    /// `popup.tab_accepts_top` must travel the same `GhostConfig ->
+    /// config_watch -> InputHandler` seam as `render_block_ms` — it is the
+    /// last positional arg threaded through `update_config`, so this guards
+    /// against `apply_config_reload` dropping it on a live reload.
+    #[test]
+    fn tab_accepts_top_propagates_on_config_reload() {
+        let handler = Arc::new(Mutex::new(
+            InputHandler::new_with_embedded(
+                &[],
+                gc_terminal::TerminalProfile::for_ghostty(),
+                false,
+            )
+            .expect("handler builds"),
+        ));
+        assert!(
+            !handler.lock().unwrap().tab_accepts_top(),
+            "default tab_accepts_top should be false"
+        );
+
+        let mut config = GhostConfig::default();
+        config.popup.tab_accepts_top = true;
+
+        apply_config_reload(&handler, &config).expect("config reload applies");
+
+        assert!(
+            handler.lock().unwrap().tab_accepts_top(),
+            "reload should propagate tab_accepts_top = true into the handler"
+        );
+    }
+
     /// Drives the full hot-reload seam end-to-end: an on-disk config.toml,
     /// the real `notify::RecommendedWatcher` (kind filter + 200ms debounce +
     /// `GhostConfig::load`), and the handler update. The pure-Rust test

--- a/crates/gc-pty/src/config_watch.rs
+++ b/crates/gc-pty/src/config_watch.rs
@@ -191,6 +191,7 @@ fn apply_config_reload(handler: &Arc<Mutex<InputHandler>>, config: &GhostConfig)
             config.popup.description_box_lines,
             config.popup.description_box_debounce_ms,
             config.popup.render_block_ms as u64,
+            config.popup.tab_accepts_top,
         );
         (cleanup, h.overlay_write_ticket())
     };

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -611,6 +611,12 @@ impl InputHandler {
         self.render_block_ms
     }
 
+    /// Whether the accept key accepts the top suggestion when nothing has been
+    /// navigated. Observable for the config-reload propagation test.
+    pub fn tab_accepts_top(&self) -> bool {
+        self.tab_accepts_top
+    }
+
     /// Enable/disable accepting the top suggestion on the accept key (Tab) when
     /// nothing has been navigated. Corresponds to `config.popup.tab_accepts_top`.
     pub fn with_tab_accepts_top(mut self, enabled: bool) -> Self {
@@ -2921,7 +2927,12 @@ impl InputHandler {
     /// pull from the same `TerminalState` snapshot and are consumed by
     /// `accept_with_chaining` when the selection is a directory.
     ///
-    /// Returns `None` when the overlay has no valid selection.
+    /// Returns `None` when there is nothing to accept: no effective selection
+    /// (no navigation and either `tab_accepts_top` is off or the list is
+    /// empty — see [`Self::effective_selected`]), or the resolved index is out
+    /// of range. With `tab_accepts_top` enabled and a non-empty list, an
+    /// un-navigated overlay resolves to the top item (index 0) rather than
+    /// short-circuiting.
     fn accept_suggestion_locked(&self, p: &TerminalParser) -> Option<AcceptLocked> {
         let selected_idx = self.effective_selected()?;
         if selected_idx >= self.suggestions.len() {
@@ -5043,6 +5054,36 @@ mod tests {
     }
 
     #[test]
+    fn test_tab_accepts_top_accept_rebound_to_enter_accepts_top() {
+        // The documented "contradictory double-opt-in": rebinding the `accept`
+        // action onto Enter while tab_accepts_top is on makes Enter accept the
+        // top item, because process_key_visible checks `accept` before
+        // `accept_and_enter`. This pins the dispatch ordering — reversing the
+        // two checks would silently invert this behavior with no other failure.
+        let mut handler = make_visible_handler(vec![
+            command_suggestion("status", None),
+            command_suggestion("stash", None),
+        ])
+        .with_tab_accepts_top(true);
+        handler.keybindings.accept = KeyEvent::Enter;
+        handler.keybindings.accept_and_enter = KeyEvent::Tab;
+        assert_eq!(
+            handler.overlay.selected, None,
+            "precondition: no manual navigation"
+        );
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        let result = handler.process_key(&KeyEvent::Enter, &parser, &mut buf);
+
+        assert!(
+            result.ends_with(b"status "),
+            "Enter rebound to `accept` should accept the top item, got {result:?}"
+        );
+        assert!(!handler.visible, "popup should dismiss after accepting");
+    }
+
+    #[test]
     fn test_tab_accepts_top_chains_into_top_directory() {
         // Accepting a directory at the top via the preselect fallback must still
         // drive cd-chaining (predict the buffer + re-trigger) exactly as an
@@ -5108,6 +5149,43 @@ mod tests {
             handler.effective_selected(),
             Some(0),
             "hot-reload should enable the top-item preselect fallback"
+        );
+    }
+
+    #[test]
+    fn test_update_config_disables_tab_accepts_top() {
+        // The on->off direction is the riskier reload: a stale `true` left
+        // behind would keep silently hijacking Tab. update_config must clear
+        // the field, not just set it.
+        let mut handler = make_visible_handler(vec![command_suggestion("status", None)])
+            .with_tab_accepts_top(true);
+        assert_eq!(
+            handler.effective_selected(),
+            Some(0),
+            "precondition: flag on yields the top-item preselect fallback"
+        );
+
+        handler.update_config(
+            PopupTheme::default(),
+            Keybindings::default(),
+            &[' ', '/'],
+            DEFAULT_MAX_VISIBLE,
+            1200,
+            true,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            DescriptionBoxMode::Off,
+            60,
+            5,
+            80,
+            80,
+            false, // tab_accepts_top
+        );
+
+        assert_eq!(
+            handler.effective_selected(),
+            None,
+            "hot-reload should clear the top-item preselect fallback"
         );
     }
 

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -495,6 +495,20 @@ pub struct InputHandler {
     overlay_cleanup_generation: u64,
     /// Pending acknowledgement for cleanup bytes that clear committed overlay layouts.
     pending_overlay_cleanup: Option<PendingOverlayCleanup>,
+    /// When `true`, the accept key (Tab) accepts the top-ranked suggestion even
+    /// when the user has not navigated yet (`overlay.selected == None`), instead
+    /// of forwarding a literal tab to the shell. Opt-in via
+    /// `config.popup.tab_accepts_top`; default `false` preserves the historical
+    /// "navigate first, then accept" flow. See issue #150.
+    ///
+    /// Deliberately scoped to the `accept` action only. With the default
+    /// bindings (`accept` = Tab, `accept_and_enter` = Enter) this means Enter
+    /// still runs the command line — because it is a separate binding — so a
+    /// stray Enter never silently accepts a suggestion the user meant to run
+    /// verbatim. (Rebinding the `accept` action itself onto Enter makes Enter
+    /// the accept key, which then accepts the top item; the dispatch checks
+    /// `accept` before `accept_and_enter`.)
+    tab_accepts_top: bool,
 }
 
 impl InputHandler {
@@ -553,6 +567,7 @@ impl InputHandler {
             pending_overlay_render: None,
             overlay_cleanup_generation: 0,
             pending_overlay_cleanup: None,
+            tab_accepts_top: false,
         })
     }
 
@@ -594,6 +609,13 @@ impl InputHandler {
     /// Return the current render-block budget in milliseconds.
     pub fn render_block_ms(&self) -> u64 {
         self.render_block_ms
+    }
+
+    /// Enable/disable accepting the top suggestion on the accept key (Tab) when
+    /// nothing has been navigated. Corresponds to `config.popup.tab_accepts_top`.
+    pub fn with_tab_accepts_top(mut self, enabled: bool) -> Self {
+        self.tab_accepts_top = enabled;
+        self
     }
 
     /// Set popup min/max width bounds (display columns). Stored on the
@@ -806,6 +828,7 @@ impl InputHandler {
         detail_box_lines: u16,
         detail_box_debounce_ms: u16,
         render_block_ms: u64,
+        tab_accepts_top: bool,
     ) -> Vec<u8> {
         let mut cleanup = Vec::new();
         let mut cleanup_scope: Option<CleanupScope> = None;
@@ -881,6 +904,7 @@ impl InputHandler {
         self.detail_box_lines = detail_box_lines;
         self.detail_box_debounce_ms = detail_box_debounce_ms as u64;
         self.render_block_ms = render_block_ms;
+        self.tab_accepts_top = tab_accepts_top;
 
         cleanup
     }
@@ -1152,7 +1176,7 @@ impl InputHandler {
             return Vec::new();
         }
         if key == &self.keybindings.accept {
-            if self.overlay.selected.is_none() {
+            if self.effective_selected().is_none() {
                 self.dismiss(stdout);
                 return key_to_bytes(key);
             }
@@ -1246,13 +1270,30 @@ impl InputHandler {
         }
     }
 
+    /// The suggestion index the accept path should act on.
+    ///
+    /// Normally this is the navigated selection (`overlay.selected`). When
+    /// `tab_accepts_top` is enabled and the user has not navigated yet, it
+    /// falls back to the top item (index 0) so the accept key accepts the
+    /// top-ranked suggestion directly (issue #150).
+    ///
+    /// Returns `None` when there is genuinely nothing to accept: no navigation
+    /// and either the flag is off or the list is empty (e.g. a feedback-only
+    /// popup). The fallback is gated on a non-empty list so a `Some(0)` index
+    /// always points at a real suggestion.
+    fn effective_selected(&self) -> Option<usize> {
+        self.overlay
+            .selected
+            .or_else(|| (self.tab_accepts_top && !self.suggestions.is_empty()).then_some(0))
+    }
+
     /// Accept the current suggestion, with directory chaining for paths ending in '/'.
     fn accept_with_chaining(
         &mut self,
         parser: &Arc<Mutex<TerminalParser>>,
         stdout: &mut dyn Write,
     ) -> Vec<u8> {
-        let selected_idx = match self.overlay.selected {
+        let selected_idx = match self.effective_selected() {
             Some(idx) if idx < self.suggestions.len() => idx,
             _ => {
                 self.dismiss(stdout);
@@ -2882,7 +2923,7 @@ impl InputHandler {
     ///
     /// Returns `None` when the overlay has no valid selection.
     fn accept_suggestion_locked(&self, p: &TerminalParser) -> Option<AcceptLocked> {
-        let selected_idx = self.overlay.selected?;
+        let selected_idx = self.effective_selected()?;
         if selected_idx >= self.suggestions.len() {
             return None;
         }
@@ -4193,6 +4234,7 @@ mod tests {
             pending_overlay_render: None,
             overlay_cleanup_generation: 0,
             pending_overlay_cleanup: None,
+            tab_accepts_top: false,
         }
     }
 
@@ -4902,6 +4944,173 @@ mod tests {
         assert!(!handler.visible, "popup should be dismissed");
     }
 
+    // --- tab_accepts_top (issue #150) ---
+
+    #[test]
+    fn test_tab_accepts_top_accepts_first_when_enabled() {
+        let mut handler = make_visible_handler(vec![
+            command_suggestion("status", None),
+            command_suggestion("stash", None),
+        ])
+        .with_tab_accepts_top(true);
+        assert_eq!(
+            handler.overlay.selected, None,
+            "precondition: no manual navigation"
+        );
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        let result = handler.process_key(&KeyEvent::Tab, &parser, &mut buf);
+
+        assert_ne!(
+            result,
+            vec![0x09],
+            "Tab should accept the top item, not forward a literal tab"
+        );
+        assert!(
+            result.ends_with(b"status "),
+            "accepting the top command inserts it with a trailing space, got {result:?}"
+        );
+        assert!(!handler.visible, "popup should dismiss after accepting");
+    }
+
+    #[test]
+    fn test_tab_accepts_top_disabled_still_forwards_tab() {
+        // Default (flag off) preserves the historical "navigate first" flow.
+        let mut handler = make_visible_handler(vec![command_suggestion("status", None)]);
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        let result = handler.process_key(&KeyEvent::Tab, &parser, &mut buf);
+
+        assert_eq!(
+            result,
+            vec![0x09],
+            "default behavior: forward literal tab when nothing navigated"
+        );
+        assert!(!handler.visible);
+    }
+
+    #[test]
+    fn test_tab_accepts_top_does_not_hijack_enter() {
+        // Enter must keep running the command line even with the flag on, so a
+        // stray Enter never silently accepts a suggestion into a command the
+        // user meant to run verbatim.
+        let mut handler = make_visible_handler(vec![command_suggestion("status", None)])
+            .with_tab_accepts_top(true);
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        let result = handler.process_key(&KeyEvent::Enter, &parser, &mut buf);
+
+        assert_eq!(
+            result,
+            vec![0x0D],
+            "Enter forwards CR even with tab_accepts_top enabled"
+        );
+        assert!(!handler.visible);
+    }
+
+    #[test]
+    fn test_tab_accepts_top_with_no_suggestions_forwards_tab() {
+        // A feedback-only popup (Loading/Empty/Error, zero suggestions) has no
+        // top item to accept, so Tab still forwards a literal tab.
+        let mut handler = make_visible_handler(vec![]).with_tab_accepts_top(true);
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        let result = handler.process_key(&KeyEvent::Tab, &parser, &mut buf);
+
+        assert_eq!(result, vec![0x09]);
+    }
+
+    #[test]
+    fn test_tab_accepts_top_respects_existing_navigation() {
+        // A real selection wins over the preselect fallback: Tab accepts the
+        // navigated item, not the top.
+        let mut handler = make_visible_handler(vec![
+            command_suggestion("status", None),
+            command_suggestion("stash", None),
+        ])
+        .with_tab_accepts_top(true);
+        handler.overlay.selected = Some(1); // navigated to "stash"
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        let mut buf = Vec::new();
+        let result = handler.process_key(&KeyEvent::Tab, &parser, &mut buf);
+
+        assert!(
+            result.ends_with(b"stash "),
+            "should accept the navigated item, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_tab_accepts_top_chains_into_top_directory() {
+        // Accepting a directory at the top via the preselect fallback must still
+        // drive cd-chaining (predict the buffer + re-trigger) exactly as an
+        // explicitly-selected directory does, even though overlay.selected was
+        // never set.
+        let mut handler = make_visible_handler(vec![Suggestion {
+            text: "Desktop/".to_string(),
+            kind: SuggestionKind::Directory,
+            source: SuggestionSource::Filesystem,
+            ..Default::default()
+        }])
+        .with_tab_accepts_top(true);
+        assert_eq!(
+            handler.overlay.selected, None,
+            "precondition: no navigation"
+        );
+
+        let parser = Arc::new(Mutex::new(gc_parser::TerminalParser::new(24, 80)));
+        {
+            let mut p = parser.lock().unwrap();
+            p.state_mut().predict_command_buffer("cd ".to_string(), 3);
+        }
+
+        let mut buf = Vec::new();
+        handler.process_key(&KeyEvent::Tab, &parser, &mut buf);
+
+        let p = parser.lock().unwrap();
+        assert_eq!(
+            p.state().command_buffer(),
+            Some("cd Desktop/"),
+            "preselected directory should chain like a navigated one"
+        );
+    }
+
+    #[test]
+    fn test_update_config_toggles_tab_accepts_top() {
+        // The flag hot-reloads through update_config like the other popup fields.
+        let mut handler = make_visible_handler(vec![command_suggestion("status", None)]);
+        assert_eq!(
+            handler.effective_selected(),
+            None,
+            "default: no preselect fallback"
+        );
+
+        handler.update_config(
+            PopupTheme::default(),
+            Keybindings::default(),
+            &[' ', '/'],
+            DEFAULT_MAX_VISIBLE,
+            1200,
+            true,
+            DEFAULT_MIN_POPUP_WIDTH,
+            DEFAULT_MAX_POPUP_WIDTH,
+            DescriptionBoxMode::Off,
+            60,
+            5,
+            80,
+            80,
+            true, // tab_accepts_top
+        );
+
+        assert_eq!(
+            handler.effective_selected(),
+            Some(0),
+            "hot-reload should enable the top-item preselect fallback"
+        );
+    }
+
     // --- parse_key_name tests ---
 
     #[test]
@@ -5081,6 +5290,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         assert_eq!(handler.theme.selected_on, vec![0x1B, b'[', b'1', b'm']);
@@ -5114,6 +5324,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         assert_eq!(handler.keybindings, new_kb);
@@ -5137,6 +5348,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         assert_eq!(handler.max_visible, 20);
@@ -5160,6 +5372,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         assert_eq!(handler.trigger_chars, vec!['@', '#', '!']);
@@ -5183,6 +5396,7 @@ mod tests {
             7,
             0,
             80,
+            false,
         );
 
         assert_eq!(handler.min_popup_width, 35);
@@ -5228,6 +5442,7 @@ mod tests {
             3,
             0,
             80,
+            false,
         );
 
         assert!(
@@ -5285,6 +5500,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         let output = String::from_utf8_lossy(&cleanup);
@@ -5332,6 +5548,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         let output = String::from_utf8_lossy(&cleanup);
@@ -5425,6 +5642,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         assert!(!handler.auto_trigger_enabled());
@@ -5454,6 +5672,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         assert!(!handler.visible);
@@ -5489,6 +5708,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         assert!(
@@ -5525,6 +5745,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         assert!(handler.visible);
@@ -7696,6 +7917,7 @@ mod tests {
             5,
             80,
             80,
+            false,
         );
 
         let output = String::from_utf8_lossy(&cleanup);

--- a/crates/gc-pty/src/handler.rs
+++ b/crates/gc-pty/src/handler.rs
@@ -5055,18 +5055,24 @@ mod tests {
 
     #[test]
     fn test_tab_accepts_top_accept_rebound_to_enter_accepts_top() {
-        // The documented "contradictory double-opt-in": rebinding the `accept`
-        // action onto Enter while tab_accepts_top is on makes Enter accept the
-        // top item, because process_key_visible checks `accept` before
-        // `accept_and_enter`. This pins the dispatch ordering — reversing the
-        // two checks would silently invert this behavior with no other failure.
+        // The documented "contradictory double-opt-in": both `accept` and
+        // `accept_and_enter` are bound to Enter (accept_and_enter's default),
+        // while tab_accepts_top is on and the user has not navigated. Because
+        // process_key_visible checks `accept` before `accept_and_enter`, Enter
+        // hits the `accept` branch — whose effective_selected() resolves the
+        // preselect fallback to Some(0) — and accepts the top item ("status ").
+        // Reversing the two checks would instead hit `accept_and_enter`, which
+        // reads the raw overlay.selected (None here) and returns a bare carriage
+        // return (vec![0x0D]) that runs the line WITHOUT accepting. This test
+        // therefore pins the dispatch ordering: a reorder flips the result from
+        // "accept top" to "bare CR" and trips the assertions below.
         let mut handler = make_visible_handler(vec![
             command_suggestion("status", None),
             command_suggestion("stash", None),
         ])
         .with_tab_accepts_top(true);
         handler.keybindings.accept = KeyEvent::Enter;
-        handler.keybindings.accept_and_enter = KeyEvent::Tab;
+        handler.keybindings.accept_and_enter = KeyEvent::Enter;
         assert_eq!(
             handler.overlay.selected, None,
             "precondition: no manual navigation"
@@ -5078,7 +5084,12 @@ mod tests {
 
         assert!(
             result.ends_with(b"status "),
-            "Enter rebound to `accept` should accept the top item, got {result:?}"
+            "Enter (accept checked before accept_and_enter) should accept the top item, got {result:?}"
+        );
+        assert_ne!(
+            result,
+            vec![0x0D],
+            "must not forward a bare carriage return — that is the reversed-dispatch behavior"
         );
         assert!(!handler.visible, "popup should dismiss after accepting");
     }

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -218,6 +218,7 @@ pub async fn run_proxy(shell: &OsStr, args: &[OsString], config: &GhostConfig) -
             .with_trigger_chars(&config.trigger.auto_chars)
             .with_auto_trigger(config.trigger.auto_trigger)
             .with_render_block_ms(config.popup.render_block_ms as u64)
+            .with_tab_accepts_top(config.popup.tab_accepts_top)
             .with_suggest_config(
                 config.suggest.max_results,
                 config.suggest.providers.commands,

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -54,6 +54,7 @@ const DEFAULT_CONFIG_TOML: &str = "\
 # description_box_max_width = 60  # Max description-box width; clamped to [20, 200]
 # description_box_lines = 5  # Max wrapped description lines; 0 resets to 5, above 20 clamps to 20
 # description_box_debounce_ms = 80  # Description-box selection debounce; 0 disables
+# tab_accepts_top = false  # Set true to make Tab accept the top suggestion when nothing is navigated (Fig/Kiro-style); Enter still runs the line
 
 # [suggest]
 # max_results = 50

--- a/crates/ghost-complete/src/tui/fields.rs
+++ b/crates/ghost-complete/src/tui/fields.rs
@@ -188,6 +188,14 @@ pub fn all_fields() -> Vec<FieldMeta> {
             reload: ReloadBehavior::Live,
             help: "Debounce window (ms) for description-box updates on selection change (0-500)",
         },
+        FieldMeta {
+            section: "popup",
+            key: "tab_accepts_top",
+            field_type: FieldType::Bool,
+            default: "false",
+            reload: ReloadBehavior::Live,
+            help: "Make Tab accept the top suggestion when nothing is navigated yet (Fig/Kiro-style); Enter still runs the command line",
+        },
         // suggest
         FieldMeta {
             section: "suggest",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -41,6 +41,7 @@ Controls the popup appearance.
 | `description_box_max_width` | integer | `60` | Maximum width (display columns) for the description box. Clamped to `[20, 200]`. The actual rendered width adapts to the columns remaining beside the main popup. |
 | `description_box_lines` | integer | `5` | Maximum wrapped lines in the description box. Long descriptions are hard-truncated with an ellipsis on the final line. `0` resets to default `5`; values above `20` are clamped to `20`. |
 | `description_box_debounce_ms` | integer | `80` | Debounce window (ms) for description-box updates on selection change. Holding arrow keys causes the box to update at most once per window, avoiding flicker. Set to `0` to disable debounce. Clamped to `[0, 500]`. |
+| `tab_accepts_top` | bool | `false` | When `true`, the accept key (Tab) accepts the top-ranked suggestion even when you haven't navigated yet, instead of forwarding a literal tab to the shell. Restores the Fig/Kiro "type, glance, Tab" flow without the extra arrow-key press. Only the `accept` action is affected: with the default bindings the `accept_and_enter` action (Enter) is a separate binding and still runs the command line, so a stray Enter never silently accepts the top suggestion. (If you rebind the `accept` action itself onto Enter, Enter becomes the accept key and will accept the top item.) |
 
 ```toml
 [popup]
@@ -56,6 +57,7 @@ description_box = "off"
 description_box_max_width = 60
 description_box_lines = 5
 description_box_debounce_ms = 80
+tab_accepts_top = false
 ```
 
 Popup width is content-driven (sized to the longest visible suggestion) and clamped to `[min_width, max_width]`. Descriptions that don't fit are truncated with a single-column ellipsis (`…`). Set `description_box = "side"` to surface a wrapped description when the inline description would be hidden or truncated. The box is capped by `description_box_lines` and available rows without permanently widening the main popup.
@@ -410,7 +412,7 @@ match_highlight = "underline"
 | `[trigger]` | `auto_chars` | Yes |
 | `[trigger]` | `delay_ms` | No |
 | `[trigger]` | `auto_trigger` | Yes |
-| `[popup]` | `max_visible`, `borders`, `feedback_dismiss_ms`, `spinner`, `show_provider_errors`, `render_block_ms`, `min_width`, `max_width`, `description_box`, `description_box_max_width`, `description_box_lines`, `description_box_debounce_ms` | Yes |
+| `[popup]` | `max_visible`, `borders`, `feedback_dismiss_ms`, `spinner`, `show_provider_errors`, `render_block_ms`, `min_width`, `max_width`, `description_box`, `description_box_max_width`, `description_box_lines`, `description_box_debounce_ms`, `tab_accepts_top` | Yes |
 | `[suggest]` | All fields | No |
 | `[suggest.providers]` | All fields | No |
 | `[suggest.spec_cache]` | All fields | No |


### PR DESCRIPTION
## What

Adds an opt-in `popup.tab_accepts_top` config flag (default `false`). When enabled, the **accept key (Tab)** accepts the top-ranked suggestion even when the user hasn't navigated yet (`overlay.selected == None`), instead of dismissing the popup and forwarding a literal tab to the shell.

Closes #150.

## Why

Tools like Fig/Kiro accept the highlighted first suggestion on a single Tab, enabling a fast "type, glance, Tab, done" rhythm. Today Ghost Complete requires an extra `Down` (or arrow) press to "activate" the selection before Tab will accept it. This flag restores that muscle memory for users coming from those tools, kept behind an opt-in so the current "navigate first, then accept" behavior remains the default for everyone who relies on it.

## How

- New helper `InputHandler::effective_selected()` returns `overlay.selected`, falling back to `Some(0)` **only** when `tab_accepts_top` is enabled **and** the suggestion list is non-empty (so the fallback index always points at a real suggestion).
- It's wired into exactly the three accept-path reads: the accept-key guard in `process_key_visible`, `accept_with_chaining`'s `selected_idx`, and `accept_suggestion_locked`.
- **Enter safety:** `accept_and_enter` (Enter, by default) deliberately keeps reading the raw `overlay.selected.is_some()`. With the default bindings, Enter is a *separate binding* from `accept`, so it still runs the command line and never silently accepts the top suggestion into a command meant to be run verbatim. (If a user deliberately rebinds the `accept` action onto Enter, Enter becomes the accept key — the dispatch checks `accept` before `accept_and_enter`. This is a contradictory double-opt-in, surfaced in the docs.)
- The detail box continues to read the raw selection (no preselect highlight), so the popup looks identical until you navigate or accept.
- Plumbed through every config surface guarded by the drift tests: `gc-config` (`PopupConfig` + `Default` + `all_field_paths`), the proxy builder, hot-reload via `config_watch`, the install template, the TUI config editor, and `docs/CONFIGURATION.md` (table + hot-reload list). The flag is hot-reloadable.

The default-off path is byte-identical to prior behavior — `effective_selected()` equals `overlay.selected` whenever the flag is off or the user has navigated.

## Testing

- [x] `cargo test` passes (full workspace green; +9 new tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manually tested in Ghostty with zsh

New tests (TDD):
- `test_tab_accepts_top_accepts_first_when_enabled` — Tab accepts the top instead of forwarding a tab
- `test_tab_accepts_top_disabled_still_forwards_tab` — default behavior preserved
- `test_tab_accepts_top_does_not_hijack_enter` — Enter still forwards CR with the flag on
- `test_tab_accepts_top_with_no_suggestions_forwards_tab` — feedback-only popup still forwards a tab
- `test_tab_accepts_top_respects_existing_navigation` — a real selection wins over the fallback
- `test_tab_accepts_top_chains_into_top_directory` — a preselected directory still drives cd-chaining
- `test_update_config_toggles_tab_accepts_top` — hot-reload toggles the flag
- `test_popup_tab_accepts_top_defaults_false` / `test_popup_tab_accepts_top_parses` (gc-config)

## Notes / follow-ups

- This change was self-reviewed via a multi-agent adversarial pass (correctness / completeness / regression). The only confirmed finding was a doc-precision issue (the Enter-safety wording), now fixed by attributing the safety to the `accept_and_enter` *binding* rather than the Enter *key*.
- Out of scope (pre-existing, noted by review): there is no validation that `accept != accept_and_enter`. That collision is already silently order-dependent in the keybinding dispatch regardless of this feature; a config-validation warning could be added separately.
