### PR TITLE
feat(terminal): add support for Otty (a Ghostty fork)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Otty terminal support**: Ghost Complete now recognizes Otty
+  (`TERM_PROGRAM=otty`, bundle id `io.appmakes.otty`), a Ghostty fork, as a
+  first-class supported terminal. It
+  inherits Ghostty's exact capability profile — DECSET 2026 synchronized output
+  and native OSC 133 prompt markers — so popups render at the correct cursor
+  position with no configuration and **without** `[experimental] multi_terminal`.
+  Unlike Ghostty proper, Otty does not set `GHOSTTY_RESOURCES_DIR`, so it is
+  detected purely via `TERM_PROGRAM`; the zsh init whitelist and the shell
+  integration's native-OSC-133 gate were updated to match. Brings the supported
+  terminal count to 10 (#153).
+
 ### Security
 
 - Bumped `anyhow` from 1.0.102 to 1.0.103 to clear **RUSTSEC-2026-0190**: an

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Zstd compression preserves the embedded 711-spec corpus while shrinking the benc
 
 Ghost Complete is under active development. Contributions and bug reports are welcome.
 
-- **9 supported terminals on macOS:** Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed, and VSCode (incl. VSCodium, Cursor, Windsurf, Positron, Trae) — all work out of the box with no additional configuration.
+- **10 supported terminals on macOS:** Ghostty, Otty (a Ghostty fork), Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed, and VSCode (incl. VSCodium, Cursor, Windsurf, Positron, Trae) — all work out of the box with no additional configuration.
 - **zsh is the primary shell.** Bash and fish support manual trigger only (Ctrl+/).
 - **macOS only.** No Linux or Windows support planned at this time.
 - **Pre-1.0.** Config format, spec format, and behavior may change between releases.

--- a/crates/gc-pty/src/proxy.rs
+++ b/crates/gc-pty/src/proxy.rs
@@ -100,8 +100,8 @@ pub async fn run_proxy(shell: &OsStr, args: &[OsString], config: &GhostConfig) -
     }
 
     // Gate unknown terminals behind experimental flag.
