### PR TITLE
fix(deps): bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Security
+
+- Bumped `anyhow` from 1.0.102 to 1.0.103 to clear **RUSTSEC-2026-0190**: an
+  unsoundness in `Error::downcast_mut()` that could trigger undefined behavior
+  when a mutable downcast follows an `Error::context` call. Lockfile-only change;
+  the workspace already required `anyhow = "1"` (#154).
 
 ## [0.18.0] - 2026-06-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"


### PR DESCRIPTION
## What

Bumps `anyhow` from **1.0.102 → 1.0.103** in `Cargo.lock` to clear the RustSec advisory **RUSTSEC-2026-0190**. Lockfile-only change — the workspace manifest already declares `anyhow = "1"`, which permits the patched release, so no `Cargo.toml` edits are needed. Adds a `### Security` entry to the `[Unreleased]` CHANGELOG section.

## Why

`anyhow` 1.0.102 contains an **unsoundness in `Error::downcast_mut()`** ([RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190.html), [dtolnay/anyhow#451](https://github.com/dtolnay/anyhow/issues/451)): when context is added via `Error::context()` and `Error::downcast_mut()` is later called on the returned `Error`, borrow rules are violated and the result is undefined behavior (Miri flags a Stacked-Borrows retag violation). The advisory marks all `< 1.0.103` as affected and `>= 1.0.103` as patched (upstream fix `6e8c000`).

The advisory surfaces in this repo's `audit` workflow (`rustsec/audit-check` + `cargo-deny`), so leaving it unaddressed keeps CI red on the security gate.

## Testing

- [x] `cargo deny check advisories` → `advisories ok` (was flagging RUSTSEC-2026-0190 before the bump)
- [x] `cargo check --workspace --all-targets` → clean (same-minor soundness patch, API-compatible)
- [ ] `cargo test` — deferred to CI (no source changed; lockfile-only patch bump within the `1.0.x` line)

Closes #154