### PR TITLE
chore(deps): dependabot backlog + AWS SDK security patch (GHSA-g59m-gf8j-gjf5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             fig_converter:
@@ -172,7 +172,7 @@ jobs:
               - 'tools/spec-priority-audit/**'
       - name: Set up Node
         if: steps.filter.outputs.fig_converter == 'true' || steps.filter.outputs.spec_priority_audit == 'true'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
       - name: Install fig-converter dependencies
@@ -197,7 +197,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             fig_converter:
@@ -205,7 +205,7 @@ jobs:
               - '.github/workflows/ci.yml'
       - name: Set up Node
         if: steps.filter.outputs.fig_converter == 'true'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
       - name: Install fig-converter dependencies
@@ -238,7 +238,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
       - name: Install fig-converter dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http 0.62.6",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -182,22 +182,23 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.11"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1ed337dabcf765ad5f2fb426f13af22d576328aaf09eac8f70953530798ec0"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "bytes-utils",
  "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -206,15 +207,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iam"
-version = "1.80.0"
+version = "1.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98dccd5be21369742b73aa2fc7f4d604ff1fe9613b5d79d2c676cd04b94a309a"
+checksum = "02e37dac8a83af61c7dd26b543f09c5028726e3237e86e6cd6caa62a9c2db600"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.62.6",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -229,15 +230,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.85.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2c741e2e439f07b5d1b33155e246742353d82167c785a2ff547275b7e32483"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -245,21 +247,23 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.87.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6428ae5686b18c0ee99f6f3c39d94ae3f8b42894cdc35c35d8fb2470e9db2d4c"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -267,21 +271,23 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.87.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5871bec9a79a3e8d928c7788d654f135dde0e71d2dd98089388bab36b37ef607"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -290,18 +296,19 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -408,6 +415,15 @@ name = "aws-smithy-json"
 version = "0.61.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -599,11 +615,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -680,7 +696,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -781,6 +797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +821,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -827,9 +855,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -929,12 +957,20 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1016,13 +1052,14 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -1043,7 +1080,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1097,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1308,7 +1345,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "shlex",
+ "shlex 2.0.1",
  "tempfile",
  "tokio",
  "toml",
@@ -1322,16 +1359,6 @@ dependencies = [
 [[package]]
 name = "gc-terminal"
 version = "0.18.0"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -1470,6 +1497,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1485,9 +1517,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
@@ -1558,6 +1590,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1637,7 +1678,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2065,7 +2106,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2591,28 +2632,28 @@ dependencies = [
 
 [[package]]
 name = "rquickjs"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a135375fbac5ba723bb6a48f432a72f81539cedde422f0121a86c7c4e96d8e0d"
+checksum = "c0688f8b0192998cca685adefdfad3483da295fa40a0ec406b4c14ecd729e858"
 dependencies = [
  "rquickjs-core",
 ]
 
 [[package]]
 name = "rquickjs-core"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bccb7121a123865c8ace4dea42e7ed84d78b90cbaf4ca32c59849d8d210c9672"
+checksum = "2fee8c5383f0cfda3b980a80ca4520e726e09b593c59562f579daa51b6c20411"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "rquickjs-sys",
 ]
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b1b6528590d4d65dc86b5159eae2d0219709546644c66408b2441696d1d725"
+checksum = "698077537c286a169de8693b216672bcef148bf2e2e112ebf50758c68e9afa09"
 dependencies = [
  "cc",
 ]
@@ -2636,7 +2677,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2835,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2874,6 +2915,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -2935,7 +2982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3015,7 +3062,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3193,17 +3240,11 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -3216,14 +3257,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3232,14 +3274,8 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3449,12 +3485,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3633,7 +3663,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3806,18 +3836,12 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1", features = ["derive"] }
 crossterm = "0.29"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
-toml_edit = "0.22"
+toml_edit = "0.25"
 toml = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 
 [profile.release]
 strip = "symbols"

--- a/crates/gc-jsrt/Cargo.toml
+++ b/crates/gc-jsrt/Cargo.toml
@@ -20,7 +20,7 @@ description = "Bounded QuickJS evaluator for Ghost Complete's requires_js spec g
 # `rust-alloc` keeps QuickJS allocations going through Rust's global
 # allocator so memory usage shows up in the same accounting as everything
 # else in the binary.
-rquickjs = { version = "0.10", default-features = false, features = ["rust-alloc"] }
+rquickjs = { version = "0.12", default-features = false, features = ["rust-alloc"] }
 serde = { workspace = true }
 serde_json = "1"
 thiserror = "2"

--- a/crates/gc-jsrt/tests/engine_unicode.rs
+++ b/crates/gc-jsrt/tests/engine_unicode.rs
@@ -1,0 +1,69 @@
+//! Tripwire for the bundled QuickJS (quickjs-ng) engine's Unicode behavior.
+//!
+//! `requires_js` generators are arbitrary corpus JS; the JS engine is the
+//! code path that turns spec JS into completion suggestions. A quickjs-ng
+//! bump can advance the bundled Unicode tables — the rquickjs 0.10 -> 0.12
+//! bump pulled in Unicode 17.0.0 — which shifts `String` case-folding /
+//! normalization and `RegExp` Unicode-property matching for non-ASCII
+//! input. A generator that lowercases, normalizes, or regex-filters branch
+//! names, tags, or paths would then silently emit different suggestions.
+//!
+//! There are no golden-output tests over the real corpus generators, so
+//! this test pins the current engine's behavior on a representative set of
+//! Unicode-sensitive operations. A future engine bump that changes any of
+//! them fails HERE, forcing a human to re-audit generator output rather
+//! than discovering the drift in production.
+
+use std::time::Duration;
+
+use gc_jsrt::{JsRuntimeInput, JsWorker};
+
+const FAST_TIMEOUT: Duration = Duration::from_millis(1_500);
+
+fn tripwire_input() -> JsRuntimeInput {
+    JsRuntimeInput {
+        generator_id: "unicode-tripwire".into(),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn engine_unicode_behavior_is_pinned() {
+    let worker = JsWorker::spawn().expect("spawn worker");
+    // Each check yields "<key>=<result>" so a drift report names exactly
+    // which Unicode operation changed.
+    let program = r#"(function(){
+        const checks = [
+            ["sharp-s-upper",     "ß".toUpperCase()],
+            ["cap-e-acute-lower", "É".toLowerCase()],
+            ["dotted-I-lower",    "İ".toLowerCase()],
+            ["nfc",               "é".normalize("NFC")],
+            ["nfd",               "é".normalize("NFD")],
+            ["prop-letter",       String(/^\p{L}+$/u.test("café日本ß"))],
+            ["prop-decimal",      String(/\p{Nd}/u.test("٥"))],
+            ["han-script",        String(/\p{Script=Han}/u.test("日"))]
+        ];
+        return checks.map(function(c){ return {name: c[0] + "=" + c[1]}; });
+    })()"#;
+    let out = worker
+        .evaluate(program, tripwire_input(), FAST_TIMEOUT)
+        .await
+        .expect("evaluation infrastructure should not fail");
+    let names: Vec<_> = out.suggestions().iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        names,
+        [
+            "sharp-s-upper=SS",
+            "cap-e-acute-lower=\u{e9}",
+            "dotted-I-lower=i\u{307}",
+            "nfc=\u{e9}",
+            "nfd=e\u{301}",
+            "prop-letter=true",
+            "prop-decimal=true",
+            "han-script=true",
+        ],
+        "QuickJS (quickjs-ng) Unicode behavior drifted after an engine bump; \
+         re-audit requires_js generator output for non-ASCII input. diagnostics: {:?}",
+        out.diagnostics
+    );
+}

--- a/crates/gc-suggest/Cargo.toml
+++ b/crates/gc-suggest/Cargo.toml
@@ -17,7 +17,7 @@ aws-config = { version = "=1.6.3", default-features = false, features = [
     "default-https-client",
     "sso",
 ] }
-aws-sdk-iam = { version = "=1.80.0", default-features = false, features = [
+aws-sdk-iam = { version = "=1.95.0", default-features = false, features = [
     "behavior-version-latest",
     "rt-tokio",
     "default-https-client",
@@ -31,7 +31,7 @@ toml = { workspace = true }
 tracing = { workspace = true }
 dirs = "6"
 regex = "1"
-shlex = "1"
+shlex = "2"
 tempfile = "3"
 unicode-ident = "1"
 zstd = { version = "0.13", default-features = false }

--- a/crates/gc-suggest/src/mirror.rs
+++ b/crates/gc-suggest/src/mirror.rs
@@ -510,6 +510,27 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    fn sha256_hex_matches_fips_180_4_known_answers() {
+        // Pins the on-disk hash format. `list_user_edited_specs` and
+        // `write_embedded_mirror` compare freshly computed sha256 hashes
+        // against hashes a PRIOR binary persisted in the version stamp.
+        // If a future digest-crate bump (e.g. the sha2 0.10 -> 0.11
+        // RustCrypto generation shift) ever changed the output bytes for
+        // identical input, every mirrored spec would be falsely flagged
+        // "user-edited" on upgrade and auto-refresh would silently skip
+        // all overwrites. These canonical FIPS-180-4 / RFC-6234 vectors
+        // fail loudly the moment that happens.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
     fn mirror_status_not_installed_when_dir_absent() {
         let dir = TempDir::new().unwrap();
         let missing = dir.path().join("does-not-exist");


### PR DESCRIPTION
## What

Consolidated dependency maintenance clearing the current Dependabot backlog, plus the open AWS SDK security patch.

**Security — resolves Dependabot advisory `GHSA-g59m-gf8j-gjf5` (5 low-severity alerts: #2–#6)**
- `aws-sdk-iam` 1.80.0 → **1.95.0** (patched ≥ 1.95.0) — supersedes #135, which only reached 1.90.0 and did **not** clear the patch line
- `aws-sdk-sts` 1.87.0 → **1.103.0** (transitive via aws-config, patched ≥ 1.91.0)
- `aws-sdk-ssooidc` 1.87.0 → **1.100.0** (transitive, patched ≥ 1.91.0)
- `aws-sdk-sso` 1.85.0 → **1.98.0** (transitive, patched ≥ 1.89.0)

**Cargo bumps — each an open Dependabot PR, re-derived on current master**
- `shlex` 1.3.0 → 2.0.1 (#133)
- `sha2` 0.10.9 → 0.11.0 (#134, pulls the RustCrypto digest 0.11 generation)
- `rquickjs` 0.10.0 → 0.12.0 (#136)
- `toml_edit` 0.22.27 → 0.25.12 (#90 — was CONFLICTING against master; regenerated cleanly here)

**CI action bumps**
- `actions/setup-node` 5 → 6 (#87)
- `dorny/paths-filter` 3 → 4 (#88)

Supersedes #133, #134, #135, #136, #90, #87, #88.

## Why

Clear the Dependabot backlog and resolve the AWS SDK advisory in a single CI pass and one clean `Cargo.lock` resolution, instead of a rebase-treadmill across 7 stale, mutually lock-conflicting PRs.

**Deliberately excluded (deferred to a post-release follow-up):** #72 (`attest-build-provenance` 2→4), #36 (`download-artifact` 7→8), #35 (`upload-artifact` 4→7). All three mutate the cargo-dist-generated `release.yml`, and the jobs that actually exercise them (`build-local-artifacts` / `build-global-artifacts`) are **SKIPPED on PR CI** — so a green PR proves nothing about whether the release still publishes. They land after the next release ships, keeping any breakage off the critical publish path (which took three retags to stabilize for v0.18.0).

## Testing

- [x] `cargo test` passes — full workspace, run locally against current master
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo deny check advisories` → `advisories ok`
- [x] Adversarial changelog-vs-usage audit of each breaking bump (shlex 2.0, sha2 0.11, rquickjs 0.12, toml_edit 0.25)
- [x] Added regression tripwires the audit recommended: FIPS-180-4 known-answer test for `sha256_hex` (guards the on-disk version-stamp hash format) and a QuickJS Unicode-behavior pin (guards `requires_js` generator output against future engine/Unicode-table bumps)
- [ ] Manually tested in Ghostty with zsh — not performed in this batch (pure dependency/lockfile + CI-config change; no source behavior touched)