-    // Known terminals (Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app)
-    // work without any flag. Unknown terminals need multi_terminal = true.
+    // All known terminals (see `Terminal::supported_terminals`) work without
+    // any flag. Only Unknown terminals need multi_terminal = true.
     // Note: CommandExt::exec() is the Unix execvp() syscall — no shell
     // interpretation, no injection risk. `shell` comes from $SHELL or argv.
     if should_fallback_to_shell(
@@ -1686,6 +1686,9 @@ mod tests {
         // All known terminals work without the experimental flag
         let known = [
             Terminal::Ghostty,
+            // Otty (Ghostty fork) must work without multi_terminal — it is a
+            // known terminal, so it never falls back to a plain shell.
+            Terminal::Otty,
             Terminal::Kitty,
             Terminal::WezTerm,
             Terminal::Alacritty,

--- a/crates/gc-terminal/src/lib.rs
+++ b/crates/gc-terminal/src/lib.rs
@@ -4,6 +4,13 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Terminal {
     Ghostty,
+    /// Otty — a Ghostty fork (bundle id `io.appmakes.otty`). Inherits
+    /// Ghostty's rendering pipeline, so it has the same capability profile
+    /// (Synchronized + native OSC 133). Detected via `TERM_PROGRAM=otty`;
+    /// unlike Ghostty proper it does NOT set `GHOSTTY_RESOURCES_DIR`, so it
+    /// gets no env-var-based tmux detection (best-effort via TERM_PROGRAM,
+    /// same as Rio).
+    Otty,
     Kitty,
     WezTerm,
     Alacritty,
@@ -31,6 +38,7 @@ impl Terminal {
     pub fn supported_terminals() -> &'static [&'static str] {
         &[
             "Ghostty",
+            "Otty",
             "Kitty",
             "WezTerm",
             "Alacritty",
@@ -47,6 +55,7 @@ impl fmt::Display for Terminal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Terminal::Ghostty => write!(f, "Ghostty"),
+            Terminal::Otty => write!(f, "Otty"),
             Terminal::Kitty => write!(f, "Kitty"),
             Terminal::WezTerm => write!(f, "WezTerm"),
             Terminal::Alacritty => write!(f, "Alacritty"),
@@ -266,6 +275,7 @@ impl TerminalProfile {
     fn from_term_program(term_program: &str, in_tmux: bool) -> Self {
         let terminal = match term_program {
             "ghostty" => Terminal::Ghostty,
+            "otty" => Terminal::Otty,
             "iTerm.app" => Terminal::ITerm2,
             "Apple_Terminal" => Terminal::TerminalApp,
             "WezTerm" => Terminal::WezTerm,
@@ -287,8 +297,10 @@ impl TerminalProfile {
 
     fn new(terminal: Terminal, in_tmux: bool) -> Self {
         let (render_strategy, prompt_detection) = match &terminal {
-            // Full native support: synchronized output + OSC 133 prompt markers
+            // Full native support: synchronized output + OSC 133 prompt markers.
+            // Otty is a Ghostty fork, so it shares Ghostty's profile exactly.
             Terminal::Ghostty
+            | Terminal::Otty
             | Terminal::Kitty
             | Terminal::WezTerm
             | Terminal::Rio
@@ -318,6 +330,12 @@ impl TerminalProfile {
     #[cfg(any(test, feature = "test-utils"))]
     pub fn for_ghostty() -> Self {
         Self::new(Terminal::Ghostty, false)
+    }
+
+    /// Test constructor: Otty profile (Synchronized, OSC 133) — Ghostty fork.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn for_otty() -> Self {
+        Self::new(Terminal::Otty, false)
     }
 
     /// Test constructor: iTerm2 profile (PreRenderBuffer, ShellIntegration).
@@ -386,6 +404,7 @@ mod tests {
     #[test]
     fn test_terminal_is_known() {
         assert!(Terminal::Ghostty.is_known());
+        assert!(Terminal::Otty.is_known());
         assert!(Terminal::Kitty.is_known());
         assert!(Terminal::WezTerm.is_known());
         assert!(Terminal::Alacritty.is_known());
@@ -400,8 +419,8 @@ mod tests {
 
     #[test]
     fn test_supported_terminals_count() {
-        // 9 supported terminals: Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed, VSCode
-        assert_eq!(Terminal::supported_terminals().len(), 9);
+        // 10 supported terminals: Ghostty, Otty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed, VSCode
+        assert_eq!(Terminal::supported_terminals().len(), 10);
     }
 
     #[test]
@@ -410,6 +429,7 @@ mod tests {
             Terminal::supported_terminals(),
             &[
                 "Ghostty",
+                "Otty",
                 "Kitty",
                 "WezTerm",
                 "Alacritty",
@@ -431,6 +451,17 @@ mod tests {
         assert_eq!(profile.render_strategy(), RenderStrategy::Synchronized);
         assert_eq!(profile.prompt_detection(), PromptDetection::Osc133);
         assert!(!profile.in_tmux());
+    }
+
+    #[test]
+    fn test_otty_profile() {
+        // Otty is a Ghostty fork — same capability profile as Ghostty.
+        let profile = TerminalProfile::from_term_program("otty", false);
+        assert_eq!(*profile.terminal(), Terminal::Otty);
+        assert_eq!(profile.render_strategy(), RenderStrategy::Synchronized);
+        assert_eq!(profile.prompt_detection(), PromptDetection::Osc133);
+        assert!(!profile.in_tmux());
+        assert_eq!(profile.display_name(), "Otty");
     }
 
     #[test]
@@ -535,6 +566,7 @@ mod tests {
     #[test]
     fn test_terminal_display() {
         assert_eq!(Terminal::Ghostty.to_string(), "Ghostty");
+        assert_eq!(Terminal::Otty.to_string(), "Otty");
         assert_eq!(Terminal::Kitty.to_string(), "Kitty");
         assert_eq!(Terminal::WezTerm.to_string(), "WezTerm");
         assert_eq!(Terminal::Alacritty.to_string(), "Alacritty");
@@ -599,6 +631,30 @@ mod tests {
         );
         assert_eq!(*p.terminal(), Terminal::Ghostty);
         assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_otty_direct() {
+        // Otty sets TERM_PROGRAM=otty and no dedicated env var — detected via
+        // the TERM_PROGRAM path. It notably does NOT set GHOSTTY_RESOURCES_DIR,
+        // so ghostty_res stays false here.
+        let p = detect(
+            "otty", false, false, false, false, false, false, false, false,
+        );
+        assert_eq!(*p.terminal(), Terminal::Otty);
+        assert!(!p.in_tmux());
+    }
+
+    #[test]
+    fn test_detect_otty_via_tmux_term_program_fallback() {
+        // Otty has no dedicated env var for tmux detection (it does not set
+        // GHOSTTY_RESOURCES_DIR) — falls back to TERM_PROGRAM, same as Rio.
+        let p = detect(
+            "otty", true, false, false, false, false, false, false, false,
+        );
+        assert_eq!(*p.terminal(), Terminal::Otty);
+        assert!(p.in_tmux());
+        assert_eq!(p.display_name(), "Otty (via tmux)");
     }
 
     #[test]
@@ -885,6 +941,14 @@ mod tests {
     }
 
     #[test]
+    fn test_for_otty() {
+        let p = TerminalProfile::for_otty();
+        assert_eq!(*p.terminal(), Terminal::Otty);
+        assert_eq!(p.render_strategy(), RenderStrategy::Synchronized);
+        assert_eq!(p.prompt_detection(), PromptDetection::Osc133);
+    }
+
+    #[test]
     fn test_for_kitty() {
         let p = TerminalProfile::for_kitty();
         assert_eq!(*p.terminal(), Terminal::Kitty);
@@ -958,6 +1022,14 @@ mod tests {
     #[test]
     fn test_capitalized_ghostty_is_unknown() {
         let profile = TerminalProfile::from_term_program("Ghostty", false);
+        assert!(matches!(profile.terminal(), Terminal::Unknown(_)));
+    }
+
+    #[test]
+    fn test_capitalized_otty_is_unknown() {
+        // Otty reports TERM_PROGRAM=otty (lowercase); match the strict-casing
+        // policy applied to every other terminal.
+        let profile = TerminalProfile::from_term_program("Otty", false);
         assert!(matches!(profile.terminal(), Terminal::Unknown(_)));
     }
 

--- a/crates/ghost-complete/src/install.rs
+++ b/crates/ghost-complete/src/install.rs
@@ -795,14 +795,14 @@ mod tests {
         assert!(tmux_branch.contains("$ALACRITTY_SOCKET"));
         assert!(tmux_branch.contains("$ITERM_SESSION_ID"));
         assert!(tmux_branch.contains("\"$TERM_PROGRAM\" == \"rio\""));
+        assert!(tmux_branch.contains("\"$TERM_PROGRAM\" == \"otty\""));
         assert!(tmux_branch.contains("$ZED_TERM"));
         assert!(tmux_branch.contains("$VSCODE_IPC_HOOK_CLI"));
 
         // Direct terminal detection (non-tmux)
         assert!(non_tmux_branch.contains("case \"$TERM_PROGRAM\""));
-        assert!(
-            non_tmux_branch.contains("ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed|vscode)")
-        );
+        assert!(non_tmux_branch
+            .contains("ghostty|otty|WezTerm|rio|iTerm.app|Apple_Terminal|zed|vscode)"));
         assert!(non_tmux_branch.contains("$ZED_TERM"));
         assert!(non_tmux_branch.contains("$VSCODE_IPC_HOOK_CLI"));
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -245,7 +245,7 @@ Opt-in features that are not yet considered stable.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `multi_terminal` | bool | `false` | Enable unsupported/unknown terminals. All 9 supported terminals (Ghostty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed, VSCode) work without this flag. Set to `true` only if you want to try Ghost Complete on an unlisted terminal. |
+| `multi_terminal` | bool | `false` | Enable unsupported/unknown terminals. All 10 supported terminals (Ghostty, Otty, Kitty, WezTerm, Alacritty, Rio, iTerm2, Terminal.app, Zed, VSCode) work without this flag. Set to `true` only if you want to try Ghost Complete on an unlisted terminal. |
 | `aws_sdk_provider` | bool | `false` | Opt in to native AWS SDK completions. Default `false` means Ghost Complete does not make outbound AWS SDK calls. |
 | `aws_sdk_fallback_to_cli` | bool | `true` | When native AWS SDK completions are enabled but cannot run, allow the existing `aws` CLI script path to produce slower fallback completions. |
 | `brew_search_cap` | integer | `1000` | Ceiling on `brew search ""` results considered by the searchable-formulae provider. Lower this on slower machines; raise for broader unfiltered exploration. |
@@ -279,7 +279,7 @@ reports the visible AWS env/file state without making live AWS calls.
 
 Ghost Complete auto-detects the terminal via `TERM_PROGRAM` and terminal-specific env vars (`KITTY_WINDOW_ID`, `WEZTERM_UNIX_SOCKET`, `ALACRITTY_SOCKET`, `ZED_TERM`, `VSCODE_IPC_HOOK_CLI`), then selects the appropriate rendering strategy:
 
-- **Ghostty, Kitty, WezTerm, Rio, Zed** — DECSET 2026 synchronized output, native OSC 133 prompt markers.
+- **Ghostty, Otty, Kitty, WezTerm, Rio, Zed** — DECSET 2026 synchronized output, native OSC 133 prompt markers. Otty is a Ghostty fork (`TERM_PROGRAM=otty`) and inherits Ghostty's exact capability profile; unlike Ghostty proper it does not set `GHOSTTY_RESOURCES_DIR`, so it is detected purely via `TERM_PROGRAM`.
 - **VSCode** (and forks: VSCodium, Cursor, Windsurf, Positron, Trae) — DECSET 2026 synchronized output via xterm.js, native OSC 133. Coexists with VSCode's own shell integration: the proxy forwards the editor's OSC 633 sequences untouched so command decorations / sticky scroll / "run recent command" keep working, and Ghost Complete's own shell integration suppresses its redundant OSC 7771 emission when `VSCODE_INJECTION=1` is set.
 - **Alacritty** — DECSET 2026 synchronized output, OSC 7771 shell integration prompt markers (Alacritty does not support OSC 133).
 - **iTerm2 / Terminal.app** — pre-render buffer (single `write()` atomicity), OSC 7771 shell integration prompt markers.

--- a/shell/ghost-complete.bash
+++ b/shell/ghost-complete.bash
@@ -32,10 +32,12 @@ _gc_urlencode_path() {
 # OSC 633). In those terminals our OSC 7771 fallback is redundant — the
 # terminal already understands the OSC 133 we emit below, and OSC 7771
 # only exists for terminals that mangle OSC 133. Currently covers
-# Ghostty, Zed, and VSCode (the latter only once its shell integration
-# is active, signalled by VSCODE_INJECTION being set).
+# Ghostty, Otty (a Ghostty fork), Zed, and VSCode (the latter only once
+# its shell integration is active, signalled by VSCODE_INJECTION being set).
 _gc_native_osc133() {
     [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
+    # Otty is a Ghostty fork; it parses OSC 133 natively like Ghostty.
+    [[ "$TERM_PROGRAM" == "otty" ]] && return 0
     [[ -n "$ZED_TERM" ]] && return 0
     [[ -n "$VSCODE_INJECTION" ]] && return 0
     return 1

--- a/shell/ghost-complete.fish
+++ b/shell/ghost-complete.fish
@@ -22,10 +22,14 @@ end
 # OSC 633). In those terminals our OSC 7771 fallback is redundant — the
 # terminal already understands the OSC 133 we emit below, and OSC 7771
 # only exists for terminals that mangle OSC 133. Currently covers
-# Ghostty, Zed, and VSCode (the latter only once its shell integration
-# is active, signalled by VSCODE_INJECTION being set).
+# Ghostty, Otty (a Ghostty fork), Zed, and VSCode (the latter only once
+# its shell integration is active, signalled by VSCODE_INJECTION being set).
 function _gc_native_osc133
     if test "$TERM_PROGRAM" = ghostty -o -n "$GHOSTTY_RESOURCES_DIR"
+        return 0
+    end
+    # Otty is a Ghostty fork; it parses OSC 133 natively like Ghostty.
+    if test "$TERM_PROGRAM" = otty
         return 0
     end
     if test -n "$ZED_TERM"

--- a/shell/ghost-complete.zsh
+++ b/shell/ghost-complete.zsh
@@ -143,11 +143,13 @@ _gc_report_env() {
 # OSC 633). In those terminals our OSC 7771 fallback is redundant — the
 # terminal already understands the OSC 133 we emit below, and OSC 7771
 # only exists for terminals that mangle OSC 133. Currently covers
-# Ghostty, Kitty, WezTerm, Rio, Zed, and VSCode (the latter only once
-# its shell integration is active, signalled by VSCODE_INJECTION being
-# set).
+# Ghostty, Otty (a Ghostty fork), Kitty, WezTerm, Rio, Zed, and VSCode
+# (the latter only once its shell integration is active, signalled by
+# VSCODE_INJECTION being set).
 _gc_native_osc133() {
     [[ "$TERM_PROGRAM" == "ghostty" || -n "$GHOSTTY_RESOURCES_DIR" ]] && return 0
+    # Otty is a Ghostty fork; it parses OSC 133 natively like Ghostty.
+    [[ "$TERM_PROGRAM" == "otty" ]] && return 0
     [[ -n "$KITTY_WINDOW_ID" ]] && return 0
     [[ -n "$WEZTERM_UNIX_SOCKET" || "$TERM_PROGRAM" == "WezTerm" ]] && return 0
     [[ "$TERM_PROGRAM" == "rio" ]] && return 0

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -49,7 +49,8 @@ __ghost_complete_init() {
        [[ -n "$ZED_TERM" ]] || \
        [[ -n "$VSCODE_IPC_HOOK_CLI" ]] || \
        [[ -n "$ITERM_SESSION_ID" ]] || \
-       [[ "$TERM_PROGRAM" == "rio" ]]; then
+       [[ "$TERM_PROGRAM" == "rio" ]] || \
+       [[ "$TERM_PROGRAM" == "otty" ]]; then
       if command -v ghost-complete >/dev/null 2>&1; then
         export GHOST_COMPLETE_ACTIVE=1
         exec ghost-complete
@@ -85,7 +86,7 @@ __ghost_complete_init() {
       supported=1
     else
       case "$TERM_PROGRAM" in
-        ghostty|WezTerm|rio|iTerm.app|Apple_Terminal|zed|vscode) supported=1 ;;
+        ghostty|otty|WezTerm|rio|iTerm.app|Apple_Terminal|zed|vscode) supported=1 ;;
       esac
     fi
     if [[ $supported -eq 1 ]] && command -v ghost-complete >/dev/null 2>&1; then


### PR DESCRIPTION
## What

Adds first-class support for **Otty** — a macOS Ghostty fork (`TERM_PROGRAM=otty`, bundle id `io.appmakes.otty`). Otty now works out of the box with **no configuration** and **without** `[experimental] multi_terminal`.

Otty is introduced as a proper `Terminal::Otty` variant carrying Ghostty's exact capability profile (DECSET 2026 synchronized output + native OSC 133), mirroring how `Zed`/`VSCode` were added — one variant per terminal even when capabilities match, so `doctor`/`status`/logs report the real terminal instead of lying "Ghostty".

Changes:
- **`gc-terminal`** — new `Terminal::Otty` variant, `TERM_PROGRAM=otty` → `Otty` detection, added to `supported_terminals()`, `Display`, `for_otty()` test constructor, and a full set of tests (profile, direct + tmux-fallback detection, `is_known`, display, strict-casing).
- **`shell/init.zsh`** — add `otty` to both the tmux launch guard and the non-tmux `TERM_PROGRAM` whitelist (this is why the proxy never started — layer 1 of the issue).
- **`shell/ghost-complete.{zsh,bash,fish}`** — treat `otty` as native OSC 133 so the redundant OSC 7771 fallback is suppressed, exactly like Ghostty.
- **`gc-pty/proxy`** — Otty is a known (non-`Unknown`) terminal, so `should_fallback_to_shell` returns `false`; it never falls back to a plain shell and never needs `multi_terminal` (layer 2). Test extended to prove it. Stale enumerated comment replaced with a reference to `Terminal::supported_terminals`.
- **Docs/CHANGELOG** — supported terminal count bumped 9 → 10; Otty documented in `README.md` and `docs/CONFIGURATION.md`.

## Why

Resolves #153. Otty is a Ghostty fork but, unlike Ghostty proper, does **not** set `GHOSTTY_RESOURCES_DIR`, so it slipped through both detection layers:

1. `shell/init.zsh` gated `exec ghost-complete` behind a `TERM_PROGRAM` whitelist that omitted `otty` → the PTY proxy never launched (no popup, no log file — `doctor` still passed, which is what stumped users).
2. Even once launched, the proxy treated Otty as `Unknown` and gated rendering behind `[experimental] multi_terminal`.

Since Otty inherits Ghostty's rendering pipeline, mapping it to Ghostty's capability profile makes it work with zero user configuration — the outcome the reporter verified by hand.

## Testing

- [x] `cargo test` passes (full workspace green — `gc-terminal` +8 new tests, `ghost-complete` install-structure test updated, `gc-pty` fallback test extended)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `zsh -n` / `bash -n` parse checks pass on all edited shell scripts
- [ ] Manually tested in Ghostty with zsh — reporter offered to verify the patch in Otty itself (I don't have Otty locally)

> Note: Otty inside tmux is best-effort via `TERM_PROGRAM` (same as Rio) since it exposes no dedicated env var that survives tmux — this matches the existing Rio behavior.
